### PR TITLE
Compute the eigenvalues of the CANDECOMP/PARAFAC decomposition

### DIFF
--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -58,8 +58,8 @@ def shape(tensor):
 def ndim(tensor):
     return tensor.ndim
 
-def arange(start, stop=None, step=1.0):
-    return np.arange(start, stop, step, dtype="float64")
+def arange(start, stop=None, step=1.0, dtype="float64"):
+    return np.arange(start, stop, step, dtype=dtype)
 
 def reshape(tensor, shape):
     return np.reshape(tensor, shape=shape)

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -67,6 +67,9 @@ def reshape(tensor, shape):
 def moveaxis(tensor, source, target):
     return np.moveaxis(tensor, source, target)
 
+def prod(tensor, *args, **kwds):
+    return np.prod(tensor, *args, **kwds)
+
 def dot(matrix1, matrix2):
     return np.dot(matrix1, matrix2)
 
@@ -82,26 +85,34 @@ def min(tensor, *args, **kwargs):
 def max(tensor, *args, **kwargs):
     return np.min(tensor, *args, **kwargs).asscalar()
 
-def norm(tensor, order):
+def norm(tensor, order=2, axis=()):
     """Computes the l-`order` norm of tensor
     Parameters
     ----------
     tensor : ndarray
     order : int
+    axis : int or tuple
     Returns
     -------
     float
         l-`order` norm of tensor
     """
+    # TODO: better handling of difference in null axis between numpy and mxnet
+    if axis is None:
+        axis = ()
+
     if order == 'inf':
-        return np.max(np.abs(tensor)).asscalar()
+        return np.max(np.abs(tensor), axis=axis).asscalar()
     if order == 1:
-        res =  np.sum(np.abs(tensor))
+        res =  np.sum(np.abs(tensor), axis=axis)
     elif order == 2:
-        res = np.sqrt(np.sum(tensor**2))
+        res = np.sqrt(np.sum(tensor**2, axis=axis))
     else:
-        res = np.sum(np.abs(tensor)**order)**(1/order)
-    return res.asscalar()
+        res = np.sum(np.abs(tensor)**order, axis=axis)**(1/order)
+
+    if res.shape == (1,):
+        return res.asscalar()
+    return res
 
 
 def kr(matrices):

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -59,7 +59,7 @@ def ndim(tensor):
     return tensor.ndim
 
 def arange(start, stop=None, step=1.0):
-    return np.arange(start, stop, step)
+    return np.arange(start, stop, step, dtype="float64")
 
 def reshape(tensor, shape):
     return np.reshape(tensor, shape=shape)
@@ -85,7 +85,7 @@ def min(tensor, *args, **kwargs):
 def max(tensor, *args, **kwargs):
     return np.min(tensor, *args, **kwargs).asscalar()
 
-def norm(tensor, order=2, axis=()):
+def norm(tensor, order=2, axis=None):
     """Computes the l-`order` norm of tensor
     Parameters
     ----------
@@ -108,7 +108,7 @@ def norm(tensor, order=2, axis=()):
     elif order == 2:
         res = np.sqrt(np.sum(tensor**2, axis=axis))
     else:
-        res = np.sum(np.abs(tensor)**order, axis=axis)**(1/order)
+        res = np.sum(np.abs(tensor)**order, axis=axis)**(1./order)
 
     if res.shape == (1,):
         return res.asscalar()

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -40,6 +40,7 @@ def ndim(tensor):
 arange = np.arange
 reshape = np.reshape
 moveaxis = np.moveaxis
+prod = np.prod
 dot = np.dot
 kron = np.kron
 abs = np.abs
@@ -58,25 +59,30 @@ sign = np.sign
 where = np.where
 copy = np.copy
 
-def norm(tensor, order):
+def norm(tensor, order=2, axis=None):
     """Computes the l-`order` norm of tensor
     Parameters
     ----------
     tensor : ndarray
     order : int
+    axis : tuple
     Returns
     -------
     float
         l-`order` norm of tensor
     """
+    # TODO: better handling of difference in null axis between numpy and mxnet
+    if axis == ():
+        axis = None
+
     if order == 'inf':
-        return np.max(np.abs(tensor))
+        return np.max(np.abs(tensor), axis=axis)
     if order == 1:
-        return np.sum(np.abs(tensor))
+        return np.sum(np.abs(tensor), axis=axis)
     elif order == 2:
-        return np.sqrt(np.sum(tensor**2))
+        return np.sqrt(np.sum(tensor**2, axis=axis))
     else:
-        return np.sum(np.abs(tensor)**order)**(1/order)
+        return np.sum(np.abs(tensor)**order, axis=axis)**(1/order)
 
 
 def kr(matrices):

--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -6,48 +6,36 @@ from ..kruskal_tensor import kruskal_to_tensor
 from ..tenalg import khatri_rao
 
 # Author: Jean Kossaifi <jean.kossaifi+tensors@gmail.com>
+# Author: Chris Swierczewski <csw@amazon.com>
 
 # License: BSD 3 clause
 
 
-def parafac(tensor, rank, n_iter_max=100, init='svd', tol=10e-7,
-            random_state=None, verbose=False):
-    """CANDECOMP/PARAFAC decomposition via alternating least squares (ALS)
+def initialize_factors(tensor, rank, init='svd', random_state=None):
+    r"""Initialize factors used in `parafac`.
 
-        Computes a rank-`rank` decomposition of `tensor` [1]_ such that:
-        ``tensor = [| factors[0], ..., factors[-1] |]``
+    The type of initialization is set using `init`. If `init == 'random'` then
+    initialize factor matrices using `random_state`. If `init == 'svd'` then
+    initialize the `m`th factor matrix using the `rank` left singular vectors
+    of the `m`th unfolding of the input tensor.
 
     Parameters
     ----------
     tensor : ndarray
-    rank  : int
-            number of components
-    n_iter_max : int
-                 maximum number of iteration
+    rank : int
     init : {'svd', 'random'}, optional
-    tol : float, optional
-          tolerance: the algorithm stops when the variation in
-          the reconstruction error is less than the tolerance
-    random_state : {None, int, np.random.RandomState}
-    verbose : int, optional
-        level of verbosity
 
     Returns
     -------
     factors : ndarray list
-            list of factors of the CP decomposition
-            element `i` is of shape (tensor.shape[i], rank)
+        List of initialized factors of the CP decomposition where element `i`
+        is of shape (tensor.shape[i], rank)
 
-    References
-    ----------
-    .. [1] T.G.Kolda and B.W.Bader, "Tensor Decompositions and Applications",
-       SIAM REVIEW, vol. 51, n. 3, pp. 455-500, 2009.
     """
     rng = check_random_state(random_state)
 
     if init is 'random':
         factors = [T.tensor(rng.random_sample((tensor.shape[i], rank))) for i in range(tensor.ndim)]
-
     elif init is 'svd':
         factors = []
         for mode in range(tensor.ndim):
@@ -60,22 +48,77 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', tol=10e-7,
                 factor[:, :tensor.shape[mode]] = U
                 U = T.tensor(factor)
             factors.append(U[:, :rank])
+    return factors
 
+
+def parafac(tensor, rank, n_iter_max=100, init='svd', tol=10e-7,
+            random_state=None, with_eigenvalues=False, verbose=False):
+    """CANDECOMP/PARAFAC decomposition via alternating least squares (ALS)
+
+    Computes a rank-`rank` decomposition of `tensor` [1]_ such that,
+
+        ``tensor = [| factors[0], ..., factors[-1] |]``.
+
+    If `with_eigenvalues == True` returns the decomposition such that,
+
+        ``tensor = [| lambda; factors[0], ..., factors[-1] |]``.
+
+    where `lambda` is an array of `rank` eigenvalues of the decomposition and
+    the columns of the factor matrices have unit norm.
+
+    Parameters
+    ----------
+    tensor : ndarray
+    rank  : int
+        Number of components
+    n_iter_max : int
+        Maximum number of iteration
+    init : {'svd', 'random'}, optional
+    tol : float, optional
+        Tolerance: the algorithm stops when the variation in the reconstruction
+        error is less than the tolerance.
+    random_state : {None, int, np.random.RandomState}
+    with_eigenvalues : bool
+        If `True`, normalizes the columns of the factor matrices and returns
+        the eigenvalues along with the list of factors.
+    verbose : int, optional
+        Level of verbosity
+
+    Returns
+    -------
+    factors : ndarray list
+        List of factors of the CP decomposition element `i` is of shape
+        (tensor.shape[i], rank)
+    eigenvalues : ndarray, optional
+        Array of length `rank`. Output when `with_eigenvalues == True`.
+        (See above.)
+
+    References
+    ----------
+    .. [1] T.G.Kolda and B.W.Bader, "Tensor Decompositions and Applications",
+       SIAM REVIEW, vol. 51, n. 3, pp. 455-500, 2009.
+
+    """
+    factors = initialize_factors(tensor, rank, init=init, random_state=random_state)
     rec_errors = []
     norm_tensor = T.norm(tensor, 2)
+    eigenvalues = None
 
     for iteration in range(n_iter_max):
         for mode in range(tensor.ndim):
             pseudo_inverse = T.tensor(np.ones((rank, rank)))
             for i, factor in enumerate(factors):
                 if i != mode:
-                    pseudo_inverse[:] = pseudo_inverse*T.dot(factor.T, factor)
+                    pseudo_inverse *= T.dot(factor.T, factor)
             factor = T.dot(unfold(tensor, mode), khatri_rao(factors, skip_matrix=mode))
             factor = T.solve(pseudo_inverse.T, factor.T).T
+            if with_eigenvalues:
+                eigenvalues = T.norm(factor, axis=0)
+                factor /= eigenvalues
             factors[mode] = factor
 
         #if verbose or tol:
-        rec_error = T.norm(tensor - kruskal_to_tensor(factors), 2) / norm_tensor
+        rec_error = T.norm(tensor - kruskal_to_tensor(factors, eigenvalues=eigenvalues), 2) / norm_tensor
         rec_errors.append(rec_error)
 
         if iteration > 1:
@@ -88,6 +131,8 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', tol=10e-7,
                     print('converged in {} iterations.'.format(iteration))
                 break
 
+    if with_eigenvalues:
+        return factors, eigenvalues
     return factors
 
 

--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -6,7 +6,7 @@ from ..kruskal_tensor import kruskal_to_tensor
 from ..tenalg import khatri_rao
 
 # Author: Jean Kossaifi <jean.kossaifi+tensors@gmail.com>
-# Author: Chris Swierczewski <csw@amazon.com>
+# Author: Chris Swierczewski <cswiercz@gmail.com>
 
 # License: BSD 3 clause
 

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -34,38 +34,6 @@ def test_parafac():
             'abs norm of difference between svd and random init too high')
 
 
-def test_parafac_with_eigenvalues():
-    """Test for the CANDECOMP-PARAFAC decomposition with eigenvalues
-    """
-    rng = check_random_state(1234)
-    tol_norm_2 = 10e-2
-    tol_max_abs = 10e-2
-    tensor = T.tensor(rng.random_sample((3, 4, 2)))
-    factors_svd, eigenvalues_svd = parafac(
-        tensor, rank=4, n_iter_max=200, init='svd', tol=10e-5,
-        with_eigenvalues=True)
-    factors_random, eigenvalues_random = parafac(
-        tensor, rank=4, n_iter_max=200, init='random', tol=10e-5,
-        random_state=1234, with_eigenvalues=True, verbose=0)
-    rec_svd = kruskal_to_tensor(factors_svd, eigenvalues=eigenvalues_svd)
-    rec_random = kruskal_to_tensor(factors_random, eigenvalues=eigenvalues_random)
-    error = T.norm(rec_svd - tensor, 2)
-    error /= T.norm(tensor, 2)
-    T.assert_(error < tol_norm_2,
-            'norm 2 of reconstruction higher than tol')
-    # Test the max abs difference between the reconstruction and the tensor
-    T.assert_(T.max(T.abs(rec_svd - tensor)) < tol_max_abs,
-            'abs norm of reconstruction error higher than tol')
-
-    tol_norm_2 = 10e-1
-    tol_max_abs = 10e-1
-    error = T.norm(rec_svd - rec_random, 2)
-    error /= T.norm(rec_svd, 2)
-    T.assert_(error < tol_norm_2,
-            'norm 2 of difference between svd and random init too high')
-    T.assert_(T.max(T.abs(rec_svd - rec_random)) < tol_max_abs,
-            'abs norm of difference between svd and random init too high')
-
 
 def test_non_negative_parafac():
     """Test for non-negative PARAFAC

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -34,6 +34,38 @@ def test_parafac():
             'abs norm of difference between svd and random init too high')
 
 
+def test_parafac_with_eigenvalues():
+    """Test for the CANDECOMP-PARAFAC decomposition with eigenvalues
+    """
+    rng = check_random_state(1234)
+    tol_norm_2 = 10e-2
+    tol_max_abs = 10e-2
+    tensor = T.tensor(rng.random_sample((3, 4, 2)))
+    factors_svd, eigenvalues_svd = parafac(
+        tensor, rank=4, n_iter_max=200, init='svd', tol=10e-5,
+        with_eigenvalues=True)
+    factors_random, eigenvalues_random = parafac(
+        tensor, rank=4, n_iter_max=200, init='random', tol=10e-5,
+        random_state=1234, with_eigenvalues=True, verbose=0)
+    rec_svd = kruskal_to_tensor(factors_svd, eigenvalues=eigenvalues_svd)
+    rec_random = kruskal_to_tensor(factors_random, eigenvalues=eigenvalues_random)
+    error = T.norm(rec_svd - tensor, 2)
+    error /= T.norm(tensor, 2)
+    T.assert_(error < tol_norm_2,
+            'norm 2 of reconstruction higher than tol')
+    # Test the max abs difference between the reconstruction and the tensor
+    T.assert_(T.max(T.abs(rec_svd - tensor)) < tol_max_abs,
+            'abs norm of reconstruction error higher than tol')
+
+    tol_norm_2 = 10e-1
+    tol_max_abs = 10e-1
+    error = T.norm(rec_svd - rec_random, 2)
+    error /= T.norm(rec_svd, 2)
+    T.assert_(error < tol_norm_2,
+            'norm 2 of difference between svd and random init too high')
+    T.assert_(T.max(T.abs(rec_svd - rec_random)) < tol_max_abs,
+            'abs norm of difference between svd and random init too high')
+
 
 def test_non_negative_parafac():
     """Test for non-negative PARAFAC

--- a/tensorly/kruskal_tensor.py
+++ b/tensorly/kruskal_tensor.py
@@ -11,11 +11,21 @@ from .tenalg import khatri_rao
 # License: BSD 3 clause
 
 
-def kruskal_to_tensor(factors, eigenvalues=None):
+def kruskal_to_tensor(factors, weights=None):
     """Turns the Khatri-product of matrices into a full tensor
 
-        ``factor_matrices = [|U_1, ... U_n|]`` becomes
-        a tensor shape ``(U[1].shape[0], U[2].shape[0], ... U[-1].shape[0])``
+        ``factor_matrices = [|U_1, ... U_n|]``
+
+    becomes a tensor shape
+
+        ``(U[1].shape[0], U[2].shape[0], ... U[-1].shape[0])``
+
+    If a vector of `n` `weights` is provided then the product
+
+        ``factor_matrices = [| weights; U_1, ... U_n |]``
+
+    is computed; each rank-1 component is scaled by the corresponding element
+    of the vector `weights`.
 
     Parameters
     ----------
@@ -23,9 +33,9 @@ def kruskal_to_tensor(factors, eigenvalues=None):
         list of factor matrices, all with the same number of columns
         i.e. for all matrix U in factor_matrices:
         U has shape ``(s_i, R)``, where R is fixed and s_i varies with i
-    eigenvalues : ndarray
-        (Optional) List of `n` eigenvalues. If provided, will compute the
-        tensor with scaled rank-1 components.
+    weights : ndarray
+        (Optional) List of `n` weights. If provided, will compute the tensor
+        with scaled rank-1 components.
 
     Returns
     -------
@@ -43,11 +53,9 @@ def kruskal_to_tensor(factors, eigenvalues=None):
     """
     shape = [factor.shape[0] for factor in factors]
     first_factor = factors[0]
-    remaining_factors = factors[1:]
-    if eigenvalues is not None:
-        full_tensor = T.dot(first_factor*eigenvalues, khatri_rao(remaining_factors).T)
-    else:
-        full_tensor = T.dot(first_factor, khatri_rao(remaining_factors).T)
+    if weights is not None:
+        first_factor *= eigenvalues
+    full_tensor = T.dot(first_factor, khatri_rao(factors[1:]).T)
     return fold(full_tensor, 0, shape)
 
 

--- a/tensorly/kruskal_tensor.py
+++ b/tensorly/kruskal_tensor.py
@@ -11,7 +11,7 @@ from .tenalg import khatri_rao
 # License: BSD 3 clause
 
 
-def kruskal_to_tensor(factors):
+def kruskal_to_tensor(factors, eigenvalues=None):
     """Turns the Khatri-product of matrices into a full tensor
 
         ``factor_matrices = [|U_1, ... U_n|]`` becomes
@@ -23,6 +23,9 @@ def kruskal_to_tensor(factors):
         list of factor matrices, all with the same number of columns
         i.e. for all matrix U in factor_matrices:
         U has shape ``(s_i, R)``, where R is fixed and s_i varies with i
+    eigenvalues : ndarray
+        (Optional) List of `n` eigenvalues. If provided, will compute the
+        tensor with scaled rank-1 components.
 
     Returns
     -------
@@ -36,9 +39,15 @@ def kruskal_to_tensor(factors):
 
     There are other possible and equivalent alternate implementation, e.g.
     summing over r and updating an outer product of vectors.
+
     """
     shape = [factor.shape[0] for factor in factors]
-    full_tensor = T.dot(factors[0], khatri_rao(factors[1:]).T)
+    first_factor = factors[0]
+    remaining_factors = factors[1:]
+    if eigenvalues is not None:
+        full_tensor = T.dot(first_factor*eigenvalues, khatri_rao(remaining_factors).T)
+    else:
+        full_tensor = T.dot(first_factor, khatri_rao(remaining_factors).T)
     return fold(full_tensor, 0, shape)
 
 

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -289,3 +289,53 @@ def test_partial_svd():
     with T.assert_raises(ValueError):
         tensor = T.tensor(np.random.random((3, 3, 3)))
         T.partial_svd(tensor)
+
+
+def test_shape():
+    A = T.arange(3*4*5)
+
+    shape1 = (3*4,5)
+    A1 = A.reshape(shape1)
+    T.assert_equal(T.shape(A1), shape1)
+
+    shape2 = (3,4,5)
+    A2 = A.reshape(shape2)
+    T.assert_equal(T.shape(A2), shape2)
+
+
+def test_ndim():
+    A = T.arange(3*4*5)
+    T.assert_equal(T.ndim(A), 1)
+
+    shape1 = (3*4,5)
+    A1 = A.reshape(shape1)
+    T.assert_equal(T.ndim(A1), 2)
+
+    shape2 = (3,4,5)
+    A2 = A.reshape(shape2)
+    T.assert_equal(T.ndim(A2), 3)
+
+
+def test_norm():
+    v = T.tensor([1,2,3])
+    T.assert_equal(T.norm(v,1), 6)
+
+    A = T.arange(6).reshape((3,2))
+    T.assert_equal(T.norm(A, 1), 15)
+
+    column_norms1 = T.norm(A, 1, axis=0)
+    row_norms1 = T.norm(A, 1, axis=1)
+    T.assert_array_equal(column_norms1, T.tensor([6, 9]))
+    T.assert_array_equal(row_norms1, T.tensor([1, 5, 9]))
+
+    column_norms2 = T.norm(A, 2, axis=0)
+    row_norms2 = T.norm(A, 2, axis=1)
+    T.assert_array_almost_equal(column_norms2, T.tensor([4.47213602, 5.91608]))
+    T.assert_array_almost_equal(row_norms2, T.tensor([1., 3.60555124, 6.40312433]))
+
+    # limit as order->oo is the oo-norm
+    column_norms10 = T.norm(A, 10, axis=0)
+    row_norms10 = T.norm(A, 10, axis=1)
+    T.assert_array_almost_equal(column_norms10, T.tensor([4.00039053, 5.00301552]))
+    T.assert_array_almost_equal(row_norms10, T.tensor([1., 3.00516224, 5.05125666]))
+


### PR DESCRIPTION
Some versions of the CP decomposition algorithm return the eigenvalues along
with appropriately normalized factor matrices. This change adds a flag
`with_eigenvalues` which will optionally return these normalized factors along
with an array of `rank` eigenvalues.

This commit also makes necessary modifications to the backend `norm` functions
to support computing norms across particular axes.