### PR TITLE
eigenvalue computation requires conjugate transpose

### DIFF
--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -214,11 +214,11 @@ def partial_svd(matrix, n_eigenvecs=None):
         # We can perform a partial SVD
         # First choose whether to use X * X.T or X.T *X
         if dim_1 < dim_2:
-            S, U = scipy.sparse.linalg.eigsh(numpy.dot(matrix, matrix.T), k=n_eigenvecs, which='LM')
+            S, U = scipy.sparse.linalg.eigsh(numpy.dot(matrix, matrix.T.conj()), k=n_eigenvecs, which='LM')
             S = numpy.sqrt(S)
             V = numpy.dot(matrix.T, U * 1/S.reshape((1, -1)))
         else:
-            S, V = scipy.sparse.linalg.eigsh(numpy.dot(matrix.T, matrix), k=n_eigenvecs, which='LM')
+            S, V = scipy.sparse.linalg.eigsh(numpy.dot(matrix.T.conj(), matrix), k=n_eigenvecs, which='LM')
             S = numpy.sqrt(S)
             U = numpy.dot(matrix, V) * 1/S.reshape((1, -1))
 

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -216,7 +216,7 @@ def partial_svd(matrix, n_eigenvecs=None):
         if dim_1 < dim_2:
             S, U = scipy.sparse.linalg.eigsh(numpy.dot(matrix, matrix.T.conj()), k=n_eigenvecs, which='LM')
             S = numpy.sqrt(S)
-            V = numpy.dot(matrix.T, U * 1/S.reshape((1, -1)))
+            V = numpy.dot(matrix.T.conj(), U * 1/S.reshape((1, -1)))
         else:
             S, V = scipy.sparse.linalg.eigsh(numpy.dot(matrix.T.conj(), matrix), k=n_eigenvecs, which='LM')
             S = numpy.sqrt(S)
@@ -224,7 +224,7 @@ def partial_svd(matrix, n_eigenvecs=None):
 
         # WARNING: here, V is still the transpose of what it should be
         U, S, V = U[:, ::-1], S[::-1], V[:, ::-1]
-        return tensor(U, **ctx), tensor(S, **ctx), tensor(V.T, **ctx)
+        return tensor(U, **ctx), tensor(S, **ctx), tensor(V.T.conj(), **ctx)
 
 def qr(matrix):
     try:

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -178,7 +178,7 @@ def partial_svd(matrix, n_eigenvecs=None):
         if dim_1 < dim_2:
             S, U = scipy.sparse.linalg.eigsh(np.dot(matrix, matrix.T.conj()), k=n_eigenvecs, which='LM')
             S = np.sqrt(S)
-            V = np.dot(matrix.T, U * 1/S[None, :])
+            V = np.dot(matrix.T.conj(), U * 1/S[None, :])
         else:
             S, V = scipy.sparse.linalg.eigsh(np.dot(matrix.T.conj(), matrix), k=n_eigenvecs, which='LM')
             S = np.sqrt(S)
@@ -186,4 +186,4 @@ def partial_svd(matrix, n_eigenvecs=None):
 
         # WARNING: here, V is still the transpose of what it should be
         U, S, V = U[:, ::-1], S[::-1], V[:, ::-1]
-        return U, S, V.T
+        return U, S, V.T.conj()

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -176,11 +176,11 @@ def partial_svd(matrix, n_eigenvecs=None):
         # We can perform a partial SVD
         # First choose whether to use X * X.T or X.T *X
         if dim_1 < dim_2:
-            S, U = scipy.sparse.linalg.eigsh(np.dot(matrix, matrix.T), k=n_eigenvecs, which='LM')
+            S, U = scipy.sparse.linalg.eigsh(np.dot(matrix, matrix.T.conj()), k=n_eigenvecs, which='LM')
             S = np.sqrt(S)
             V = np.dot(matrix.T, U * 1/S[None, :])
         else:
-            S, V = scipy.sparse.linalg.eigsh(np.dot(matrix.T, matrix), k=n_eigenvecs, which='LM')
+            S, V = scipy.sparse.linalg.eigsh(np.dot(matrix.T.conj(), matrix), k=n_eigenvecs, which='LM')
             S = np.sqrt(S)
             U = np.dot(matrix, V) * 1/S[None, :]
 

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -297,11 +297,11 @@ def partial_svd(matrix, n_eigenvecs=None):
         # We can perform a partial SVD
         # First choose whether to use X * X.T or X.T *X
         if dim_1 < dim_2:
-            S, U = scipy.sparse.linalg.eigsh(numpy.dot(matrix, matrix.T), k=n_eigenvecs, which='LM')
+            S, U = scipy.sparse.linalg.eigsh(numpy.dot(matrix, matrix.T.conj()), k=n_eigenvecs, which='LM')
             S = numpy.sqrt(S)
             V = numpy.dot(matrix.T, U * 1/S.reshape((1, -1)))
         else:
-            S, V = scipy.sparse.linalg.eigsh(numpy.dot(matrix.T, matrix), k=n_eigenvecs, which='LM')
+            S, V = scipy.sparse.linalg.eigsh(numpy.dot(matrix.T.conj(), matrix), k=n_eigenvecs, which='LM')
             S = numpy.sqrt(S)
             U = numpy.dot(matrix, V) * 1/S.reshape((1, -1))
 

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -299,7 +299,7 @@ def partial_svd(matrix, n_eigenvecs=None):
         if dim_1 < dim_2:
             S, U = scipy.sparse.linalg.eigsh(numpy.dot(matrix, matrix.T.conj()), k=n_eigenvecs, which='LM')
             S = numpy.sqrt(S)
-            V = numpy.dot(matrix.T, U * 1/S.reshape((1, -1)))
+            V = numpy.dot(matrix.T.conj(), U * 1/S.reshape((1, -1)))
         else:
             S, V = scipy.sparse.linalg.eigsh(numpy.dot(matrix.T.conj(), matrix), k=n_eigenvecs, which='LM')
             S = numpy.sqrt(S)
@@ -307,7 +307,7 @@ def partial_svd(matrix, n_eigenvecs=None):
 
         # WARNING: here, V is still the transpose of what it should be
         U, S, V = U[:, ::-1], S[::-1], V[:, ::-1]
-        return tensor(U, **ctx), tensor(S, **ctx), tensor(V.T, **ctx)
+        return tensor(U, **ctx), tensor(S, **ctx), tensor(V.T.conj(), **ctx)
 
 def sqrt(tensor, *args, **kwargs):
     if torch.is_tensor(tensor):


### PR DESCRIPTION
For tensors containing complex numbers the partial SVD needs to take the conjugate transpose. All unit tests still pass.