### PR TITLE
Fix testing errors

### DIFF
--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -70,7 +70,6 @@ class JaxBackend(Backend):
             return np.sum(np.abs(tensor)**order, axis=axis)**(1 / order)
 
     def kr(self, matrices, weights=None, mask=None):
-        if mask is None: mask = 1
         n_columns = matrices[0].shape[1]
         n_factors = len(matrices)
 
@@ -83,7 +82,8 @@ class JaxBackend(Backend):
         if weights is not None:
             matrices = [m if i else m*self.reshape(weights, (1, -1)) for i, m in enumerate(matrices)]
 
-        return np.einsum(operation, *matrices).reshape((-1, n_columns))*mask
+        m = mask.reshape((-1, 1)) if mask is not None else 1
+        return np.einsum(operation, *matrices).reshape((-1, n_columns))*m
 
     @property
     def SVD_FUNS(self):

--- a/tensorly/contrib/decomposition/tests/test_mps_decomposition_cross.py
+++ b/tensorly/contrib/decomposition/tests/test_mps_decomposition_cross.py
@@ -61,7 +61,7 @@ def test_matrix_product_state_cross_2():
     rank = [1, 3, 3, 4, 2, 2, 1]
     factors = matrix_product_state_cross(tensor, rank)
 
-    for k in range(6):
+    for k in range(5):
         (r_prev, n_k, r_k) = factors[k].shape
 
         first_error_message = "MPS rank " + str(k) + " is greater than the maximum allowed "

--- a/tensorly/contrib/decomposition/tests/test_mps_decomposition_cross.py
+++ b/tensorly/contrib/decomposition/tests/test_mps_decomposition_cross.py
@@ -3,7 +3,6 @@ import tensorly as tl
 import pytest
 import numpy as np
 import itertools
-import numpy.random as npr
 
 from ..mps_decomposition_cross import matrix_product_state_cross
 from ....mps_tensor import mps_to_tensor
@@ -20,7 +19,6 @@ skip_if_jax = pytest.mark.skipif(tl.get_backend() == "jax",
 @skip_if_tensorflow
 def test_matrix_product_state_cross_1():
     """ Test for matrix_product_state """
-    rng = check_random_state(1234)
 
     ## Test 1
 
@@ -55,13 +53,12 @@ def test_matrix_product_state_cross_2():
     ## Test 2
     # Create tensor with random elements
     tensor = tl.tensor(rng.random_sample([3, 4, 5, 6, 2, 10]))
-    tensor_shape = tensor.shape
 
     # Find MPS decomposition of the tensor
-    rank = [1, 3, 3, 4, 2, 2, 1]
+    rank = [1, 2, 2, 3, 2, 2, 1]
     factors = matrix_product_state_cross(tensor, rank)
 
-    for k in range(5):
+    for k in range(6):
         (r_prev, n_k, r_k) = factors[k].shape
 
         first_error_message = "MPS rank " + str(k) + " is greater than the maximum allowed "
@@ -125,7 +122,6 @@ def test_matrix_product_state_cross_4():
     def func (X):
         return sum(X)**3
 
-    maxvoleps = 1e-4
     tol = 1e-3
     n = 10
     d = 4

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -92,8 +92,8 @@ def test_masked_parafac():
     tensor = T.tensor(rng.random_sample((3, 3, 3)))
     mask = T.tensor(np.ones((3, 3, 3)))
 
-    mask_fact = parafac(tensor, rank=1, mask=mask, init='random', random_state=1234)
-    fact = parafac(tensor, rank=1)
+    mask_fact = parafac(tensor, rank=2, mask=mask, init='random', random_state=1234)
+    fact = parafac(tensor, rank=2)
     diff = kruskal_to_tensor(mask_fact) - kruskal_to_tensor(fact)
     assert_(T.norm(diff) < 0.01, 'norm 2 of reconstruction higher than 0.01')
 

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -92,8 +92,8 @@ def test_masked_parafac():
     tensor = T.tensor(rng.random_sample((3, 3, 3)))
     mask = T.tensor(np.ones((3, 3, 3)))
 
-    mask_fact = parafac(tensor, rank=2, mask=mask, init='random', random_state=1234)
-    fact = parafac(tensor, rank=2)
+    mask_fact = parafac(tensor, rank=1, mask=mask, init='random', random_state=1234)
+    fact = parafac(tensor, rank=1)
     diff = kruskal_to_tensor(mask_fact) - kruskal_to_tensor(fact)
     assert_(T.norm(diff) < 0.01, 'norm 2 of reconstruction higher than 0.01')
 

--- a/tensorly/decomposition/tests/test_candecomp_parafac.py
+++ b/tensorly/decomposition/tests/test_candecomp_parafac.py
@@ -92,8 +92,8 @@ def test_masked_parafac():
     tensor = T.tensor(rng.random_sample((3, 3, 3)))
     mask = T.tensor(np.ones((3, 3, 3)))
 
-    mask_fact = parafac(tensor, rank=2, mask=mask)
-    fact = parafac(tensor, rank=2)
+    mask_fact = parafac(tensor, rank=1, mask=mask, init='random', random_state=1234)
+    fact = parafac(tensor, rank=1)
     diff = kruskal_to_tensor(mask_fact) - kruskal_to_tensor(fact)
     assert_(T.norm(diff) < 0.01, 'norm 2 of reconstruction higher than 0.01')
 

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -105,7 +105,7 @@ def test_masked_tucker():
 
     # We won't use the SVD decomposition, but check that it at least runs successfully
     mask_fact = tucker(mask_tensor, rank=(1, 1, 1), mask=mask, init="svd")
-    mask_fact = tucker(mask_tensor, rank=(1, 1, 1), mask=mask, init="random")
+    mask_fact = tucker(mask_tensor, rank=(1, 1, 1), mask=mask, init="random", random_state=1234)
     mask_err = tl.norm(tucker_to_tensor(mask_fact) - tensor)
 
     assert_(mask_err < 0.001, 'norm 2 of reconstruction higher than 0.001')


### PR DESCRIPTION
This fixes some sporadic and consistent testing errors:

- Rank of MPS cross decomposition reduced
- Fixed shape of mask in masked kr for Jax backend (not sure how this got past before)
- Set random seed on masked Tucker and PARAFAC tests