### PR TITLE
Add utilities for kruskal tensors

### DIFF
--- a/tensorly/kruskal_tensor.py
+++ b/tensorly/kruskal_tensor.py
@@ -93,3 +93,41 @@ def kruskal_to_vec(factors):
         vectorised tensor
     """
     return tensor_to_vec(kruskal_to_tensor(factors))
+
+def normalize_kruskal(factors):
+    """Normalizes factors to unit length and returns factor magnitudes
+        turns  ``factors = [|U_1, ... U_n|]`` into ``[lam; |V_1, ... V_n|]``,
+        where the norm of the columns of all `U_k` are absorbed into the
+        weights `lam` and so that the columns of all `V_k` have unit
+        Euclidean norm. In the special case that `factors` represents a 
+        symmetric tensor the weights `lam` correspond to higher-order
+        eigenvalues and the normalized factors `V_k` correspond to
+        higher-order eigenvectors.
+    Parameters
+    ----------
+    factors : ndarray list
+        list of matrices, all with the same number of columns
+        i.e.::
+            for u in U:
+                u[i].shape == (s_i, R)
+                
+        where `R` is fixed while `s_i` can vary with `i`
+    Returns
+    -------
+    normalized_factors : ndarray list
+        list of matrices with the same shape as `factors`
+    lam : ndarray
+        vector of length `R` holding weights
+    """
+
+    # allocate variables for weights, and normalized factors
+    lam = np.ones(rank)
+    V = []
+
+    # normalize columns of factor matrices
+    for fact in factors:
+        s = np.linalg.norm(fact, axis=0)
+        lam *= s
+        V.append(fact / np.where(s==0, 1, s))
+
+    return V, lam

--- a/tensorly/kruskal_tensor.py
+++ b/tensorly/kruskal_tensor.py
@@ -96,13 +96,12 @@ def kruskal_to_vec(factors):
 
 def normalize_kruskal(factors):
     """Normalizes factors to unit length and returns factor magnitudes
-        turns  ``factors = [|U_1, ... U_n|]`` into ``[lam; |V_1, ... V_n|]``,
-        where the norm of the columns of all `U_k` are absorbed into the
-        weights `lam` and so that the columns of all `V_k` have unit
-        Euclidean norm. In the special case that `factors` represents a 
-        symmetric tensor the weights `lam` correspond to higher-order
-        eigenvalues and the normalized factors `V_k` correspond to
-        higher-order eigenvectors.
+        turns  ``factors = [|U_1, ... U_n|]`` into ``[weights; |V_1, ... V_n|]``,
+        where the columns of each `V_k` are normalized to unit Euclidean length
+        from the columns of `U_k` with the normalizing constants absorbed
+        into `weights`. In the special case of a symmetric tensor, `weights`
+        holds the eigenvalues of the tensor.
+
     Parameters
     ----------
     factors : ndarray list
@@ -116,18 +115,19 @@ def normalize_kruskal(factors):
     -------
     normalized_factors : ndarray list
         list of matrices with the same shape as `factors`
-    lam : ndarray
-        vector of length `R` holding weights
+    weights : ndarray
+        vector of length `R` holding normalizing constants
     """
 
     # allocate variables for weights, and normalized factors
-    lam = np.ones(rank)
+    rank = factors[0].shape[0]
+    weights = T.ones(rank)
     V = []
 
     # normalize columns of factor matrices
     for fact in factors:
-        s = np.linalg.norm(fact, axis=0)
-        lam *= s
-        V.append(fact / np.where(s==0, 1, s))
+        s = T.norm(fact, axis=0)
+        weights *= s
+        V.append(fact / T.where(s==0, 1, s))
 
     return V, lam

--- a/tensorly/kruskal_tensor.py
+++ b/tensorly/kruskal_tensor.py
@@ -128,6 +128,6 @@ def normalize_kruskal(factors):
     for factor in factors:
         s = T.norm(factor, axis=0)
         weights *= s
-        V.append(factor / T.where(s==0, 1, s))
+        V.append(factor / T.where(s==0, T.ones(s.size), s))
 
     return V, weights

--- a/tensorly/kruskal_tensor.py
+++ b/tensorly/kruskal_tensor.py
@@ -125,9 +125,9 @@ def normalize_kruskal(factors):
     V = []
 
     # normalize columns of factor matrices
-    for fact in factors:
-        s = T.norm(fact, axis=0)
+    for factor in factors:
+        s = T.norm(factor, axis=0)
         weights *= s
-        V.append(fact / T.where(s==0, 1, s))
+        V.append(factor / T.where(s==0, 1, s))
 
-    return V, lam
+    return V, weights


### PR DESCRIPTION
So far I added my function for normalizing the factor matrices of a kruskal tensor.

The other function that I find quite useful is [`align_kruskal`](https://github.com/ahwillia/tensortools/blob/master/tensortools/kruskal.py#L69), which is analogous to the `score` function in Kolda's TensorToolbox in MATLAB.

Also, what do you think of adding the [`_validate_kruskal`](https://github.com/ahwillia/tensortools/blob/master/tensortools/kruskal.py#L191) function which basically checks that the user gave an appropriate input?