### PR TITLE
Allow optional weights input in kruskal_to_tensor

### DIFF
--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -26,7 +26,7 @@ def context(tensor):
     """
     return {'ctx':tensor.context, 'dtype':tensor.dtype}
 
-def tensor(data, ctx=mx.cpu(), dtype="float64"):
+def tensor(data, ctx=mx.cpu(), dtype='float32'):
     """Tensor class
     """
     if dtype is None and isinstance(data, numpy.ndarray):

--- a/tensorly/kruskal_tensor.py
+++ b/tensorly/kruskal_tensor.py
@@ -11,7 +11,7 @@ from .tenalg import khatri_rao
 # License: BSD 3 clause
 
 
-def kruskal_to_tensor(factors):
+def kruskal_to_tensor(factors, weights=None):
     """Turns the Khatri-product of matrices into a full tensor
 
         ``factor_matrices = [|U_1, ... U_n|]`` becomes
@@ -37,8 +37,11 @@ def kruskal_to_tensor(factors):
     There are other possible and equivalent alternate implementation, e.g.
     summing over r and updating an outer product of vectors.
     """
-    shape = [factor.shape[0] for factor in factors]
-    full_tensor = T.dot(factors[0], T.transpose(khatri_rao(factors[1:])))
+    shape = [T.shape(factor)[0] for factor in factors]
+    if weights is not None:
+        full_tensor = T.dot(factors[0]*weights, T.transpose(khatri_rao(factors[1:])))
+    else:
+        full_tensor = T.dot(factors[0], T.transpose(khatri_rao(factors[1:])))
     return fold(full_tensor, 0, shape)
 
 

--- a/tensorly/tests/test_kruskal_tensor.py
+++ b/tensorly/tests/test_kruskal_tensor.py
@@ -67,6 +67,15 @@ def test_kruskal_to_tensor():
         tl.assert_array_almost_equal(reconstructed, unfolded)
         matrices.insert(i, U_i)
 
+def test_kruskal_to_tensor_with_weights():
+    A = tl.reshape(tl.arange(1,5), (2,2))
+    B = tl.reshape(tl.arange(5,9), (2,2))
+    weights = tl.tensor([2,-1])
+
+    out = kruskal_to_tensor([A,B], weights=weights)
+    expected = tl.tensor([[-2,-2], [6, 10]])  # computed by hand
+    tl.assert_array_equal(out, expected)
+
 
 def test_kruskal_to_unfolded():
     """Test for kruskal_to_unfolded.


### PR DESCRIPTION
In some applications it is useful to scale the factor matrices using a vector of weights. An optional argument `weights` is added to `kruskal_to_tensor`.

Pre-requisite to #29 .

## Note

I also changed the default MXNet `dtype` to `float32` from `float64`. This is because other MXNet tensor creation functions like `ones()` defaults to `float32` as well. Otherwise, the following annoying behavior occurs:

```python
>>> import tensorly as T
Using numpy backend.
>>> T.set_backend('mxnet')
Using mxnet backend.
>>> x = T.tensor([1,2,3])
>>> y = T.ones(3)
>>> T.dot(x,y)
MXNetError
```