### PR TITLE
Bugfix: PARAFAC2 not using "init" option

### DIFF
--- a/tensorly/decomposition/parafac2.py
+++ b/tensorly/decomposition/parafac2.py
@@ -1,10 +1,9 @@
-import warnings
 import tensorly as tl
 from tensorly.random import random_parafac2
 from tensorly import backend as T
 from . import parafac
 from ..parafac2_tensor import parafac2_to_slice, Parafac2Tensor, _validate_parafac2_tensor
-from ..kruskal_tensor import kruskal_normalise, KruskalTensor
+from ..kruskal_tensor import KruskalTensor
 from ..base import unfold
 
 # Authors: Marie Roald
@@ -220,7 +219,7 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
     that the function accept both lists of matrices and a single nd-array as input without
     any reordering of the modes.
     """
-    weights, factors, projections = initialize_decomposition(tensor_slices, rank, random_state=random_state)
+    weights, factors, projections = initialize_decomposition(tensor_slices, rank, init=init, random_state=random_state)
 
     rec_errors = []
     norm_tensor = tl.sqrt(sum(tl.norm(tensor_slice, 2)**2 for tensor_slice in tensor_slices))

--- a/tensorly/decomposition/parafac2.py
+++ b/tensorly/decomposition/parafac2.py
@@ -219,7 +219,7 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
     that the function accept both lists of matrices and a single nd-array as input without
     any reordering of the modes.
     """
-    weights, factors, projections = initialize_decomposition(tensor_slices, rank, init=init, random_state=random_state)
+    weights, factors, projections = initialize_decomposition(tensor_slices, rank, init=init, svd=svd, random_state=random_state)
 
     rec_errors = []
     norm_tensor = tl.sqrt(sum(tl.norm(tensor_slice, 2)**2 for tensor_slice in tensor_slices))


### PR DESCRIPTION
The `init` option wasn't being used, because it wasn't passed to `initialize_decomposition`. Fixed here.