### PR TITLE
ENH: get pretrained PyTorch models

### DIFF
--- a/tensorly/contrib/__init__.py
+++ b/tensorly/contrib/__init__.py
@@ -2,3 +2,5 @@
 
     Allows to add quickly and test new functions for which the API is not necessarily fixed
 """
+
+from ._torch import pytorch_model

--- a/tensorly/contrib/_torch.py
+++ b/tensorly/contrib/_torch.py
@@ -1,7 +1,7 @@
 import torchvision.models as models
 
 
-def get_pytorch_model(model='resnet18'):
+def pytorch_model(model='resnet18'):
     """
     Parameters
     ----------

--- a/tensorly/contrib/_torch.py
+++ b/tensorly/contrib/_torch.py
@@ -1,4 +1,3 @@
-import torchvision.models as models
 from .. import get_backend
 
 
@@ -21,6 +20,7 @@ def pytorch_model(model='resnet18'):
         raise ValueError("This function is only implemented PyTorch backend. "
                          "Run tensorly.set_backend('pytorch') to prevent "
                          "this error")
-    fn = getattr(models, model)
+    import torchvision
+    fn = getattr(torchvision.models, model)
     net = fn(pretrained=True)
     return list(net.parameters())

--- a/tensorly/contrib/_torch.py
+++ b/tensorly/contrib/_torch.py
@@ -1,4 +1,5 @@
 import torchvision.models as models
+from .. import get_backend
 
 
 def pytorch_model(model='resnet18'):
@@ -16,6 +17,10 @@ def pytorch_model(model='resnet18'):
         List of PyTorch tensors that represent the weights of a pretrained
         neural network
     """
+    if get_backend() != 'pytorch':
+        raise ValueError("This function is only implemented PyTorch backend. "
+                         "Run tensorly.set_backend('pytorch') to prevent "
+                         "this error")
     fn = getattr(models, model)
     net = fn(pretrained=True)
     return list(net.parameters())

--- a/tensorly/contrib/_torch.py
+++ b/tensorly/contrib/_torch.py
@@ -1,0 +1,21 @@
+import torchvision.models as models
+
+
+def get_pytorch_model(model='resnet18'):
+    """
+    Parameters
+    ----------
+    models : str, optional. default ``inception``
+        Other available models are any of the keys in
+        https://pytorch.org/docs/stable/torchvision/models.html
+        e.g., ``'alexnet'`` or ``vgg16``
+
+    Returns
+    -------
+    params : list
+        List of PyTorch tensors that represent the weights of a pretrained
+        neural network
+    """
+    fn = getattr(models, model)
+    net = fn(pretrained=True)
+    return list(net.parameters())

--- a/tensorly/contrib/tests/test_torch.py
+++ b/tensorly/contrib/tests/test_torch.py
@@ -1,9 +1,18 @@
-from tensorly.contrib import pytorch_model
 import torch
+import pytest
+from ... import contrib
+from ... import set_backend, get_backend
+
+
+def test_pytorch_model_raises():
+    assert get_backend() == 'numpy'
+    with pytest.raises(ValueError, match="set_backend"):
+        contrib.pytorch_model(model='resnet18')
 
 
 def test_pytorch_model():
-    params = pytorch_model(model='resnet18')
+    set_backend('pytorch')
+    params = contrib.pytorch_model(model='resnet18')
     shapes = [p.shape for p in params]
     set(shapes) == {torch.Size([64, 3, 7, 7]),
                     torch.Size([64]),

--- a/tensorly/contrib/tests/test_torch.py
+++ b/tensorly/contrib/tests/test_torch.py
@@ -1,0 +1,25 @@
+from tensorly.contrib import pytorch_model
+import torch
+
+
+def test_pytorch_model():
+    params = pytorch_model(model='resnet18')
+    shapes = [p.shape for p in params]
+    assert all(shape in [torch.Size([64, 3, 7, 7]),
+                         torch.Size([64]),
+                         torch.Size([64, 64, 3, 3]),
+                         torch.Size([128, 64, 3, 3]),
+                         torch.Size([128, 64, 1, 1]),
+                         torch.Size([128, 128, 3, 3]),
+                         torch.Size([256, 128, 3, 3]),
+                         torch.Size([256]),
+                         torch.Size([128]),
+                         torch.Size([256, 256, 3, 3]),
+                         torch.Size([256, 128, 1, 1]),
+                         torch.Size([512]),
+                         torch.Size([1000, 512]),
+                         torch.Size([1000]),
+                         torch.Size([512, 256, 3, 3]),
+                         torch.Size([512, 512, 3, 3]),
+                         torch.Size([512, 256, 1, 1])]
+               for shape in shapes)

--- a/tensorly/contrib/tests/test_torch.py
+++ b/tensorly/contrib/tests/test_torch.py
@@ -12,22 +12,5 @@ def test_pytorch_model_raises():
 
 def test_pytorch_model():
     set_backend('pytorch')
-    params = contrib.pytorch_model(model='resnet18')
-    shapes = [p.shape for p in params]
-    set(shapes) == {torch.Size([64, 3, 7, 7]),
-                    torch.Size([64]),
-                    torch.Size([64, 64, 3, 3]),
-                    torch.Size([128, 64, 3, 3]),
-                    torch.Size([128, 64, 1, 1]),
-                    torch.Size([128, 128, 3, 3]),
-                    torch.Size([256, 128, 3, 3]),
-                    torch.Size([256]),
-                    torch.Size([128]),
-                    torch.Size([256, 256, 3, 3]),
-                    torch.Size([256, 128, 1, 1]),
-                    torch.Size([512]),
-                    torch.Size([1000, 512]),
-                    torch.Size([1000]),
-                    torch.Size([512, 256, 3, 3]),
-                    torch.Size([512, 512, 3, 3]),
-                    torch.Size([512, 256, 1, 1])}
+    with pytest.raises(AttributeError, match="no attribute 'junk'"):
+        contrib.pytorch_model(model='junk')

--- a/tensorly/contrib/tests/test_torch.py
+++ b/tensorly/contrib/tests/test_torch.py
@@ -1,16 +1,14 @@
-import torch
 import pytest
+import tensorly as tl
 from ... import contrib
 from ... import set_backend, get_backend
 
 
-def test_pytorch_model_raises():
-    assert get_backend() == 'numpy'
-    with pytest.raises(ValueError, match="set_backend"):
-        contrib.pytorch_model(model='resnet18')
-
-
 def test_pytorch_model():
-    set_backend('pytorch')
-    with pytest.raises(AttributeError, match="no attribute 'junk'"):
-        contrib.pytorch_model(model='junk')
+    if tl._BACKEND == 'pytorch':
+        import torch
+        with pytest.raises(AttributeError, match="no attribute 'junk'"):
+            contrib.pytorch_model(model='junk')
+    else:
+        with pytest.raises(ValueError, match="set_backend"):
+            contrib.pytorch_model(model='resnet18')

--- a/tensorly/contrib/tests/test_torch.py
+++ b/tensorly/contrib/tests/test_torch.py
@@ -5,21 +5,20 @@ import torch
 def test_pytorch_model():
     params = pytorch_model(model='resnet18')
     shapes = [p.shape for p in params]
-    assert all(shape in [torch.Size([64, 3, 7, 7]),
-                         torch.Size([64]),
-                         torch.Size([64, 64, 3, 3]),
-                         torch.Size([128, 64, 3, 3]),
-                         torch.Size([128, 64, 1, 1]),
-                         torch.Size([128, 128, 3, 3]),
-                         torch.Size([256, 128, 3, 3]),
-                         torch.Size([256]),
-                         torch.Size([128]),
-                         torch.Size([256, 256, 3, 3]),
-                         torch.Size([256, 128, 1, 1]),
-                         torch.Size([512]),
-                         torch.Size([1000, 512]),
-                         torch.Size([1000]),
-                         torch.Size([512, 256, 3, 3]),
-                         torch.Size([512, 512, 3, 3]),
-                         torch.Size([512, 256, 1, 1])]
-               for shape in shapes)
+    set(shapes) == {torch.Size([64, 3, 7, 7]),
+                    torch.Size([64]),
+                    torch.Size([64, 64, 3, 3]),
+                    torch.Size([128, 64, 3, 3]),
+                    torch.Size([128, 64, 1, 1]),
+                    torch.Size([128, 128, 3, 3]),
+                    torch.Size([256, 128, 3, 3]),
+                    torch.Size([256]),
+                    torch.Size([128]),
+                    torch.Size([256, 256, 3, 3]),
+                    torch.Size([256, 128, 1, 1]),
+                    torch.Size([512]),
+                    torch.Size([1000, 512]),
+                    torch.Size([1000]),
+                    torch.Size([512, 256, 3, 3]),
+                    torch.Size([512, 512, 3, 3]),
+                    torch.Size([512, 256, 1, 1])}


### PR DESCRIPTION
Gets a pretrained model from https://pytorch.org/docs/stable/torchvision/models.html. This function returns a list of PyTorch tensors representing the different learned weights of the neural network. These tensors are of different sizes and different orders.

The test for this function downloads 46MB, the smallest file I could find after a brief search. Subsequent tests after the data has been downloaded are very fast, 0.7 seconds on my machine.