### PR TITLE
Refactor parafac initialization

### DIFF
--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -77,11 +77,10 @@ def initialize_factors(tensor, rank, init='svd', random_state=None):
     rng = check_random_state(random_state)
 
     if init is 'random':
-        factors = [T.tensor(rng.random_sample((tensor.shape[i], rank))) for i in range(T.ndim(tensor))]
+        factors = [T.tensor(rng.random_sample((tensor.shape[i], rank)), **T.context(tensor)) for i in range(T.ndim(tensor))]
         factors, _ = normalize_factors(factors)
         return factors
-
-    if init is 'svd':
+    elif init is 'svd':
         factors = []
         for mode in range(T.ndim(tensor)):
             U, _, _ = T.partial_svd(unfold(tensor, mode), n_eigenvecs=rank)

--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -78,7 +78,6 @@ def initialize_factors(tensor, rank, init='svd', random_state=None):
 
     if init is 'random':
         factors = [T.tensor(rng.random_sample((tensor.shape[i], rank)), **T.context(tensor)) for i in range(T.ndim(tensor))]
-        factors, _ = normalize_factors(factors)
         return factors
     elif init is 'svd':
         factors = []

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -8,120 +8,6 @@ from ...random import check_random_state
 from ... import backend as T
 
 
-randomized_test_cases = {
-    'order3_small': {
-        'dimensions': (8, 8, 8), 'rank': 4, 'seed': 0},
-    'order3_large': {
-        'dimensions': (16, 16, 16), 'rank': 12, 'seed': 0},
-    'order3_mixed': {
-        'dimensions': (16, 12, 8), 'rank': 8, 'seed': 0},
-    'order3_small_orthogonal': {
-        'dimensions': (8, 8, 8), 'rank': 4, 'seed': 0, 'orthogonal': True},
-    'order3_large_orthogonal': {
-        'dimensions': (16, 16, 16), 'rank': 12, 'seed': 0, 'orthogonal': True},
-    'order3_mixed_orthogonal': {
-        'dimensions': (16, 12, 8), 'rank': 8, 'seed': 0, 'orthogonal': True},
-    'order4': {
-        'dimensions': (8, 8, 8, 8), 'rank': 4, 'seed': 0},
-    'order4_orthogonal': {
-        'dimensions': (8, 8, 8, 8), 'rank': 4, 'seed': 0, 'orthogonal': True},
-}
-
-
-def create_random_decomposition(dimensions=(10,10,10), rank=10, seed=None,
-                                orthogonal=False, noisy=False):
-    r"""Random tensor generation used in testing.
-
-    Returns a random tensor of specified order along with a list of its
-    constituent normalized factor matrices and corresponding weight vector.
-
-    Parameters
-    ----------
-    dimensions : tuple
-    rank : int
-        The desired rank of the tensor. Note that if `orthogonal == True` then
-        the rank must be less than or equal to the smallest dimension of the
-        tensor.
-    seed : int
-        Random number generation seed.
-    orthogonal : bool
-        If `True`, creates a tensor with orthogonal rank-1 components.
-    noisy : bool
-        If `True`, adds Gaussian noise to the tensor. (Useful when constructing
-        near-orthogonal tensors for experimentation.)
-
-    Returns
-    -------
-    tensor : ndarray
-    factors : list of 2D ndarrays
-        A list of random ALS factors.
-    weights : 1D ndarray
-        A list of random weights.
-
-    """
-    order = len(dimensions)
-    dim = min(dimensions)
-    if (rank > dim) and orthogonal:
-        raise ValueError('Can only construct orthogonal tensors when '
-                         'rank <= min(dimensions)')
-
-    np.random.seed(seed)
-    weights = 4*T.arange(1, rank+1)
-    factors = [T.tensor(np.random.randn(dim,rank)) for dim in dimensions]
-
-    if orthogonal:
-        factors = [T.qr(factor)[0] for factor in factors]
-    tensor = kruskal_to_tensor(factors, weights)
-
-    if noisy:
-        scale = rank/(rank+10.**(order-1))
-        tensor += T.tensor(scale*np.random.randn(*dimensions))
-    return tensor, factors, weights
-
-
-def test_parafac_errors():
-    with pytest.raises(ValueError) as e:
-        create_random_decomposition(dimensions=(8,8,8), rank=10, orthogonal=True)
-
-    tensor = T.tensor([[1,2],[3,4]])
-    rank = 1
-    with pytest.raises(ValueError) as e:
-        initialize_factors(tensor, rank, init='invalid initialization')
-
-
-@pytest.mark.parametrize(
-    'params',
-    list(randomized_test_cases.values()),
-    ids=list(randomized_test_cases.keys()))
-def test_parafac_random(params):
-    rank = params['rank']
-    tensor, weights, factors = create_random_decomposition(**params)
-    factors_estimated = parafac(tensor, rank, n_iter_max=500, tol=1e-8)
-    factors_estimated, weights_estimated = normalize_factors(factors_estimated)
-    tensor_estimted = kruskal_to_tensor(
-        factors_estimated, weights=weights_estimated)
-
-    error = T.norm(tensor - tensor_estimted)/T.norm(tensor)
-    T.assert_(error < 1e-4,
-              '2-Norm relative error between known and recovered tensor too large')
-
-@pytest.mark.parametrize(
-    'params',
-    list(randomized_test_cases.values()),
-    ids=list(randomized_test_cases.keys()))
-def test_parafac_random_noisy(params):
-    rank = params['rank']
-    tensor, weights, factors = create_random_decomposition(noisy=True, **params)
-    factors_estimated = parafac(tensor, rank, n_iter_max=500, tol=1e-8)
-    factors_estimated, weights_estimated = normalize_factors(factors_estimated)
-    tensor_estimted = kruskal_to_tensor(
-        factors_estimated, weights=weights_estimated)
-
-    error = T.norm(tensor - tensor_estimted)/T.norm(tensor)
-    T.assert_(error < 1e-1,
-              '2-Norm relative error between known and recovered tensor too large')
-
-
 def test_parafac():
     """Test for the CANDECOMP-PARAFAC decomposition
     """
@@ -149,7 +35,6 @@ def test_parafac():
             'norm 2 of difference between svd and random init too high')
     T.assert_(T.max(T.abs(rec_svd - rec_random)) < tol_max_abs,
             'abs norm of difference between svd and random init too high')
-
 
 def test_non_negative_parafac():
     """Test for non-negative PARAFAC

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from ..candecomp_parafac import parafac, non_negative_parafac, normalize_factors
+from ..candecomp_parafac import (
+    parafac, non_negative_parafac, normalize_factors, initialize_factors)
 from ...kruskal_tensor import kruskal_to_tensor
 from ...random import check_random_state
 from ... import backend as T
@@ -78,9 +79,15 @@ def create_random_decomposition(dimensions=(10,10,10), rank=10, seed=None,
     return tensor, factors, weights
 
 
-def test_parafac_raises_value_error():
+def test_parafac_errors():
     with pytest.raises(ValueError) as e:
         create_random_decomposition(dimensions=(8,8,8), rank=10, orthogonal=True)
+
+    tensor = T.tensor([[1,2],[3,4]])
+    rank = 1
+    with pytest.raises(ValueError) as e:
+        initialize_factors(tensor, rank, init='invalid initialization')
+
 
 @pytest.mark.parametrize(
     'params',
@@ -142,7 +149,6 @@ def test_parafac():
             'norm 2 of difference between svd and random init too high')
     T.assert_(T.max(T.abs(rec_svd - rec_random)) < tol_max_abs,
             'abs norm of difference between svd and random init too high')
-
 
 
 def test_non_negative_parafac():

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -36,6 +36,10 @@ def test_parafac():
     T.assert_(T.max(T.abs(rec_svd - rec_random)) < tol_max_abs,
             'abs norm of difference between svd and random init too high')
 
+    with np.testing.assert_raises(ValueError):
+        rank = 4
+        _ = initialize_factors(tensor, rank, init='bogus init type')
+
 def test_non_negative_parafac():
     """Test for non-negative PARAFAC
 

--- a/tensorly/random/base.py
+++ b/tensorly/random/base.py
@@ -28,9 +28,9 @@ def check_random_state(seed):
 
     raise ValueError('Seed should be None, int or np.random.RandomState')
 
-def cp_tensor(shape, rank, full=False, random_state=None):
+def cp_tensor(shape, rank, full=False, orthogonal=False, random_state=None):
     """Generates a random CP tensor
-    
+
     Parameters
     ----------
     shape : tuple
@@ -40,25 +40,33 @@ def cp_tensor(shape, rank, full=False, random_state=None):
     full : bool, optional, default is False
         if True, a full tensor is returned
         otherwise, the decomposed tensor is returned
+    orthogonal : bool, optional, default is False
+        if True, creates a tensor with orthogonal components
     random_state : `np.random.RandomState`
-        
+
     Returns
     -------
     cp_tensor : ND-array or 2D-array list
         ND-array : full tensor if `full` is True
         2D-array list : list of factors otherwise
     """
+    if (rank > min(shape)) and orthogonal:
+        raise ValueError('Can only construct orthogonal tensors when rank <= '
+                         'min(shape)')
+
     rns = check_random_state(random_state)
     factors = [T.tensor(rns.random_sample((s, rank))) for s in shape]
+    if orthogonal:
+        factors = [T.qr(factor)[0] for factor in factors]
+
     if full:
         return kruskal_to_tensor(factors)
     else:
         return factors
-    
 
 def tucker_tensor(shape, rank, full=False, random_state=None):
     """Generates a random Tucker tensor
-    
+
     Parameters
     ----------
     shape : tuple
@@ -71,7 +79,7 @@ def tucker_tensor(shape, rank, full=False, random_state=None):
         if True, a full tensor is returned
         otherwise, the decomposed tensor is returned
     random_state : `np.random.RandomState`
-        
+
     Returns
     -------
     tucker_tensor : ND-array or (ND-array, 2D-array list)
@@ -97,5 +105,3 @@ def tucker_tensor(shape, rank, full=False, random_state=None):
         return tucker_to_tensor(core, factors)
     else:
         return core, factors
-
-


### PR DESCRIPTION
We factor out the factor initialization code from the main parafac algorithm. We
do this in anticipation of upcoming changes to the main algorithm mentioned in
PR #29. Otherwise, `parafac()` will be too large of a function and, therefore,
difficult to debug.

Added a collection of randomized parafac tests, as well.