### PR TITLE
Fix mask shape during kr calculation

### DIFF
--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -53,11 +53,6 @@ class NumpyBackend(Backend):
             return np.sum(np.abs(tensor)**order, axis=axis)**(1 / order)
 
     def kr(self, matrices, weights=None, mask=None):
-        if mask is None:
-            mask = 1
-        else:
-            mask = mask.reshape((-1, 1))
-
         n_columns = matrices[0].shape[1]
         n_factors = len(matrices)
 
@@ -70,7 +65,8 @@ class NumpyBackend(Backend):
         if weights is not None:
             matrices = [m if i else m*self.reshape(weights, (1, -1)) for i, m in enumerate(matrices)]
 
-        return np.einsum(operation, *matrices).reshape((-1, n_columns))*mask
+        m = mask.reshape((-1, 1)) if mask is not None else 1
+        return np.einsum(operation, *matrices).reshape((-1, n_columns))*m
 
     @property
     def SVD_FUNS(self):

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -53,7 +53,11 @@ class NumpyBackend(Backend):
             return np.sum(np.abs(tensor)**order, axis=axis)**(1 / order)
 
     def kr(self, matrices, weights=None, mask=None):
-        if mask is None: mask = 1
+        if mask is None:
+            mask = 1
+        else:
+            mask = mask.reshape((-1, 1))
+
         n_columns = matrices[0].shape[1]
         n_factors = len(matrices)
 

--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -207,7 +207,7 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',\
             pseudo_inverse += Id
 
             if mask is not None:
-                tensor = tensor*mask + tl.kruskal_to_tensor((None, factors))*(1-mask)
+                tensor = tensor*mask + tl.kruskal_to_tensor((None, factors), mask=1-mask)
 
             mttkrp = unfolding_dot_khatri_rao(tensor, (None, factors), mode)
             factor = tl.transpose(tl.solve(tl.conj(tl.transpose(pseudo_inverse)),

--- a/tensorly/decomposition/candecomp_parafac.py
+++ b/tensorly/decomposition/candecomp_parafac.py
@@ -207,7 +207,7 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',\
             pseudo_inverse += Id
 
             if mask is not None:
-                tensor = tensor*mask + tl.kruskal_to_tensor((None, factors), mask=1-mask)
+                tensor = tensor*mask + tl.kruskal_to_tensor((None, factors))*(1-mask)
 
             mttkrp = unfolding_dot_khatri_rao(tensor, (None, factors), mode)
             factor = tl.transpose(tl.solve(tl.conj(tl.transpose(pseudo_inverse)),

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -82,7 +82,7 @@ def test_masked_parafac():
     """
     rng = check_random_state(1234)
     tensor = T.tensor(rng.random_sample((3, 3, 3)))
-    mask = np.ones((3, 3, 3))
+    mask = T.tensor(np.ones((3, 3, 3)))
 
     mask_fact = parafac(tensor, rank=2, mask=mask)
     fact = parafac(tensor, rank=2)

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -78,7 +78,7 @@ def test_parafac():
 
 def test_masked_parafac():
     """Test for the masked CANDECOMP-PARAFAC decomposition.
-    This checks that a mask of 0's is identical to the unmasked case.
+    This checks that a mask of 1's is identical to the unmasked case.
     """
     rng = check_random_state(1234)
     tensor = T.tensor(rng.random_sample((3, 3, 3)))

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -75,6 +75,21 @@ def test_parafac():
     error = T.norm(tensor - rec, 2)/T.norm(tensor)
     assert_(error < tol)
 
+
+def test_masked_parafac():
+    """Test for the masked CANDECOMP-PARAFAC decomposition.
+    This checks that a mask of 0's is identical to the unmasked case.
+    """
+    rng = check_random_state(1234)
+    tensor = T.tensor(rng.random_sample((3, 3, 3)))
+    mask = np.ones((3, 3, 3))
+
+    mask_fact = parafac(tensor, rank=2, mask=mask)
+    fact = parafac(tensor, rank=2)
+    diff = kruskal_to_tensor(mask_fact) - kruskal_to_tensor(fact)
+    assert_(T.norm(diff) < 1.0e-6, 'norm 2 of reconstruction higher than 0.2')
+
+
 def test_non_negative_parafac():
     """Test for non-negative PARAFAC
 

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -87,7 +87,7 @@ def test_masked_parafac():
     mask_fact = parafac(tensor, rank=2, mask=mask)
     fact = parafac(tensor, rank=2)
     diff = kruskal_to_tensor(mask_fact) - kruskal_to_tensor(fact)
-    assert_(T.norm(diff) < 1.0e-6, 'norm 2 of reconstruction higher than 0.2')
+    assert_(T.norm(diff) < 0.01, 'norm 2 of reconstruction higher than 0.01')
 
 
 def test_non_negative_parafac():


### PR DESCRIPTION
I believe this fixes #142. A very basic test is also added here to check that a mask with no effect gives the same result.

The problem ultimately came down to the kr form being unfolded. The mask effect could be handled within parafac more simply, but I wasn't sure whether there is a reason for the current design.