### PR TITLE
Python 2 compatibility

### DIFF
--- a/tensorly/__init__.py
+++ b/tensorly/__init__.py
@@ -25,8 +25,11 @@ def set_backend(backend_name):
     _BACKEND = backend_name
 
     # reloads tensorly.backend
-    importlib.reload(backend)
-
+    try:
+        importlib.reload(backend)
+    except:
+        reload(backend)
+        
     # reload from .backend import * (e.g. tensorly.tensor)
     globals().update(
             {fun: getattr(backend, fun) for n in backend.__all__} if hasattr(backend, '__all__') 

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -13,7 +13,7 @@ except ImportError as error:
     message = ('Impossible to import MXNet.\n'
                'To use TensorLy with the MXNet backend, '
                'you must first install MXNet!')
-    raise ImportError(message) from error
+    raise ImportError(message)
 
 import warnings
 import numpy

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -13,7 +13,7 @@ except ImportError as error:
     message = ('Impossible to import PyTorch.\n'
                'To use TensorLy with the PyTorch backend, '
                'you must first install PyTorch!')
-    raise ImportError(message) from error
+    raise ImportError(message)
 
 
 import numpy


### PR DESCRIPTION
- import_lib.reoad isn't supported in Python 2, so reload is used if import_lib.reload raises an exception.
- Exception chaining (raise ImportError(message) from err) isn't supported in Python 2.