### PR TITLE
Add where() to Pytorch backend

### DIFF
--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -100,24 +100,10 @@ def clip(tensor, a_min=None, a_max=None, inplace=False):
 
 def where(condition, x, y):
     assert condition.shape == x.shape == y.shape, 'Dimension mismatch'
-    N = condition.nelement()
-
-    # See https://github.com/pytorch/pytorch/issues/2813
-    try:
-        out = torch.zeros_like(x)
-    except AttributeError:
-        out = x.new(x.size()).zero_()
-
-    # unroll inputs and outputs for ease of iteration through elements
-    condition_ = condition.view(N)
-    x_ = x.view(N)
-    y_ = y.view(N)
-    out_ = out.view(N)
-
-    for i in range(N):
-        out_[i] = x_[i] if condition_[i] else y_[i]
-    return out
-
+    result = zeros_like(condition, **context(x))
+    result[condition] = x
+    result[~condition] = y
+    return result
 
 def all(tensor):
     return torch.sum(tensor != 0)

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -98,6 +98,22 @@ def clip(tensor, a_min=None, a_max=None, inplace=False):
     else:
         return torch.clamp(tensor, a_min, a_max)
 
+def where(condition, x, y):
+    assert condition.shape == x.shape == y.shape, 'Dimension mismatch'
+    N = condition.nelement()
+    out = torch.zeros_like(x)
+
+    # unroll inputs and outputs for ease of iteration through elements
+    condition_ = condition.view(N)
+    x_ = x.view(N)
+    y_ = y.view(N)
+    out_ = out.view(N)
+
+    for i in range(N):
+        out_[i] = x_[i] if condition_[i] else y_[i]
+    return out
+
+
 def all(tensor):
     return torch.sum(tensor != 0)
 

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -101,7 +101,12 @@ def clip(tensor, a_min=None, a_max=None, inplace=False):
 def where(condition, x, y):
     assert condition.shape == x.shape == y.shape, 'Dimension mismatch'
     N = condition.nelement()
-    out = torch.zeros_like(x)
+
+    # See https://github.com/pytorch/pytorch/issues/2813
+    try:
+        out = torch.zeros_like(x)
+    except AttributeError:
+        out = x.new(x.size()).zero_()
 
     # unroll inputs and outputs for ease of iteration through elements
     condition_ = condition.view(N)

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -364,7 +364,8 @@ def test_norm():
     T.assert_array_equal(row_norms_oo, T.tensor([1, 3, 5]))
 
 
-def test_where_1d():
+def test_where():
+    # 1D
     shape = (2*3*4,); N = np.prod(shape)
     X = T.arange(N)
     zeros = T.zeros(X.shape)
@@ -372,11 +373,11 @@ def test_where_1d():
     out = T.where(X < 2*3, zeros, ones)
     for i in range(N):
         if i < 2*3:
-            assert out[i] == 0
+            assert out[i] == 0, 'Unexpected result on vector'
         else:
-            assert out[i] == 1
+            assert out[i] == 1, 'Unexpected result on vector'
 
-def test_where_2d():
+    # 2D
     shape = (2*3,4); N = np.prod(shape)
     X = T.reshape(T.arange(N), shape)
     zeros = T.zeros(X.shape)
@@ -386,11 +387,11 @@ def test_where_2d():
         for j in range(shape[1]):
             index = i*shape[1] + j
             if index < 2*3:
-                assert out[i,j] == 0
+                assert out[i,j] == 0, 'Unexpected result on matrix'
             else:
-                assert out[i,j] == 1
+                assert out[i,j] == 1, 'Unexpected result on matrix'
 
-def test_where_3d():
+    # 3D
     shape = (2,3,4); N = np.prod(shape)
     X = T.reshape(T.arange(N), shape)
     zeros = T.zeros(X.shape)
@@ -401,9 +402,10 @@ def test_where_3d():
             for k in range(shape[2]):
                 index = (i*shape[1] + j)*shape[2] + k
                 if index < 2*3:
-                    assert out[i,j,k] == 0
+                    assert out[i,j,k] == 0, 'Unexpected result on 3-tensor'
                 else:
-                    assert out[i,j,k] == 1
+                    assert out[i,j,k] == 1, 'Unexpected result on 3-tensor'
+
 
 def test_qr():
     M = 8; N = 5

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -364,6 +364,47 @@ def test_norm():
     T.assert_array_equal(row_norms_oo, T.tensor([1, 3, 5]))
 
 
+def test_where_1d():
+    shape = (2*3*4,); N = np.prod(shape)
+    X = T.arange(N)
+    zeros = T.zeros(X.shape)
+    ones = T.ones(X.shape)
+    out = T.where(X < 2*3, zeros, ones)
+    for i in range(N):
+        if i < 2*3:
+            assert out[i] == 0
+        else:
+            assert out[i] == 1
+
+def test_where_2d():
+    shape = (2*3,4); N = np.prod(shape)
+    X = T.reshape(T.arange(N), shape)
+    zeros = T.zeros(X.shape)
+    ones = T.ones(X.shape)
+    out = T.where(X < 2*3, zeros, ones)
+    for i in range(shape[0]):
+        for j in range(shape[1]):
+            index = i*shape[1] + j
+            if index < 2*3:
+                assert out[i,j] == 0
+            else:
+                assert out[i,j] == 1
+
+def test_where_3d():
+    shape = (2,3,4); N = np.prod(shape)
+    X = T.reshape(T.arange(N), shape)
+    zeros = T.zeros(X.shape)
+    ones = T.ones(X.shape)
+    out = T.where(X < 2*3, zeros, ones)
+    for i in range(shape[0]):
+        for j in range(shape[1]):
+            for k in range(shape[2]):
+                index = (i*shape[1] + j)*shape[2] + k
+                if index < 2*3:
+                    assert out[i,j,k] == 0
+                else:
+                    assert out[i,j,k] == 1
+
 def test_qr():
     M = 8; N = 5
     A = T.tensor(np.random.random((M,N)))

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -1,9 +1,11 @@
 import numpy as np
+import tensorly as tl
+
 from scipy.sparse.linalg import svds
 from scipy.linalg import svd
 
+from .. import numpy_backend
 from .. import backend as T
-import tensorly as tl
 from ..base import fold, unfold
 from ..base import partial_fold, partial_unfold
 from ..base import tensor_to_vec, vec_to_tensor
@@ -405,6 +407,16 @@ def test_where():
                     assert out[i,j,k] == 0, 'Unexpected result on 3-tensor'
                 else:
                     assert out[i,j,k] == 1, 'Unexpected result on 3-tensor'
+
+    # random testing against Numpy's output
+    shapes = (16,8,4,2)
+    for order in range(1,5):
+        shape = shapes[:order]
+        tensor = T.tensor(np.random.randn(*shape))
+        args = (tensor < 0, T.zeros(shape), T.ones(shape))
+        result = T.where(*args)
+        expected = np.where(*map(T.to_numpy, args))
+        T.assert_array_equal(result, expected)
 
 
 def test_qr():


### PR DESCRIPTION
Pytorch does not seem to include the `where()` function so we implement our own.

Note that this only provides the three-argument version. `np.where(condition)`, where the other two arguments are `None`, is equivalent to `condition.nonzero()`. MXNet, however, only supports the three argument version.

This function will be used in #29 .