### PR TITLE
Add test where rank > min_dim.

### DIFF
--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -124,11 +124,12 @@ def test_parafac2_normalize_factors():
     assert abs(tl.max(norms) - tl.max(normalized_rec.weights))/tl.max(norms) < 1e-2
     assert abs(tl.min(norms) - tl.min(normalized_rec.weights))/tl.min(norms) < 1e-2
 
-def test_parafac2_init_valid():
-    rng = check_random_state(1234)
-    rank = 3
 
-    random_parafac2_tensor = random_parafac2(shapes=[(15, 30)]*25, rank=rank, random_state=rng)
+@pytest.mark.parametrize("rank", [2, 4])
+def test_parafac2_init_valid(rank):
+    rng = check_random_state(1234)
+
+    random_parafac2_tensor = random_parafac2(shapes=[(15, 30)]*3, rank=rank, random_state=rng)
     tensor = parafac2_to_tensor(random_parafac2_tensor)
     weights, (A, B, C), projections = random_parafac2_tensor
     B = T.dot(projections[0], B)


### PR DESCRIPTION
I believe this is an error in PARAFAC2—I've added a test here to demonstrate what I'm seeing. Specifically when rank > min_dim, SVD initialization fails. It's not a problem with SVD but rather using the results to construct the PARAFAC2 decomposition. I'm not confident enough what is happening here to fix it. @MarieRoald, perhaps you could advise?

```
    def _compute_projections(tensor_slices, factors, svd_fun, out=None):
        A, B, C = factors
    
        if out is None:
            out = [T.zeros((tensor_slice.shape[0], C.shape[1]), **T.context(tensor_slice)) for tensor_slice in tensor_slices]
    
        slice_idxes = range(T.shape(A)[0])
        for projection, i, tensor_slice in zip(out, slice_idxes, tensor_slices):
            a_i = A[i]
>           lhs = T.dot(B, T.transpose(a_i*C))
E           ValueError: operands could not be broadcast together with shapes (3,) (30,4)
```