### PR TITLE
MAINT: update backend warning message

### DIFF
--- a/tensorly/backend/__init__.py
+++ b/tensorly/backend/__init__.py
@@ -15,6 +15,7 @@ elif _BACKEND == 'cupy':
     from .cupy_backend import *
 else:
     import warnings
-    warnings.warn('_BACKEND should be either "mxnet", "pytorch" or "numpy", {} given.'.format(_BACKEND))
+    warnings.warn('_BACKEND should be either "mxnet", "pytorch", '
+                  '"tensorflow", "cupy" or "numpy". '
+                  '{} was given.'.format(_BACKEND))
     warnings.warn('Using MXNet backend.')
-


### PR DESCRIPTION
This PR updates the warning message when changing the backend.

`__init__.py` seems to have an extra warning about the mxnet backend. Is this required?