### PR TITLE
Make example tensor visible in docs

### DIFF
--- a/doc/user_guide/backend.rst
+++ b/doc/user_guide/backend.rst
@@ -5,11 +5,11 @@ TensorLy's backend system
 
 Backend?
 --------
-To represent tensors and for numerical computation, TensorLy supports several backends transparently: the ubuquitous NumPy (the default), MXNet, and PyTorch.
+To represent tensors and for numerical computation, TensorLy supports several backends transparently: the ubiquitous NumPy (the default), MXNet, and PyTorch.
 For the end user, the interface is exactly the same, but under the hood, a different library is used to represent multi-dimensional arrays and perform computations on these. In other words, you write your code using TensorLy and can then decide whether the computation is done using NumPy, PyTorch or MXNet.
 
-Why backends
-------------
+Why backends?
+-------------
 The goal of TensorLy is to make tensor methods accessible. While NumPy needs no introduction, the MXNet and PyTorch backends are especially useful as they allows to perform transparently computation on CPU or GPU. Last but not least, using MXNet or PyTorch as a backend, we are able to combine tensor methods and deep learning easily!
 
 How do I change the backend?
@@ -30,7 +30,7 @@ Once you change the backend, all the computation is done using that backend.
 Context of a tensor
 -------------------
 
-Different backends have different parameters associated with the tensors. For instance, in NumPy mwe traditionally set the dtype when creating an ndarray, while in mxnet we also have to change the *context* (GPU or CPU), with the `ctx` argument. Similarly, in PyTorch, we might want to create a FloatTensor for CPU and a cuda.FloatTensor for GPU. 
+Different backends have different parameters associated with the tensors. For instance, in NumPy we traditionally set the dtype when creating an ndarray, while in mxnet we also have to change the *context* (GPU or CPU), with the `ctx` argument. Similarly, in PyTorch, we might want to create a FloatTensor for CPU and a cuda.FloatTensor for GPU. 
 
 To handle this difference, we implemented a `context` function, that, given a tensor, returns a dictionary of values characterising that tensor. A function getting a tensor as input and creating a new tensor should use that context to create the new tensor.
 

--- a/doc/user_guide/tensor_decomposition.rst
+++ b/doc/user_guide/tensor_decomposition.rst
@@ -20,7 +20,8 @@ We demonstrate here how to perform a Canonical Polyadic Decomposition. A rank-r 
 
 First, let's create a second order tensor that is zero everywhere except in a swiss shape that is one.
 
-.. code-block::python
+.. code-block:: python
+                
    >>> import numpy as np
    >>> import tensorly as tl
    >>> tensor = tl.tensor([[ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
@@ -98,7 +99,7 @@ Using the same tensor as previously, we will perform a rank [2, 3]-decomposition
    >>> [f.shape for f in factors]
    [(12, 2), (12, 3)]
 
-As previously, we can reconstruct a full tensor from our Tucker decomposition:
+As before, we can reconstruct a full tensor from our Tucker decomposition:
 
 .. code:: python
    

--- a/doc/user_guide/tensor_regression.rst
+++ b/doc/user_guide/tensor_regression.rst
@@ -8,7 +8,7 @@ Setting
 
 Tensor regression is available in the module :mod:`tensorly.regression`.
 
-Given a series of :math:`N` tensor samples/observations, :math:`\tilde X_i, i={1, \cdots, N}`, and corresponding labels :math:`y_i, i={1, \cdots, N}`, we want to find the weight tesor :math:`\tilde W` such that, for each :math:`i={1, \cdots, N}`: 
+Given a series of :math:`N` tensor samples/observations, :math:`\tilde X_i, i={1, \cdots, N}`, and corresponding labels :math:`y_i, i={1, \cdots, N}`, we want to find the weight tensor :math:`\tilde W` such that, for each :math:`i={1, \cdots, N}`: 
 
 .. math::
 


### PR DESCRIPTION
Fixes a display error at http://tensorly.org/stable/user_guide/tensor_decomposition.html where the example tensor isn't shown. 

Also a few other very minor spelling changes in the docs