### PR TITLE
Make parafac() work with complex-valued tensors

### DIFF
--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -123,7 +123,7 @@ def norm(tensor, order=2, axis=None):
     if order == 1:
         return np.sum(np.abs(tensor), axis=axis)
     elif order == 2:
-        return np.sqrt(np.sum(tensor**2, axis=axis))
+        return np.sqrt(np.sum(np.abs(tensor)**2, axis=axis))
     else:
         return np.sum(np.abs(tensor)**order, axis=axis)**(1/order)
 

--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -175,9 +175,9 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd', tol=1e-8,
             pseudo_inverse = tl.tensor(np.ones((rank, rank)), **tl.context(tensor))
             for i, factor in enumerate(factors):
                 if i != mode:
-                    pseudo_inverse = pseudo_inverse*tl.dot(tl.transpose(factor), factor)
-            factor = tl.dot(unfold(tensor, mode), khatri_rao(factors, skip_matrix=mode))
-            factor = tl.transpose(tl.solve(tl.transpose(pseudo_inverse), tl.transpose(factor)))
+                    pseudo_inverse = pseudo_inverse*tl.dot(tl.transpose(factor).conj(), factor)
+            factor = tl.dot(unfold(tensor, mode), khatri_rao(factors, skip_matrix=mode).conj())
+            factor = tl.transpose(tl.solve(tl.transpose(pseudo_inverse).conj(), tl.transpose(factor)))
             factors[mode] = factor
 
         if tol:


### PR DESCRIPTION
The current implementation of PARAFAC currently does not work properly with complex-valued tensors (it converges to a solution that has high reconstruction error). This fix enables a reliable convergence to a solution with low reconstruction error.