### PR TITLE
Remove non-ascii characters from decomposition docstrings

### DIFF
--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -152,7 +152,7 @@ def non_negative_tucker(tensor, ranks, n_iter_max=10, init='svd', tol=10e-5,
     .. [2] Yong-Deok Kim and Seungjin Choi,
        "Nonnegative tucker decomposition",
        IEEE Conference on Computer Vision and Pattern Recognition s(CVPR),
-       pp 1–8, 2007
+       pp 1-8, 2007
     """
     epsilon = 10e-12
 

--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -123,7 +123,7 @@ def non_negative_parafac(tensor, rank, n_iter_max=100, init='svd', tol=10e-7,
     .. [2] Amnon Shashua and Tamir Hazan,
        "Non-negative tensor factorization with applications to statistics and computer vision",
        In Proceedings of the International Conference on Machine Learning (ICML),
-       pp 792–799, ICML, 2005
+       pp 792-799, ICML, 2005
     """
     epsilon = 10e-12
 


### PR DESCRIPTION
The presence of non-ascii characters causes a SyntaxError to be raised on
import. This minor fix removes said characters.

### Example

```
>>> import tensorly
>>> from tensorly.decomposition import parafac
  File "/Users/csw/tensorly/tensorly/decomposition/candecomp_parafac.py", line 126
    pp 792–799, ICML, 2005
                          ^
SyntaxError: Non-ASCII character '\xe2' in file /Users/csw/tensorly/tensorly/decomposition/candecomp_parafac.py on line 127, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```