### PR TITLE
[BUGFIX]: scipy.misc.imresize is removed from latest version of SciPy

### DIFF
--- a/examples/decomposition/plot_image_compression.py
+++ b/examples/decomposition/plot_image_compression.py
@@ -8,7 +8,8 @@ Example on how to use :func:`tensorly.decomposition.parafac`and :func:`tensorly.
 import matplotlib.pyplot as plt
 import tensorly as tl
 import numpy as np
-from scipy.misc import face, imresize
+from scipy.misc import face
+from scipy.ndimage import zoom
 from tensorly.decomposition import parafac
 from tensorly.decomposition import tucker
 from math import ceil
@@ -16,11 +17,12 @@ from math import ceil
 
 random_state = 12345
 
-image = tl.tensor(imresize(face(), 0.3), dtype='float64')
+image = face()
+image = tl.tensor(zoom(face(), (0.3, 0.3, 1)), dtype='float64')
 
 def to_image(tensor):
     """A convenience function to convert from a float dtype back to uint8"""
-    im = tl.to_numpy(tensor)
+    im = tl.to_numpy(tensor).squeeze()
     im -= im.min()
     im /= im.max()
     im *= 255

--- a/examples/decomposition/plot_image_compression.py
+++ b/examples/decomposition/plot_image_compression.py
@@ -22,7 +22,7 @@ image = tl.tensor(zoom(face(), (0.3, 0.3, 1)), dtype='float64')
 
 def to_image(tensor):
     """A convenience function to convert from a float dtype back to uint8"""
-    im = tl.to_numpy(tensor).squeeze()
+    im = tl.to_numpy(tensor)
     im -= im.min()
     im /= im.max()
     im *= 255


### PR DESCRIPTION
The documentation did not build with latest version of SciPy since `scipy.misc.imresize` is removed as of SciPy v.1.3.0. However, `scipy.ndimage.zoom`, which can accomplish the same with slightly different syntax, is. 

This pull request only includes a fix to this problem, and contains one new line and one changed line.