### PR TITLE
[Tracking] Major Parafac Improvements

### DIFF
--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -6,6 +6,7 @@ from ..kruskal_tensor import kruskal_to_tensor
 from ..tenalg import khatri_rao
 
 # Author: Jean Kossaifi <jean.kossaifi+tensors@gmail.com>
+# Author: Chris Swierczewski <csw@amazon.com>
 
 # License: BSD 3 clause
 


### PR DESCRIPTION
> This is a tracking PR for a collection of improvements to `parafac()`. I wanted to get @JeanKossaifi 's input before I dump a bunch of code into this PR.

# Sub-PRs

- [x] #32 Add functionality to backend
- [x] #33 Add where() to Pytorch backend
- [x] #34 Allow optional weights in kruskal_to_tensor
- [x]  #37 Refactor `parafac()` initialization
- [x] *Add Orthogonalized ALS*
- [ ] *Add Line Search*

# Description

In a personal, private branch of Tensorly I have implemented several improvements to `parafac()`. Primarily,

* Orthogonalized ALS [1] - QR-orthogonalizing the factor matrices in the first few iterations can lead to better local minima in fewer iterations, especially if the input tensor has orthogonal components.
* Enhanched Line Search [2] - technically, I only implemented a basic line search algorithm. Experiments show that line search improves convergence rates as well as helps the algorithm escape local minima more quickly.

I would like to add this private work to Tensorly. This work requires a bit of a refactor of the existing `parafac()` code so that it is easy to turn these options on and off as well as makes the existing code more easily extendible. Below I included some arguments to the effectiveness of these "augmentations". Please let me know if this sounds good or if you have any concerns. I will be posting the actual code (and many many tests) in this PR soon.

# Experimental Data

The two plots below are typical examples of the reconstruction error improvement on random noisly orthogonal order three tensors. (The following code shows how these tensors are generated with `noisy = True`.) The figures below compare iteration count vs. reconstruction error between "vanilla" alternating least squares (ALS) and adding combinations of line search (LS) and QR orthogonalization (QR). The dashed black line indicates the L2-norm of the added noise which is the absolute best we can do in estimating the tensor as a sum of orthogonal components.

![](https://i.imgur.com/9FY5KvQ.png)

![](https://i.imgur.com/E1GaXj8.png)

```python
def generate_random_tensor(dimensions=(10,10,10), rank=10, seed=0,
                           orthogonal=False, near_orthogonal=False, noisy=False):
    order = len(dimensions)
    dim = min(dimensions)
   if (rank > dim) and (orthogonal or near_orthogonal):
       raise ValueError('Can only construct orthogonal and near-orthogonal '
                        'tensors when rank <= min(dimensions)')

    np.random.seed(seed)
    weights = 4*tensorly.arange(1, rank+1).astype('float32')
    factors = map(tensorly.tensor, (np.random.randn(dim,rank) for dim in dimensions))

   if orthogonal:
        factors = map(lambda X: tensorly.qr(X)[0], factors)
    T = tensorly.kruskal_to_tensor(factors, weights)

   if noisy:
        scale = rank/(rank+32.)  # theoretical error approx. 1e-2 to 1e-3
        T += tensorly.tensor(scale*np.random.randn(*dimensions))
   return T, factors, weights
```

# References

> [1] V. Sharan and G. Valliant, *"Orthogonalized ALS: A Theoretically Principled Tensor Decomposition Algorithm for Practical Use"*, Proceedings of the 34th International Conference on Machine Learning, PMLR 70, 2017
> [2] M. Rajih, et. al., *"Enhanced Line Search: A Novel Method to Accelerate PARAFAC"*, SIAM J. Matrix Anal. Appl., Vol. 30, No. 3, pp. 1128-1147