### PR TITLE
Grab the version from the tensorly/__init__.py file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ install:
     # Useful for debugging any issues with conda
     - conda info -a
     # Replace dep1 dep2 ... with your dependencies
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
+    # Hardcoding numpy version temporarily, refer to issue #26
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy==1.13.3 scipy
     - source activate test-environment
     - pip install coveralls pytest pytest-cov nose
     - if [[ "$BACKEND" == "mxnet" ]]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy<1.14.0
 scipy
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
+import re
+import ast
+
 try:
     from setuptools import setup, find_packages
 except ImportError:
     from distutils.core import setup, find_packages
 
-import tensorly
-version = tensorly.__version__
+# Grab the version
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
 
+with open('tensorly/__init__.py', 'rb') as f:
+    version = str(ast.literal_eval(_version_re.search(
+        f.read().decode('utf-8')).group(1)))
 
 def readme():
     with open('README.rst') as f:


### PR DESCRIPTION
## Problem
Tensorly cannot be installed if the dependencies are not met beforehand.
The `setup.py` script is importing tensorly to grab the version; this is problematic, since importing tensorly requires that all the dependencies are already met, and we are importing it before `setup(**config)` gets run.

This defeats the purpose of using `'install_requires': ['numpy', 'scipy']`
## Solution
Grab the version by parsing through `tensorly/__version__.py` using regex
This is the method used by other popular python libraries (e.g flask).

closes #25 

--------------
**Side note**: While fixing this I discovered we currently do not support numpy v.1.14.0, so I made issue #26 , and changed requirements.txt accordingly.