### PR TITLE
Add: quantized parafac

### DIFF
--- a/examples/quantized_decomposition.ipynb
+++ b/examples/quantized_decomposition.ipynb
@@ -51,7 +51,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_tensor|| = 768.3590087890625\n"
+      "||float_tensor|| = 768.3004150390625\n"
      ]
     }
    ],
@@ -80,14 +80,14 @@
      "text": [
       "\n",
       "Per channel quantization, dtype: torch.qint8, qscheme: torch.per_channel_affine\n",
-      "Per dim 0, ||float_tensor - quant_tensor|| = 7.26156759262085\n",
-      "Per dim 1, ||float_tensor - quant_tensor|| = 7.2505903244018555\n",
-      "Per dim 2, ||float_tensor - quant_tensor|| = 7.455237865447998\n",
+      "Per dim 0, ||float_tensor - quant_tensor|| = 7.091872692108154\n",
+      "Per dim 1, ||float_tensor - quant_tensor|| = 7.260591983795166\n",
+      "Per dim 2, ||float_tensor - quant_tensor|| = 7.5831427574157715\n",
       "\n",
       "Per channel quantization, dtype: torch.qint8, qscheme: torch.per_channel_symmetric\n",
-      "Per dim 0, ||float_tensor - quant_tensor|| = 7.26156759262085\n",
-      "Per dim 1, ||float_tensor - quant_tensor|| = 7.2505903244018555\n",
-      "Per dim 2, ||float_tensor - quant_tensor|| = 7.455237865447998\n"
+      "Per dim 0, ||float_tensor - quant_tensor|| = 7.091872692108154\n",
+      "Per dim 1, ||float_tensor - quant_tensor|| = 7.260591983795166\n",
+      "Per dim 2, ||float_tensor - quant_tensor|| = 7.5831427574157715\n"
      ]
     }
    ],
@@ -123,10 +123,10 @@
      "text": [
       "\n",
       "Per tensor quantization, dtype: torch.qint8, qscheme: torch.per_tensor_affine\n",
-      "Per tensor, ||float_tensor - quant_tensor|| = 7.919113636016846\n",
+      "Per tensor, ||float_tensor - quant_tensor|| = 8.514548301696777\n",
       "\n",
       "Per tensor quantization, dtype: torch.qint8, qscheme: torch.per_tensor_symmetric\n",
-      "Per tensor, ||float_tensor - quant_tensor|| = 7.919113636016846\n"
+      "Per tensor, ||float_tensor - quant_tensor|| = 8.514548301696777\n"
      ]
     }
    ],
@@ -175,7 +175,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors||: 813.7848510742188\n"
+      "||float_factors||: 710.7957763671875\n"
      ]
     }
    ],
@@ -234,7 +234,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors - float_factors_quantized|| = 12.25833511352539\n"
+      "||float_factors - float_factors_quantized|| = 9.844650268554688\n"
      ]
     }
    ],
@@ -261,13 +261,13 @@
      "text": [
       "\n",
       "[1/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 9.449654579162598\n",
+      "||quant_factors - float_factors|| = 5.352328777313232\n",
       "\n",
       "[2/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 15.845589637756348\n",
+      "||quant_factors - float_factors|| = 7.942391872406006\n",
       "\n",
       "[3/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 32.24354553222656\n"
+      "||quant_factors - float_factors|| = 18.10138702392578\n"
      ]
     }
    ],
@@ -323,7 +323,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors||: 913.5255737304688\n"
+      "||float_factors||: 896.6329956054688\n"
      ]
     }
    ],
@@ -353,48 +353,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In parafac original_tensor_norm = 913.5255737304688\n",
-      "parafac has stopped after iteration 32\n"
+      "tensor(0.0007)\n",
+      "tensor(0.0628)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for stop_criterion in ['rec_error_decrease', 'rec_error_deviation']:\n",
+    "    out = parafac(t, rank, n_iter_max=100, init='svd', svd='numpy_svd',\\\n",
+    "                normalize_factors=False, orthogonalise=False,\\\n",
+    "                tol=1e-8, random_state=None,\\\n",
+    "                verbose=0, return_errors=False,\\\n",
+    "                non_negative=False, mask=None,\n",
+    "                stop_criterion = stop_criterion)\n",
+    "    print(tl.norm(t - kruskal_to_tensor(out)))  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor(0.0002)\n",
+      "tensor(226.9214)\n"
      ]
     }
    ],
    "source": [
     "normalize_factors = False\n",
-    "(factors_als, weights_als), _ =  quantized_parafac(t, rank, n_iter_max=50000,\\\n",
-    "                                    init='random', tol=1e-8, svd = None,\n",
-    "                                    normalize_factors = normalize_factors)"
+    "for stop_criterion in ['rec_error_decrease', 'rec_error_deviation']:\n",
+    "    (factors_als, weights_als), _ =  quantized_parafac(t, rank,\n",
+    "                                                       n_iter_max=50000,\\\n",
+    "                                                       init='random',\\\n",
+    "                                                       tol=1e-8,\\\n",
+    "                                                       svd = None,\\\n",
+    "                                                       normalize_factors = normalize_factors,\\\n",
+    "                                                       stop_criterion = stop_criterion\n",
+    "                                                      )\n",
+    "    print(tl.norm(t - kruskal_to_tensor(KruskalTensor((weights_als, factors_als)))))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor(0.0003)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tl.norm(t - kruskal_to_tensor(KruskalTensor((weights_als, factors_als))))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -403,7 +415,7 @@
        "tensor([1., 1., 1., 1., 1., 1., 1., 1.])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/quantized_decomposition.ipynb
+++ b/examples/quantized_decomposition.ipynb
@@ -1,0 +1,640 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import tensorly as tl\n",
+    "from tensorly.decomposition import parafac, quantized_parafac\n",
+    "from tensorly.kruskal_tensor import kruskal_to_tensor, KruskalTensor\n",
+    "from tensorly.base import unfold\n",
+    "from tensorly.quantization import quantize_qint\n",
+    "\n",
+    "import torch\n",
+    "tl.set_backend('pytorch')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 1. Tensor quantization\n",
+    "Quantization scheme can be either affine or symmetric.\n",
+    "\n",
+    "Scale and zero_point values to perform quantization are computed either per channel or per tensor (i.e. we get either vectors or scalars).\n",
+    "\n",
+    "Thus, there are 4 types of quantization scheme:\n",
+    "\n",
+    "    ``torch.per_tensor_affine``\n",
+    "    ``torch.per_tensor_symmetric``\n",
+    "    ``torch.per_channel_affine``\n",
+    "    ``torch.per_channel_symmetric``"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Generate a random tensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "||float_tensor|| = 767.585693359375\n"
+     ]
+    }
+   ],
+   "source": [
+    "t = torch.randn(256, 256, 9)\n",
+    "print('||float_tensor|| = {}'.format(tl.norm(t)))\n",
+    "\n",
+    "dtype = torch.qint8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Per channel  quantization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Per channel quantization, dtype: torch.qint8, qscheme: torch.per_channel_affine\n",
+      "Per dim 0, ||float_tensor - quant_tensor|| = 7.277091026306152\n",
+      "Per dim 1, ||float_tensor - quant_tensor|| = 7.280121803283691\n",
+      "Per dim 2, ||float_tensor - quant_tensor|| = 7.608396053314209\n",
+      "\n",
+      "Per channel quantization, dtype: torch.qint8, qscheme: torch.per_channel_symmetric\n",
+      "Per dim 0, ||float_tensor - quant_tensor|| = 7.277091026306152\n",
+      "Per dim 1, ||float_tensor - quant_tensor|| = 7.280121803283691\n",
+      "Per dim 2, ||float_tensor - quant_tensor|| = 7.608396053314209\n"
+     ]
+    }
+   ],
+   "source": [
+    "for qscheme in [torch.per_channel_affine, torch.per_channel_symmetric]:\n",
+    "    print(\"\\nPer channel quantization, dtype: {}, qscheme: {}\".format(dtype, qscheme))\n",
+    "    \n",
+    "    for dim in range(len(t.shape)):\n",
+    "        qt, scale, zero_point = quantize_qint(t,\\\n",
+    "                                              dtype,\\\n",
+    "                                              qscheme,\\\n",
+    "                                              dim = dim,\\\n",
+    "                                              return_scale_zeropoint=True)\n",
+    "\n",
+    "        print('Per dim {}, ||float_tensor - quant_tensor|| = {}'.format(dim, tl.norm(t - qt)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Per tensor quantization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Per tensor quantization, dtype: torch.qint8, qscheme: torch.per_tensor_affine\n",
+      "Per tensor, ||float_tensor - quant_tensor|| = 8.38266372680664\n",
+      "\n",
+      "Per tensor quantization, dtype: torch.qint8, qscheme: torch.per_tensor_symmetric\n",
+      "Per tensor, ||float_tensor - quant_tensor|| = 8.38266372680664\n"
+     ]
+    }
+   ],
+   "source": [
+    "for qscheme in [torch.per_tensor_affine, torch.per_tensor_symmetric]:\n",
+    "    print(\"\\nPer tensor quantization, dtype: {}, qscheme: {}\".format(dtype, qscheme))\n",
+    "\n",
+    "    \n",
+    "    qt, scale, zero_point = quantize_qint(t,\\\n",
+    "                                          dtype,\\\n",
+    "                                          qscheme,\\\n",
+    "                                          dim = dim,\\\n",
+    "                                          return_scale_zeropoint=True)\n",
+    "    print('Per tensor, ||float_tensor - quant_tensor|| = {}'.format(tl.norm(t - qt)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 2. Quantization of a tensor in Kruskal format:\n",
+    "    a) via quantization of the corresponding full tensor\n",
+    "    b) via quantization of decomposition factors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Generate tensor "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "||float_factors||: 737.1425170898438\n"
+     ]
+    }
+   ],
+   "source": [
+    "rank = 16\n",
+    "shape = (64, 64, 9)\n",
+    "\n",
+    "factors = [torch.randn((i, rank)) for i in shape] \n",
+    "weights = torch.ones(rank)\n",
+    "\n",
+    "# tensor in Kruscal format\n",
+    "krt = KruskalTensor((weights, factors))\n",
+    "\n",
+    "# corresponding tensor in full format\n",
+    "t = kruskal_to_tensor(krt)\n",
+    "\n",
+    "tnorm = tl.norm(t)\n",
+    "print('||float_factors||: {}'.format(tnorm))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Choose quantization scheme"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dtype = torch.qint8\n",
+    "\n",
+    "## Per tensor quantization\n",
+    "qscheme, dim = torch.per_tensor_affine, None\n",
+    "\n",
+    "## Uncomment for per channel quantization\n",
+    "# qscheme, dim = torch.per_channel_affine, 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### a) Quantize the full tensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "||float_factors - float_factors_quantized|| = 10.051530838012695\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_quant = quantize_qint(t, dtype, qscheme, dim = dim)\n",
+    "print('||float_factors - float_factors_quantized|| = {}'.format(tl.norm(t - t_quant)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### b) Quantize several factors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[1/3] factors are quantized\n",
+      "||quant_factors - float_factors|| = 9.89563274383545\n",
+      "\n",
+      "[2/3] factors are quantized\n",
+      "||quant_factors - float_factors|| = 13.896100044250488\n",
+      "\n",
+      "[3/3] factors are quantized\n",
+      "||quant_factors - float_factors|| = 17.108083724975586\n"
+     ]
+    }
+   ],
+   "source": [
+    "num_factors = len(factors)\n",
+    "for num_quant_factors in range(1, num_factors + 1):\n",
+    "    \n",
+    "    qfactors = [quantize_qint(factors[i], dtype, qscheme, dim = dim)\\\n",
+    "                for i in range(num_quant_factors)\\\n",
+    "               ] + [factors[i] for i in range(num_quant_factors, num_factors)]\n",
+    "\n",
+    "    qkrt = KruskalTensor((weights, qfactors))\n",
+    "    qt = kruskal_to_tensor(qkrt)\n",
+    "    print('\\n[{}/{}] factors are quantized'.format(num_quant_factors, num_factors))\n",
+    "    print('||quant_factors - float_factors|| = {}'.format(tl.norm(qt - t)))\n",
+    "#     print('||quant_factors - float_factors_quantized|| = {}'.format(tl.norm(qt - t_quant)))\n",
+    "\n",
+    "#     qt_quant = quantize_qint(qt, dtype, qscheme, dim = dim)\n",
+    "#     print('\\nquant_factors_quantized - t_quant_factors: {}'.format(tl.norm(qt_quant - qt)/tnorm))\n",
+    "    \n",
+    "#     print('||quant_factors_quantized - float_factors|| = {}'.format(tl.norm(qt_quant - t)/tnorm))\n",
+    "#     print('||quant_factors_quantized - float_factors_quantized|| = {}'.format(tl.norm(qt_quant - t_quant)/tnorm))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 3. Quantized ALS\n",
+    "Compare standard ALS algorithm for finding  CP decomposition with its quantized version, when at the end of each ALS step approximated factor is quantized."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Generate tensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "||float_factors||: 992.4262084960938\n"
+     ]
+    }
+   ],
+   "source": [
+    "rank = 8\n",
+    "shape = (128, 128, 9)\n",
+    "\n",
+    "factors = [torch.randn((i, rank)) for i in shape] \n",
+    "weights = torch.ones(rank)\n",
+    "\n",
+    "# tensor in Kruscal format\n",
+    "krt = KruskalTensor((weights, factors))\n",
+    "\n",
+    "# corresponding tensor in full format\n",
+    "t = kruskal_to_tensor(krt)\n",
+    "\n",
+    "tnorm = tl.norm(t)\n",
+    "print('||float_factors||: {}'.format(tnorm))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Find an approximation using ALS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "In parafac original_tensor_norm = 992.4262084960938\n",
+      "parafac has stopped after iteration 63\n"
+     ]
+    }
+   ],
+   "source": [
+    "normalize_factors = True\n",
+    "(factors_als, weights_als), _ =  quantized_parafac(t, rank, n_iter_max=50000,\\\n",
+    "                                    init='random', tol=1e-8, svd = None,\n",
+    "                                    normalize_factors = normalize_factors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(0.0004)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tl.norm(t - kruskal_to_tensor(KruskalTensor((weights_als, factors_als))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([391.0013, 355.6662, 269.9358, 423.7779, 310.8251, 315.8976, 267.2900,\n",
+       "        430.1736])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "weights_als"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Find an approximation using quantized ALS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dtype = torch.qint8\n",
+    "\n",
+    "## Per tensor quantization\n",
+    "qscheme, dim = torch.per_tensor_affine, None\n",
+    "\n",
+    "## Uncomment for per channel quantization\n",
+    "# qscheme, dim = torch.per_channel_affine, 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "In parafac original_tensor_norm = 992.4262084960938\n",
+      "iteration 500, diff_from_norm = 17.587434768676758, rel_rec_error = 0.017721654887901908\n",
+      "iteration 1000, diff_from_norm = 17.587434768676758, rel_rec_error = 0.017721654887901908\n"
+     ]
+    }
+   ],
+   "source": [
+    "normalize_factors = True\n",
+    "(factors_qals, weights_qals), _, scales, zero_points = quantized_parafac(\n",
+    "                                    t, rank, n_iter_max=1001,\\\n",
+    "                                    init='random', tol= None, svd = None,\\\n",
+    "                                    normalize_factors = normalize_factors,\\\n",
+    "                                    qmodes = [0, 1],\n",
+    "                                    quantize_every = 2,\n",
+    "                                    qscheme = qscheme, dtype = dtype, dim = dim,\n",
+    "                                    return_scale_zeropoint=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(17.5874)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tl.norm(t - kruskal_to_tensor(KruskalTensor((weights_qals, factors_qals))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([312.2208, 430.0728, 315.8293, 359.4211, 267.2516, 391.3284, 423.4779,\n",
+       "        271.4605])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "weights_qals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((tensor(0.0021), tensor(0.0021), None),\n",
+       " (tensor(0, dtype=torch.int32), tensor(0, dtype=torch.int32), None))"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scales, zero_points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[-0.1367,  0.1035,  0.0601,  ...,  0.0352, -0.0518,  0.0911],\n",
+       "        [ 0.0911,  0.1139,  0.0083,  ..., -0.0393, -0.2340, -0.1470],\n",
+       "        [ 0.0166, -0.1346, -0.1077,  ..., -0.0476,  0.0145, -0.0041],\n",
+       "        ...,\n",
+       "        [-0.1035,  0.0021, -0.0456,  ...,  0.1346, -0.1160,  0.0704],\n",
+       "        [ 0.0725,  0.0414,  0.0393,  ...,  0.0766,  0.0311, -0.0683],\n",
+       "        [ 0.0456, -0.0663,  0.0725,  ...,  0.1077, -0.0228,  0.0704]])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "factors_qals[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[ -66.,   50.,   29.,  ...,   17.,  -25.,   44.],\n",
+       "        [  44.,   55.,    4.,  ...,  -19., -113.,  -71.],\n",
+       "        [   8.,  -65.,  -52.,  ...,  -23.,    7.,   -2.],\n",
+       "        ...,\n",
+       "        [ -50.,    1.,  -22.,  ...,   65.,  -56.,   34.],\n",
+       "        [  35.,   20.,   19.,  ...,   37.,   15.,  -33.],\n",
+       "        [  22.,  -32.,   35.,  ...,   52.,  -11.,   34.]])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "factors_qals[0]/scales[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[ -43.0000,  -20.0000,  -18.0000,  ...,  -94.0000,   -2.0000,\n",
+       "            1.0000],\n",
+       "        [  94.0000,   19.0000,   -1.0000,  ...,   23.0000,   74.0000,\n",
+       "          -34.0000],\n",
+       "        [  -3.0000,    8.0000,  -23.0000,  ...,  -36.0000, -107.0000,\n",
+       "           37.0000],\n",
+       "        ...,\n",
+       "        [  59.0000,   38.0000,   10.0000,  ...,   14.0000,   -1.0000,\n",
+       "          -54.0000],\n",
+       "        [  -5.0000,   21.0000,   84.0000,  ...,   38.0000,  -10.0000,\n",
+       "           71.0000],\n",
+       "        [ -11.0000,  -23.0000,  108.0000,  ...,   -8.0000,  -16.0000,\n",
+       "           60.0000]])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "factors_qals[1]/scales[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/quantized_decomposition.ipynb
+++ b/examples/quantized_decomposition.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "scrolled": true
    },
@@ -44,14 +44,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_tensor|| = 767.585693359375\n"
+      "||float_tensor|| = 767.418212890625\n"
      ]
     }
    ],
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -80,14 +80,14 @@
      "text": [
       "\n",
       "Per channel quantization, dtype: torch.qint8, qscheme: torch.per_channel_affine\n",
-      "Per dim 0, ||float_tensor - quant_tensor|| = 7.277091026306152\n",
-      "Per dim 1, ||float_tensor - quant_tensor|| = 7.280121803283691\n",
-      "Per dim 2, ||float_tensor - quant_tensor|| = 7.608396053314209\n",
+      "Per dim 0, ||float_tensor - quant_tensor|| = 7.239077568054199\n",
+      "Per dim 1, ||float_tensor - quant_tensor|| = 7.207361698150635\n",
+      "Per dim 2, ||float_tensor - quant_tensor|| = 7.412856578826904\n",
       "\n",
       "Per channel quantization, dtype: torch.qint8, qscheme: torch.per_channel_symmetric\n",
-      "Per dim 0, ||float_tensor - quant_tensor|| = 7.277091026306152\n",
-      "Per dim 1, ||float_tensor - quant_tensor|| = 7.280121803283691\n",
-      "Per dim 2, ||float_tensor - quant_tensor|| = 7.608396053314209\n"
+      "Per dim 0, ||float_tensor - quant_tensor|| = 7.239077568054199\n",
+      "Per dim 1, ||float_tensor - quant_tensor|| = 7.207361698150635\n",
+      "Per dim 2, ||float_tensor - quant_tensor|| = 7.412856578826904\n"
      ]
     }
    ],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -123,10 +123,10 @@
      "text": [
       "\n",
       "Per tensor quantization, dtype: torch.qint8, qscheme: torch.per_tensor_affine\n",
-      "Per tensor, ||float_tensor - quant_tensor|| = 8.38266372680664\n",
+      "Per tensor, ||float_tensor - quant_tensor|| = 8.125895500183105\n",
       "\n",
       "Per tensor quantization, dtype: torch.qint8, qscheme: torch.per_tensor_symmetric\n",
-      "Per tensor, ||float_tensor - quant_tensor|| = 8.38266372680664\n"
+      "Per tensor, ||float_tensor - quant_tensor|| = 8.125895500183105\n"
      ]
     }
    ],
@@ -168,14 +168,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors||: 737.1425170898438\n"
+      "||float_factors||: 711.4100341796875\n"
      ]
     }
    ],
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,14 +227,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors - float_factors_quantized|| = 10.051530838012695\n"
+      "||float_factors - float_factors_quantized|| = 10.898009300231934\n"
      ]
     }
    ],
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -261,13 +261,13 @@
      "text": [
       "\n",
       "[1/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 9.89563274383545\n",
+      "||quant_factors - float_factors|| = 8.447911262512207\n",
       "\n",
       "[2/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 13.896100044250488\n",
+      "||quant_factors - float_factors|| = 14.076884269714355\n",
       "\n",
       "[3/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 17.108083724975586\n"
+      "||quant_factors - float_factors|| = 35.730384826660156\n"
      ]
     }
    ],
@@ -316,14 +316,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors||: 992.4262084960938\n"
+      "||float_factors||: 1053.6529541015625\n"
      ]
     }
    ],
@@ -353,20 +353,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In parafac original_tensor_norm = 992.4262084960938\n",
-      "parafac has stopped after iteration 63\n"
+      "In parafac original_tensor_norm = 1053.6529541015625\n",
+      "parafac has stopped after iteration 59\n"
      ]
     }
    ],
    "source": [
-    "normalize_factors = True\n",
+    "normalize_factors = False\n",
     "(factors_als, weights_als), _ =  quantized_parafac(t, rank, n_iter_max=50000,\\\n",
     "                                    init='random', tol=1e-8, svd = None,\n",
     "                                    normalize_factors = normalize_factors)"
@@ -374,16 +374,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor(0.0004)"
+       "tensor(0.0003)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -394,17 +394,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([391.0013, 355.6662, 269.9358, 423.7779, 310.8251, 315.8976, 267.2900,\n",
-       "        430.1736])"
+       "tensor([1., 1., 1., 1., 1., 1., 1., 1.])"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -422,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,43 +436,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In parafac original_tensor_norm = 992.4262084960938\n",
-      "iteration 500, diff_from_norm = 17.587434768676758, rel_rec_error = 0.017721654887901908\n",
-      "iteration 1000, diff_from_norm = 17.587434768676758, rel_rec_error = 0.017721654887901908\n"
+      "In parafac original_tensor_norm = 1053.6529541015625\n",
+      "iteration 500, diff_from_norm = 14.47594928741455, rel_rec_error = 0.013738820957188909\n",
+      "iteration 1000, diff_from_norm = 14.475943565368652, rel_rec_error = 0.013738815526514724\n"
      ]
     }
    ],
    "source": [
-    "normalize_factors = True\n",
+    "normalize_factors = False\n",
     "(factors_qals, weights_qals), _, scales, zero_points = quantized_parafac(\n",
     "                                    t, rank, n_iter_max=1001,\\\n",
-    "                                    init='random', tol= None, svd = None,\\\n",
+    "                                    init='random', tol= False, svd = None,\\\n",
     "                                    normalize_factors = normalize_factors,\\\n",
-    "                                    qmodes = [0, 1],\n",
-    "                                    quantize_every = 2,\n",
+    "                                    qmodes = [0, 1, 2],\n",
+    "                                    warmup_iters = 60,\n",
+    "                                    quantize_every = 1,\n",
     "                                    qscheme = qscheme, dtype = dtype, dim = dim,\n",
     "                                    return_scale_zeropoint=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor(17.5874)"
+       "tensor(14.4759)"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -484,17 +484,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([312.2208, 430.0728, 315.8293, 359.4211, 267.2516, 391.3284, 423.4779,\n",
-       "        271.4605])"
+       "tensor([1., 1., 1., 1., 1., 1., 1., 1.])"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -505,17 +504,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "((tensor(0.0021), tensor(0.0021), None),\n",
-       " (tensor(0, dtype=torch.int32), tensor(0, dtype=torch.int32), None))"
+       "((tensor(0.0665), tensor(0.0308), tensor(0.0085)),\n",
+       " (tensor(0, dtype=torch.int32),\n",
+       "  tensor(0, dtype=torch.int32),\n",
+       "  tensor(0, dtype=torch.int32)))"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,22 +527,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[-0.1367,  0.1035,  0.0601,  ...,  0.0352, -0.0518,  0.0911],\n",
-       "        [ 0.0911,  0.1139,  0.0083,  ..., -0.0393, -0.2340, -0.1470],\n",
-       "        [ 0.0166, -0.1346, -0.1077,  ..., -0.0476,  0.0145, -0.0041],\n",
+       "tensor([[-1.1302,  1.6621, -4.0555,  ..., -1.7286, -0.8643, -1.9280],\n",
+       "        [ 3.3907, -0.9973,  1.7951,  ..., -3.1912,  3.5901, -2.5928],\n",
+       "        [-2.4599, -0.9308, -0.1330,  ..., -0.5983, -1.0637, -0.1995],\n",
        "        ...,\n",
-       "        [-0.1035,  0.0021, -0.0456,  ...,  0.1346, -0.1160,  0.0704],\n",
-       "        [ 0.0725,  0.0414,  0.0393,  ...,  0.0766,  0.0311, -0.0683],\n",
-       "        [ 0.0456, -0.0663,  0.0725,  ...,  0.1077, -0.0228,  0.0704]])"
+       "        [ 2.1939, -1.0637,  2.7923,  ..., -1.4626,  0.0665, -5.3187],\n",
+       "        [ 1.1967, -0.3989, -3.5901,  ..., -2.5264, -1.1302,  1.7951],\n",
+       "        [ 1.0637,  0.3324, -3.3242,  ...,  1.3297,  2.9253,  1.3297]])"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -552,22 +553,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[ -66.,   50.,   29.,  ...,   17.,  -25.,   44.],\n",
-       "        [  44.,   55.,    4.,  ...,  -19., -113.,  -71.],\n",
-       "        [   8.,  -65.,  -52.,  ...,  -23.,    7.,   -2.],\n",
+       "tensor([[-17.,  25., -61.,  ..., -26., -13., -29.],\n",
+       "        [ 51., -15.,  27.,  ..., -48.,  54., -39.],\n",
+       "        [-37., -14.,  -2.,  ...,  -9., -16.,  -3.],\n",
        "        ...,\n",
-       "        [ -50.,    1.,  -22.,  ...,   65.,  -56.,   34.],\n",
-       "        [  35.,   20.,   19.,  ...,   37.,   15.,  -33.],\n",
-       "        [  22.,  -32.,   35.,  ...,   52.,  -11.,   34.]])"
+       "        [ 33., -16.,  42.,  ..., -22.,   1., -80.],\n",
+       "        [ 18.,  -6., -54.,  ..., -38., -17.,  27.],\n",
+       "        [ 16.,   5., -50.,  ...,  20.,  44.,  20.]])"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -578,34 +579,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[ -43.0000,  -20.0000,  -18.0000,  ...,  -94.0000,   -2.0000,\n",
-       "            1.0000],\n",
-       "        [  94.0000,   19.0000,   -1.0000,  ...,   23.0000,   74.0000,\n",
-       "          -34.0000],\n",
-       "        [  -3.0000,    8.0000,  -23.0000,  ...,  -36.0000, -107.0000,\n",
-       "           37.0000],\n",
+       "tensor([[ 90.,   2.,   0.,  ...,  50.,  54.,   7.],\n",
+       "        [  7.,  16.,  13.,  ...,   5., -32.,  41.],\n",
+       "        [  3.,  13., -23.,  ...,  17.,  -6., -10.],\n",
        "        ...,\n",
-       "        [  59.0000,   38.0000,   10.0000,  ...,   14.0000,   -1.0000,\n",
-       "          -54.0000],\n",
-       "        [  -5.0000,   21.0000,   84.0000,  ...,   38.0000,  -10.0000,\n",
-       "           71.0000],\n",
-       "        [ -11.0000,  -23.0000,  108.0000,  ...,   -8.0000,  -16.0000,\n",
-       "           60.0000]])"
+       "        [ 90.,   2.,  -8.,  ...,  23.,  10., -28.],\n",
+       "        [-65., -41.,  13.,  ...,  44.,  31.,  -6.],\n",
+       "        [-31.,  17.,  -5.,  ...,  48., -26.,   3.]])"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "factors_qals[1]/scales[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Try to quantize 2 of 3 factors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "In parafac original_tensor_norm = 1053.6529541015625\n",
+      "iteration 500, diff_from_norm = 16.254718780517578, rel_rec_error = 0.015427013911214994\n",
+      "iteration 1000, diff_from_norm = 16.254718780517578, rel_rec_error = 0.015427013911214994\n"
+     ]
+    }
+   ],
+   "source": [
+    "normalize_factors = False\n",
+    "(factors_qals, weights_qals), _, scales, zero_points = quantized_parafac(\n",
+    "                                    t, rank, n_iter_max=1001,\\\n",
+    "                                    init='random', tol= False, svd = None,\\\n",
+    "                                    normalize_factors = normalize_factors,\\\n",
+    "                                    qmodes = [0, 1],\n",
+    "                                    warmup_iters = 60,\n",
+    "                                    quantize_every = 1,\n",
+    "                                    qscheme = qscheme, dtype = dtype, dim = dim,\n",
+    "                                    return_scale_zeropoint=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(16.2547)"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tl.norm(t - kruskal_to_tensor(KruskalTensor((weights_qals, factors_qals))))"
    ]
   },
   {

--- a/examples/quantized_decomposition.ipynb
+++ b/examples/quantized_decomposition.ipynb
@@ -51,7 +51,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_tensor|| = 767.418212890625\n"
+      "||float_tensor|| = 768.3590087890625\n"
      ]
     }
    ],
@@ -80,14 +80,14 @@
      "text": [
       "\n",
       "Per channel quantization, dtype: torch.qint8, qscheme: torch.per_channel_affine\n",
-      "Per dim 0, ||float_tensor - quant_tensor|| = 7.239077568054199\n",
-      "Per dim 1, ||float_tensor - quant_tensor|| = 7.207361698150635\n",
-      "Per dim 2, ||float_tensor - quant_tensor|| = 7.412856578826904\n",
+      "Per dim 0, ||float_tensor - quant_tensor|| = 7.26156759262085\n",
+      "Per dim 1, ||float_tensor - quant_tensor|| = 7.2505903244018555\n",
+      "Per dim 2, ||float_tensor - quant_tensor|| = 7.455237865447998\n",
       "\n",
       "Per channel quantization, dtype: torch.qint8, qscheme: torch.per_channel_symmetric\n",
-      "Per dim 0, ||float_tensor - quant_tensor|| = 7.239077568054199\n",
-      "Per dim 1, ||float_tensor - quant_tensor|| = 7.207361698150635\n",
-      "Per dim 2, ||float_tensor - quant_tensor|| = 7.412856578826904\n"
+      "Per dim 0, ||float_tensor - quant_tensor|| = 7.26156759262085\n",
+      "Per dim 1, ||float_tensor - quant_tensor|| = 7.2505903244018555\n",
+      "Per dim 2, ||float_tensor - quant_tensor|| = 7.455237865447998\n"
      ]
     }
    ],
@@ -123,10 +123,10 @@
      "text": [
       "\n",
       "Per tensor quantization, dtype: torch.qint8, qscheme: torch.per_tensor_affine\n",
-      "Per tensor, ||float_tensor - quant_tensor|| = 8.125895500183105\n",
+      "Per tensor, ||float_tensor - quant_tensor|| = 7.919113636016846\n",
       "\n",
       "Per tensor quantization, dtype: torch.qint8, qscheme: torch.per_tensor_symmetric\n",
-      "Per tensor, ||float_tensor - quant_tensor|| = 8.125895500183105\n"
+      "Per tensor, ||float_tensor - quant_tensor|| = 7.919113636016846\n"
      ]
     }
    ],
@@ -175,7 +175,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors||: 711.4100341796875\n"
+      "||float_factors||: 813.7848510742188\n"
      ]
     }
    ],
@@ -234,7 +234,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors - float_factors_quantized|| = 10.898009300231934\n"
+      "||float_factors - float_factors_quantized|| = 12.25833511352539\n"
      ]
     }
    ],
@@ -261,13 +261,13 @@
      "text": [
       "\n",
       "[1/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 8.447911262512207\n",
+      "||quant_factors - float_factors|| = 9.449654579162598\n",
       "\n",
       "[2/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 14.076884269714355\n",
+      "||quant_factors - float_factors|| = 15.845589637756348\n",
       "\n",
       "[3/3] factors are quantized\n",
-      "||quant_factors - float_factors|| = 35.730384826660156\n"
+      "||quant_factors - float_factors|| = 32.24354553222656\n"
      ]
     }
    ],
@@ -323,7 +323,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "||float_factors||: 1053.6529541015625\n"
+      "||float_factors||: 913.5255737304688\n"
      ]
     }
    ],
@@ -353,15 +353,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In parafac original_tensor_norm = 1053.6529541015625\n",
-      "parafac has stopped after iteration 59\n"
+      "In parafac original_tensor_norm = 913.5255737304688\n",
+      "parafac has stopped after iteration 32\n"
      ]
     }
    ],
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -383,7 +383,7 @@
        "tensor(0.0003)"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -394,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -403,7 +403,7 @@
        "tensor([1., 1., 1., 1., 1., 1., 1., 1.])"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -421,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,16 +436,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In parafac original_tensor_norm = 1053.6529541015625\n",
-      "iteration 500, diff_from_norm = 14.47594928741455, rel_rec_error = 0.013738820957188909\n",
-      "iteration 1000, diff_from_norm = 14.475943565368652, rel_rec_error = 0.013738815526514724\n"
+      "In parafac original_tensor_norm = 913.5255737304688\n",
+      "iteration 500, diff_from_norm = 12.325675964355469, rel_rec_error = 0.013492425739131085\n",
+      "iteration 1000, diff_from_norm = 12.325695037841797, rel_rec_error = 0.013492446618115623\n"
      ]
     }
    ],
@@ -456,7 +456,7 @@
     "                                    init='random', tol= False, svd = None,\\\n",
     "                                    normalize_factors = normalize_factors,\\\n",
     "                                    qmodes = [0, 1, 2],\n",
-    "                                    warmup_iters = 60,\n",
+    "                                    warmup_iters = 1,\n",
     "                                    quantize_every = 1,\n",
     "                                    qscheme = qscheme, dtype = dtype, dim = dim,\n",
     "                                    return_scale_zeropoint=True)"
@@ -464,16 +464,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor(14.4759)"
+       "tensor(12.3257)"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -484,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -493,7 +493,7 @@
        "tensor([1., 1., 1., 1., 1., 1., 1., 1.])"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,19 +504,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "((tensor(0.0665), tensor(0.0308), tensor(0.0085)),\n",
+       "((tensor(0.2144), tensor(0.1242), tensor(0.0004)),\n",
        " (tensor(0, dtype=torch.int32),\n",
        "  tensor(0, dtype=torch.int32),\n",
        "  tensor(0, dtype=torch.int32)))"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -527,22 +527,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[-1.1302,  1.6621, -4.0555,  ..., -1.7286, -0.8643, -1.9280],\n",
-       "        [ 3.3907, -0.9973,  1.7951,  ..., -3.1912,  3.5901, -2.5928],\n",
-       "        [-2.4599, -0.9308, -0.1330,  ..., -0.5983, -1.0637, -0.1995],\n",
+       "tensor([[-12.8624,  -3.6444,   8.5750,  ...,  -2.1437,   2.1437,  -2.5725],\n",
+       "        [ -4.0731,  -2.5725,  -2.7869,  ...,  -8.5750,   2.1437,  12.8624],\n",
+       "        [  0.4287,   0.2144,  11.3618,  ..., -15.8637,   8.3606,  -0.8575],\n",
        "        ...,\n",
-       "        [ 2.1939, -1.0637,  2.7923,  ..., -1.4626,  0.0665, -5.3187],\n",
-       "        [ 1.1967, -0.3989, -3.5901,  ..., -2.5264, -1.1302,  1.7951],\n",
-       "        [ 1.0637,  0.3324, -3.3242,  ...,  1.3297,  2.9253,  1.3297]])"
+       "        [ -1.2862,   0.0000,  -6.8600,  ...,  -3.8587,  -8.5750,   9.4325],\n",
+       "        [  8.3606,  -0.6431, -15.0062,  ...,  -6.8600,  -1.5006,  -1.0719],\n",
+       "        [ -3.6444,  -1.0719,   7.2887,  ..., -25.2961,   9.4325,  21.2230]])"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -553,22 +553,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[-17.,  25., -61.,  ..., -26., -13., -29.],\n",
-       "        [ 51., -15.,  27.,  ..., -48.,  54., -39.],\n",
-       "        [-37., -14.,  -2.,  ...,  -9., -16.,  -3.],\n",
+       "tensor([[ -60.0000,  -17.0000,   40.0000,  ...,  -10.0000,   10.0000,\n",
+       "          -12.0000],\n",
+       "        [ -19.0000,  -12.0000,  -13.0000,  ...,  -40.0000,   10.0000,\n",
+       "           60.0000],\n",
+       "        [   2.0000,    1.0000,   53.0000,  ...,  -74.0000,   39.0000,\n",
+       "           -4.0000],\n",
        "        ...,\n",
-       "        [ 33., -16.,  42.,  ..., -22.,   1., -80.],\n",
-       "        [ 18.,  -6., -54.,  ..., -38., -17.,  27.],\n",
-       "        [ 16.,   5., -50.,  ...,  20.,  44.,  20.]])"
+       "        [  -6.0000,    0.0000,  -32.0000,  ...,  -18.0000,  -40.0000,\n",
+       "           44.0000],\n",
+       "        [  39.0000,   -3.0000,  -70.0000,  ...,  -32.0000,   -7.0000,\n",
+       "           -5.0000],\n",
+       "        [ -17.0000,   -5.0000,   34.0000,  ..., -118.0000,   44.0000,\n",
+       "           99.0000]])"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -579,22 +585,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor([[ 90.,   2.,   0.,  ...,  50.,  54.,   7.],\n",
-       "        [  7.,  16.,  13.,  ...,   5., -32.,  41.],\n",
-       "        [  3.,  13., -23.,  ...,  17.,  -6., -10.],\n",
+       "tensor([[-18.0000,   2.0000, -21.0000,  ...,  12.0000, -38.0000,   9.0000],\n",
+       "        [ -6.0000, -15.0000,  -2.0000,  ...,  60.0000,  74.0000,   9.0000],\n",
+       "        [ 21.0000, -17.0000, 107.0000,  ..., -32.0000, 113.0000,  63.0000],\n",
        "        ...,\n",
-       "        [ 90.,   2.,  -8.,  ...,  23.,  10., -28.],\n",
-       "        [-65., -41.,  13.,  ...,  44.,  31.,  -6.],\n",
-       "        [-31.,  17.,  -5.,  ...,  48., -26.,   3.]])"
+       "        [ 40.0000,   0.0000, -16.0000,  ...,  14.0000,   9.0000, -46.0000],\n",
+       "        [ -7.0000, 124.0000,  16.0000,  ...,  31.0000,  26.0000, -30.0000],\n",
+       "        [-14.0000, -51.0000,  88.0000,  ...,   3.0000,  78.0000, -56.0000]])"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -612,16 +618,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In parafac original_tensor_norm = 1053.6529541015625\n",
-      "iteration 500, diff_from_norm = 16.254718780517578, rel_rec_error = 0.015427013911214994\n",
-      "iteration 1000, diff_from_norm = 16.254718780517578, rel_rec_error = 0.015427013911214994\n"
+      "In parafac original_tensor_norm = 913.5255737304688\n",
+      "iteration 500, diff_from_norm = 21.66213607788086, rel_rec_error = 0.02371267614262999\n",
+      "iteration 1000, diff_from_norm = 21.66213607788086, rel_rec_error = 0.02371267614262999\n"
      ]
     }
    ],
@@ -632,7 +638,7 @@
     "                                    init='random', tol= False, svd = None,\\\n",
     "                                    normalize_factors = normalize_factors,\\\n",
     "                                    qmodes = [0, 1],\n",
-    "                                    warmup_iters = 60,\n",
+    "                                    warmup_iters = 0,\n",
     "                                    quantize_every = 1,\n",
     "                                    qscheme = qscheme, dtype = dtype, dim = dim,\n",
     "                                    return_scale_zeropoint=True)"
@@ -640,16 +646,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "tensor(16.2547)"
+       "tensor(21.6621)"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tensorly/__init__.py
+++ b/tensorly/__init__.py
@@ -1,6 +1,8 @@
 __version__ = '0.4.5'
 import sys
 
+from .quantization import quantize_qint
+
 from .base import unfold, fold
 from .base import tensor_to_vec, vec_to_tensor
 from .base import partial_unfold, partial_fold

--- a/tensorly/decomposition/__init__.py
+++ b/tensorly/decomposition/__init__.py
@@ -3,7 +3,7 @@ The :mod:`tensorly.decomposition` module includes utilities for performing
 tensor decomposition such as CANDECOMP-PARAFAC and Tucker.                                                                                               
 """
 
-from .candecomp_parafac import parafac, non_negative_parafac, randomised_parafac, sample_khatri_rao
+from .candecomp_parafac import parafac, non_negative_parafac, randomised_parafac, sample_khatri_rao, quantized_parafac
 from ._tucker import tucker, partial_tucker, non_negative_tucker
 from .robust_decomposition import robust_pca
 from .mps_decomposition import matrix_product_state

--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -587,7 +587,7 @@ def quantized_parafac(tensor, rank, n_iter_max, init,\
                     factor = factor/(tl.reshape(weights, (1, -1)))
 
                 ## Quantize the factor
-                if mode in qmodes:
+                if (iteration >= warmup_iters) and (mode in qmodes):
                     if return_scale_zeropoint:
                         factor, scale, zero_point = quantize_qint(factor,\
                                                                   dtype, qscheme,\

--- a/tensorly/quantization.py
+++ b/tensorly/quantization.py
@@ -1,0 +1,163 @@
+import tensorly as tl
+from .base import unfold
+
+import torch
+
+def get_scale_denominator(dtype):
+    """Returns a number of intervals into which we divide
+    a range of valid values [min_value, max_malue] during quantization.
+    
+    Parameters
+    ----------
+    dtype : torch.dtype
+        Type to which we cast during quantization.
+    
+    Returns
+    -------
+    int
+        Number of quantization intervals.
+    """
+    
+    if dtype == torch.qint8:
+        scale_denom = 2**8 - 1  
+    elif dtype == torch.qint32:
+        scale_denom = 2**32 - 1
+    else:
+        raise TypeError("Can't perform quantization. Unknown quantization type: {}".format(dtype))
+        return
+    
+    return scale_denom
+
+
+def get_per_channel_stats(tensor, mode = 0):  
+    """Returns max, min and mean along last dimension for mode-`mode` unfolding
+    of `tensor` with modes starting at `0`.
+    
+    Parameters
+    ----------
+    tensor : ndarray
+    mode : int, default is 0
+          Indexing starts at 0, therefore mode is in ``range(0, tensor.ndim)``.
+
+    Returns
+    -------
+    tuple
+        max, min, mean of unfolded_tensor along last dimension.
+    """
+    unfolded_tensor = unfold(tensor, mode = mode)
+    
+    tmax = unfolded_tensor.max(dim = -1)[0]
+    tmin = unfolded_tensor.min(dim = -1)[0]
+    tmean = unfolded_tensor.mean(dim = -1)
+    
+    return tmax, tmin, tmean
+
+
+def get_scale_zeropoint(tensor,\
+                        dtype = torch.qint8,\
+                        qscheme = torch.per_tensor_affine,\
+                        dim = None):
+    """Returns scale and zero_point to apply in quantization formula.
+    
+    Parameters
+    ----------
+    tensor : Tensor
+        Float tensor to quantize.
+    dtype : ``torch.dtype``, default is ``torch.qint8``
+        The desired data type of returned tensor.
+        Has to be one of the quantized dtypes: ``torch.quint8``, ``torch.qint8``, ``torch.qint32``.
+    qscheme : quantization scheme, default is ``torch.per_tensor_affine``
+        Has to be one of: ``torch.per_tensor_affine``, ``torch.per_tensor_symmetric``, ``torch.per_channel_affine``, ``torch.per_channel_symmetric``
+    dim : int or None, default is None
+        If dim is not None, along the dimension `dim` the values in the `tensor` are scaled and offset by a different value (effectively the scale and offset become vectors).
+        If dim is None, all values in the `tensor` are scaled and offset by the same value.
+    
+    Returns
+    -------
+    scale
+        Scale to apply in quantization formula.
+    zero_point
+        Offset in integer value that maps to float zero.
+    """
+    
+    scale_denom = get_scale_denominator(dtype)
+  
+    if qscheme in [torch.per_channel_affine, torch.per_channel_symmetric]:
+        
+        tmax, tmin, zero_point = get_per_channel_stats(tensor, mode = dim)
+        zero_point = zero_point.int()
+
+    elif qscheme in [torch.per_tensor_affine, torch.per_tensor_symmetric]:
+        tmax = tensor.max()
+        tmin = tensor.min() 
+        zero_point = tensor.mean().int()
+        
+    else:
+        raise TypeError("Can't perform quantization. Unknown quantization scheme: {}".format(qscheme))
+        return
+
+    scale = (tmax - tmin)/scale_denom 
+    return scale, zero_point 
+    
+    
+    
+def quantize_qint(tensor,\
+                  dtype = torch.qint8,\
+                  qscheme = torch.per_tensor_affine,\
+                  dim = None,\
+                  return_scale_zeropoint = False):
+    """Converts a float `tensor` to quantized tensor with `scale` and `zero_point`
+    computed via function `get_scale_zeropoint`.
+    
+    Parameters
+    ----------
+    tensor : Tensor
+        Float tensor to quantize.
+    dtype : ``torch.dtype``, default is ``torch.qint8``
+        The desired data type of returned tensor.
+        Has to be one of the quantized dtypes: ``torch.quint8``, ``torch.qint8``, ``torch.qint32``.
+    qscheme : quantization scheme, default is ``torch.per_tensor_affine``
+        Has to be one of: ``torch.per_tensor_affine``, ``torch.per_tensor_symmetric``, ``torch.per_channel_affine``, ``torch.per_channel_symmetric``
+    dim : int or None, default is None
+        If dim is not None, along the dimension `dim` the values in the `tensor` are scaled and offset by a different value (effectively the scale and offset become vectors).
+        If dim is None, all values in the `tensor` are scaled and offset by the same value.
+    return_scale_zeropoint : bool, default False
+        Activate return of scale and zero_point.
+            
+    Returns
+    -------
+    Quantized Tensor
+        float version of quantized `tensor`.
+        
+    scale
+        Scale to apply in quantization formula.
+    zero_point
+        Offset in integer value that maps to float zero.          
+    """
+    
+    
+    scale, zero_point = get_scale_zeropoint(tensor,\
+                                            dtype = dtype,\
+                                            qscheme = qscheme,\
+                                            dim = dim)
+    
+    if qscheme in [torch.per_channel_affine, torch.per_channel_symmetric]:
+        qtensor = torch.quantize_per_channel(tensor,\
+                                             scales=scale, zero_points = zero_point,\
+                                             dtype = dtype, axis = dim)
+    
+    elif qscheme in [torch.per_tensor_affine, torch.per_tensor_symmetric]:
+        qtensor = torch.quantize_per_tensor(tensor,\
+                                            scale=scale, zero_point = zero_point,\
+                                            dtype = dtype)
+    else:
+        raise TypeError("Can't perform quantization. Unknown quantization scheme: {}".format(qscheme))
+        return
+    
+    
+    if return_scale_zeropoint:
+        return qtensor.dequantize(), scale, zero_point
+    
+    else:
+        return qtensor.dequantize()
+


### PR DESCRIPTION
CANDECOMP/PARAFAC decomposition with quantized factors has been added.
- the main function  is  ```quantized_parafac``` , described  in  ```tensorly/decompositions/candecomp_parafac.py``` file,
- auxiliary functions are contained in  ```tensorly/quantization.py``` file.

Please, see  ```examples/quantized_decomposition.ipynb``` for a usage example.


