### PR TITLE
Add functionality to backend

### DIFF
--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -13,7 +13,7 @@ from numpy import testing
 from mxnet import nd as nd
 from mxnet.ndarray import arange, zeros, zeros_like, ones
 from mxnet.ndarray import moveaxis, dot, transpose, reshape
-from mxnet.ndarray import sqrt, abs, where, maximum, sign
+from mxnet.ndarray import sqrt, abs, where, maximum, sign, prod
 
 from . import numpy_backend
 

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -105,8 +105,8 @@ def norm(tensor, order=2, axis=None):
         axis = ()
 
     if order == 'inf':
-        return nd.max(nd.abs(tensor), axis=axis).asscalar()
-    if order == 1:
+        res = nd.max(nd.abs(tensor), axis=axis)
+    elif order == 1:
         res =  nd.sum(nd.abs(tensor), axis=axis)
     elif order == 2:
         res = nd.sqrt(nd.sum(tensor**2, axis=axis))
@@ -218,16 +218,16 @@ def partial_svd(matrix, n_eigenvecs=None):
         U, S, V = U[:, ::-1], S[::-1], V[:, ::-1]
         return tensor(U, **ctx), tensor(S, **ctx), tensor(V.T, **ctx)
 
-def qr(matrix, **kwds):
-    # NOTE - should be replaced with geqrf when available
+def qr(matrix):
     try:
-        Q, R = map(nd.transpose, nd.linalg.gelqf(matrix.T))
+        # NOTE - should be replaced with geqrf when available
+        Q, L = nd.linalg.gelqf(matrix.T)
+        return Q.T, L.T
     except AttributeError:
         warnings.warn('This version of MXNet does not include the linear '
                       'algebra function gelqf(). Substituting with numpy.')
-        Q, R = map(tensor, numpy_backend.qr(to_numpy(matrix), **kwds))
-
-    return Q, R
+        Q, R = numpy_backend.qr(to_numpy(matrix))
+        return tensor(Q), tensor(R)
 
 def clip(tensor, a_min=None, a_max=None, indlace=False):
     if a_min is not None and a_max is not None:

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -54,25 +54,32 @@ def ndim(tensor):
 def clip(tensor, a_min=None, a_max=None, inplace=False):
     return np.clip(tensor, a_min, a_max)
 
-def norm(tensor, order):
+def norm(tensor, order=2, axis=None):
     """Computes the l-`order` norm of tensor
+
     Parameters
     ----------
     tensor : ndarray
     order : int
+    axis : int or tuple
+
     Returns
     -------
-    float
-        l-`order` norm of tensor
+    float or tensor
+        If `axis` is provided returns a tensor.
     """
+    # handle difference in default axis notation
+    if axis == ():
+        axis = None
+
     if order == 'inf':
-        return np.max(np.abs(tensor))
+        return np.max(np.abs(tensor), axis=axis)
     if order == 1:
-        return np.sum(np.abs(tensor))
+        return np.sum(np.abs(tensor), axis=axis)
     elif order == 2:
-        return np.sqrt(np.sum(tensor**2))
+        return np.sqrt(np.sum(tensor**2, axis=axis))
     else:
-        return np.sum(np.abs(tensor)**order)**(1/order)
+        return np.sum(np.abs(tensor)**order, axis=axis)**(1/order)
 
 def kr(matrices):
     """Khatri-Rao product of a list of matrices
@@ -181,3 +188,5 @@ def partial_svd(matrix, n_eigenvecs=None):
         U, S, V = U[:, ::-1], S[::-1], V[:, ::-1]
         return U, S, V.T
 
+def qr(matrix, **kwds):
+    return np.linalg.qr(matrix, **kwds)

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -11,7 +11,7 @@ from numpy import reshape, moveaxis, where, copy, transpose
 from numpy import arange, ones, zeros, zeros_like
 from numpy import dot, kron
 from numpy import max, min, maximum, all, mean, sum, sign, abs, prod
-from numpy.linalg import solve
+from numpy.linalg import solve, qr
 
 # Author: Jean Kossaifi
 
@@ -187,6 +187,3 @@ def partial_svd(matrix, n_eigenvecs=None):
         # WARNING: here, V is still the transpose of what it should be
         U, S, V = U[:, ::-1], S[::-1], V[:, ::-1]
         return U, S, V.T
-
-def qr(matrix):
-    return np.linalg.qr(matrix)

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -10,7 +10,7 @@ import scipy.sparse.linalg
 from numpy import reshape, moveaxis, where, copy, transpose
 from numpy import arange, ones, zeros, zeros_like
 from numpy import dot, kron
-from numpy import max, min, maximum, all, mean, sum, sign, abs
+from numpy import max, min, maximum, all, mean, sum, sign, abs, prod
 from numpy.linalg import solve
 
 # Author: Jean Kossaifi

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -188,5 +188,5 @@ def partial_svd(matrix, n_eigenvecs=None):
         U, S, V = U[:, ::-1], S[::-1], V[:, ::-1]
         return U, S, V.T
 
-def qr(matrix, **kwds):
-    return np.linalg.qr(matrix, **kwds)
+def qr(matrix):
+    return np.linalg.qr(matrix)

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -138,7 +138,7 @@ def solve(matrix1, matrix2):
     return solution
 
 
-def norm(tensor, order=2, axis=None, **kwds):
+def norm(tensor, order=2, axis=None):
     """Computes the l-`order` norm of tensor.
 
     Parameters
@@ -152,14 +152,19 @@ def norm(tensor, order=2, axis=None, **kwds):
     float or tensor
         If `axis` is provided returns a tensor.
     """
-    # pytorch does not accept `None` for any keyword arguments
-    if order and order != 'inf':
-        kwds['p'] = order
+    # pytorch does not accept `None` for any keyword arguments. additionally,
+    # pytorch doesn't seems to support keyword arguments in the first place
+    kwds = {}
     if axis is not None:
         kwds['dim'] = axis
+    if order and order != 'inf':
+        kwds['p'] = order
 
     if order == 'inf':
-        return torch.max(torch.abs(tensor), **kwds)
+        res = torch.max(torch.abs(tensor), **kwds)
+        if axis is not None:
+            return res[0]  # ignore indices output
+        return res
     return torch.norm(tensor, **kwds)
 
 
@@ -240,5 +245,5 @@ def partial_svd(matrix, n_eigenvecs=None):
     return U, S, V
 
 
-def qr(tensor, **kwds):
-    return torch.qr(tensor, **kwds)
+def qr(tensor):
+    return torch.qr(tensor)

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -49,11 +49,14 @@ def to_numpy(tensor):
     """
     if torch.is_tensor(tensor):
         return tensor.numpy()
-    elif isinstance(tensor, numpy.ndarray):
+    if isinstance(tensor, numpy.ndarray):
         return tensor
-    else:
-        raise ValueError('Only torch.Tensor or np.ndarray) are accepted,'
-                         'given {}'.format(type(tensor)))
+
+    try:
+        return numpy.array(tensor)
+    except ValueError:
+        raise ValueError('Could not convert object of type {} into a Numpy '
+                         'NDArray'.format(type(tensor)))
 
 
 def assert_array_equal(a, b, **kwargs):
@@ -135,21 +138,29 @@ def solve(matrix1, matrix2):
     return solution
 
 
-def norm(tensor, order):
-    """Computes the l-`order` norm of tensor
+def norm(tensor, order=2, axis=None, **kwds):
+    """Computes the l-`order` norm of tensor.
+
     Parameters
     ----------
     tensor : ndarray
     order : int
+    axis : int
+
     Returns
     -------
-    float
-        l-`order` norm of tensor
+    float or tensor
+        If `axis` is provided returns a tensor.
     """
+    # pytorch does not accept `None` for any keyword arguments
+    if order and order != 'inf':
+        kwds['p'] = order
+    if axis is not None:
+        kwds['dim'] = axis
+
     if order == 'inf':
-        return torch.max(torch.abs(tensor))
-    else:
-        return torch.norm(tensor, p=order)
+        return torch.max(torch.abs(tensor), **kwds)
+    return torch.norm(tensor, **kwds)
 
 
 def kr(matrices):
@@ -228,3 +239,6 @@ def partial_svd(matrix, n_eigenvecs=None):
     U, S, V = U[:, :n_eigenvecs], S[:n_eigenvecs], V.t()[:n_eigenvecs, :]
     return U, S, V
 
+
+def qr(tensor, **kwds):
+    return torch.qr(tensor, **kwds)

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -11,7 +11,7 @@ from . import numpy_backend
 
 from torch import ones, zeros
 from torch import max, min
-from torch import sum, mean, abs, sqrt, sign
+from torch import sum, mean, abs, sqrt, sign, prod
 from torch import matmul as dot
 
 # Equivalent functions in pytorch 

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -13,6 +13,7 @@ from torch import ones, zeros
 from torch import max, min
 from torch import sum, mean, abs, sqrt, sign, prod
 from torch import matmul as dot
+from torch import qr
 
 # Equivalent functions in pytorch 
 maximum = max
@@ -243,7 +244,3 @@ def partial_svd(matrix, n_eigenvecs=None):
     U, S, V = torch.svd(matrix, some=False)
     U, S, V = U[:, :n_eigenvecs], S[:n_eigenvecs], V.t()[:n_eigenvecs, :]
     return U, S, V
-
-
-def qr(tensor):
-    return torch.qr(tensor)

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -376,4 +376,7 @@ def test_qr():
             assert abs(dot_product) < 1e-6, 'Columns of Q not orthogonal'
 
 
-
+def test_prod():
+    v = T.tensor([3, 4, 5])
+    x = T.to_numpy(T.prod(v))
+    T.assert_equal(x, 60)

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -308,3 +308,72 @@ def test_partial_svd():
     with T.assert_raises(ValueError):
         tensor = T.tensor(np.random.random((3, 3, 3)))
         T.partial_svd(tensor)
+
+
+def test_shape():
+    A = T.arange(3*4*5)
+
+    shape1 = (3*4,5)
+    A1 = T.reshape(A, shape1)
+    T.assert_equal(T.shape(A1), shape1)
+
+    shape2 = (3,4,5)
+    A2 = T.reshape(A, shape2)
+    T.assert_equal(T.shape(A2), shape2)
+
+
+def test_ndim():
+    A = T.arange(3*4*5)
+    T.assert_equal(T.ndim(A), 1)
+
+    shape1 = (3*4,5)
+    A1 = T.reshape(A, shape1)
+    T.assert_equal(T.ndim(A1), 2)
+
+    shape2 = (3,4,5)
+    A2 = T.reshape(A, shape2)
+    T.assert_equal(T.ndim(A2), 3)
+
+
+def test_norm():
+    v = T.tensor([1,2,3])
+    T.assert_equal(T.norm(v,1), 6)
+
+    A = T.reshape(T.arange(6), (3,2))
+    T.assert_equal(T.norm(A, 1), 15)
+
+    column_norms1 = T.norm(A, 1, axis=0)
+    row_norms1 = T.norm(A, 1, axis=1)
+    T.assert_array_equal(column_norms1, T.tensor([6, 9]))
+    T.assert_array_equal(row_norms1, T.tensor([1, 5, 9]))
+
+    column_norms2 = T.norm(A, 2, axis=0)
+    row_norms2 = T.norm(A, 2, axis=1)
+    T.assert_array_almost_equal(column_norms2, T.tensor([4.47213602, 5.91608]))
+    T.assert_array_almost_equal(row_norms2, T.tensor([1., 3.60555124, 6.40312433]))
+
+    # limit as order->oo is the oo-norm
+    column_norms10 = T.norm(A, 10, axis=0)
+    row_norms10 = T.norm(A, 10, axis=1)
+    T.assert_array_almost_equal(column_norms10, T.tensor([4.00039053, 5.00301552]))
+    T.assert_array_almost_equal(row_norms10, T.tensor([1., 3.00516224, 5.05125666]))
+
+
+def test_qr():
+    M = 8; N = 5
+    A = T.tensor(np.random.random((8,5)))
+    Q, R = T.qr(A)
+
+    assert T.shape(Q) == (M,N), 'Unexpected shape'
+    assert T.shape(R) == (N,N), 'Unexpected shape'
+
+    # assert that the columns of Q are orthonormal
+    Q_column_norms = T.norm(Q, 2, axis=0)
+    T.assert_array_almost_equal(Q_column_norms, T.ones(N))
+    for i in range(N):
+        for j in range(i):
+            dot_product = T.to_numpy(T.dot(Q[:,i], Q[:,j]))
+            assert abs(dot_product) < 1e-6, 'Columns of Q not orthogonal'
+
+
+

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -358,10 +358,15 @@ def test_norm():
     T.assert_array_almost_equal(column_norms10, T.tensor([4.00039053, 5.00301552]))
     T.assert_array_almost_equal(row_norms10, T.tensor([1., 3.00516224, 5.05125666]))
 
+    column_norms_oo = T.norm(A, 'inf', axis=0)
+    row_norms_oo = T.norm(A, 'inf', axis=1)
+    T.assert_array_equal(column_norms_oo, T.tensor([4, 5]))
+    T.assert_array_equal(row_norms_oo, T.tensor([1, 3, 5]))
+
 
 def test_qr():
     M = 8; N = 5
-    A = T.tensor(np.random.random((8,5)))
+    A = T.tensor(np.random.random((M,N)))
     Q, R = T.qr(A)
 
     assert T.shape(Q) == (M,N), 'Unexpected shape'
@@ -374,6 +379,9 @@ def test_qr():
         for j in range(i):
             dot_product = T.to_numpy(T.dot(Q[:,i], Q[:,j]))
             assert abs(dot_product) < 1e-6, 'Columns of Q not orthogonal'
+
+    A_reconstructed = T.dot(Q, R)
+    T.assert_array_almost_equal(A, A_reconstructed)
 
 
 def test_prod():


### PR DESCRIPTION
We add the QR decomposition function `qr()` and `prod()` function to the backends as well as update `norm()` to accept different axes. This PR is a pre-requisite to #29 .

# Tests

```bash
$ TENSORLY_BACKEND=numpy pytest -v ./tensorly
$ TENSORLY_BACKEND=mxnet pytest -v ./tensorly
$ TENSORLY_BACKEND=pytorch pytest -v ./tensorly
```