### PR TITLE
Decomposition classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,19 @@ language: python
 matrix:
     include:
      - os: linux
-       python: 3.6
-       env: BACKEND=numpy
-     - os: linux
-       python: 3.7
+       python: 3.8
        env: BACKEND=mxnet
      - os: linux
-       python: 3.7
+       python: 3.8
+       env: BACKEND=jax
+     - os: linux
+       python: 3.8
        env: BACKEND=pytorch
      - os: linux
-       python: 3.7
+       python: 3.8
        env: BACKEND=tensorflow
      - os: linux
-       python: 3.7
+       python: 3.8
        env: BACKEND=numpy DEPLOY_DOCS=1 DEPLOY_PYPI=1
        addons:
          apt:
@@ -44,11 +44,13 @@ install:
     - if [[ "$BACKEND" == "numpy" ]]; then
         pip install sparse;
       elif [[ "$BACKEND" == "pytorch" ]]; then
-        conda install pytorch-cpu torchvision-cpu -c pytorch;
+        conda install pytorch cpuonly -c pytorch;
       elif [[ "$BACKEND" == "tensorflow" ]]; then
         conda install tensorflow;
       elif [[ "$BACKEND" == "mxnet" ]]; then
         pip install mxnet;
+      elif [[ "$BACKEND" == "jax" ]]; then
+        pip install jax jaxlib;
       fi
     - pip install -e .
 

--- a/tensorly/decomposition/mps_decomposition.py
+++ b/tensorly/decomposition/mps_decomposition.py
@@ -81,3 +81,47 @@ def matrix_product_state(input_tensor, rank, verbose=False):
         print("MPS factor " + str(n_dim-1) + " computed with shape " + str(factors[n_dim-1].shape))
 
     return factors
+
+
+class TensorTrain:
+    def __init__(self, rank, verbose=False):
+        """MPS decomposition via recursive SVD
+
+            Decomposes `input_tensor` into a sequence of order-3 tensors (factors)
+            -- also known as Tensor-Train decomposition [1]_.
+
+        Parameters
+        ----------
+        input_tensor : tensorly.tensor
+        rank : {int, int list}
+                maximum allowable MPS rank of the factors
+                if int, then this is the same for all the factors
+                if int list, then rank[k] is the rank of the kth factor
+        verbose : boolean, optional
+                level of verbosity
+
+        Returns
+        -------
+        factors : MPS factors
+                order-3 tensors of the MPS decomposition
+
+        References
+        ----------
+        .. [1] Ivan V. Oseledets. "Tensor-train decomposition", SIAM J. Scientific Computing, 33(5):2295–2317, 2011.
+        """
+        self.rank = rank
+        self.verbose = verbose
+
+    def fit_transform(self, tensor):
+        self.tensor_train_ = matrix_product_state(tensor, rank=self.rank, verbose=self.verbose)
+        return self.tensor_train_
+
+    def fit(self, tensor):
+        self.fit_transform(tensor)
+        return self
+
+    def __repr__(self):
+        return f'Rank-{self.rank} Tensor-Train decomposition.'
+
+
+    

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -560,11 +560,11 @@ def test_index_update():
     insert = tl.tensor(np.copy(np_insert))
 
     np_tensor[:, 1:3] = np_insert
-    tl.index_update(tensor, tl.index[:, 1:3], insert)
+    tensor = tl.index_update(tensor, tl.index[:, 1:3], insert)
     assert_array_equal(np_tensor, tensor)
 
     np_tensor = np.random.random((3, 5)).astype(dtype=np.float32)
     tensor = tl.tensor(np.copy(np_tensor))
     np_tensor[2, :] = 2
-    tl.index_update(tensor, tl.index[2, :], 2)
+    tensor = tl.index_update(tensor, tl.index[2, :], 2)
     assert_array_equal(np_tensor, tensor)


### PR DESCRIPTION
Background
=========

This PR is to have a concrete draft to implement the long discussed new class API. The reference in the matter is probably [Scikit-Learn](https://scikit-learn.org/stable/modules/classes.html) which did an amazing job in designing a clear, simple and effective API. 

There are a few concepts behind it, namely:
	•	Consistency (of an interface with a small limited set of methods)
	•	Inspection
	•	Non-proliferation of classes
	•	Composition
	•	Sensible defaults
You can read more about in the [related paper](https://dtai.cs.kuleuven.be/events/lml2013/papers/lml2013_api_sklearn.pdf). These are all great concepts that I try to enforce in TensorLy.

Going forward, we want to add a class API for tensor decomposition. This is already the case for [tensor regression](http://tensorly.org/stable/modules/generated/tensorly.regression.tucker_regression.TuckerRegressor.html#tensorly.regression.tucker_regression.TuckerRegressor).

Proposed API
==========
Current API, updated to reflect the discussion

```python
class Decomposition:
    def  __init__(self, *args, **kwargs):
        # store all hyper-parameters
        # Only sets the values of the attributes, nothing more

    def fit(tensor, y=None, kruskal_init=None):
        # fit the decomposition on an input tensor
        return self

    def fit_transform(tensor, y=None, kruskal_init=None):
         # ...
         return decomposed_tensor

    def transform(self, tensor):
        # easy for a Tucker decomposition (return the core obtained by projecting with the factors)
        return projected_tensor
```

Principles to consider 
================
Key points discussed in the PR:

* Separation between data and algorithm:  the classes should not store the training data, only their own parameters. In particular, `KruskalTensor` is a separate class from the `Parafac` one. One issue with mixing the two is that it would introduces side effects makes is much harder to compose function (e.g. to create Pipelines).

* Optimization methods: we will have a separate class for each major optimization methods (e.g. `ParafacALS`). We may consider having a base class `Parafac` taking as parameter e.g. `method='als'`, which will specify which optimization method to use. This is slightly tricky as different methods may have different arguments and having a base class might be optimal for discoverability of these.

Questions to answer
===============

Fit_transform or decompose
----------------------------

The question is how to adapt the fit/transform for decompositions such as CP (where fit and transform cannot easily be separated), or Robust Tensor PCA, where we just express `X = L + R` but don't have an explicit way to project input data.

Once a CP decomposition is fit to the data, we get the factors of the decomposition. 
Transforming a new input tensor doesn’t make as much sense (the best I can think of would be to learn new weighting for the learned factors so as to minimise the rec error, this is more of another fit rather than a proper transform). 

The main question: do we decide CP will only have `fit_transform`? Or do we add a method `decompose` for tensor decomposition specifically, that just returns the decomposed tensor? 


Initialization
-------------
A good reference is scikit-learn’s non-negative factorisation (https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.NMF.html). The idea is to have an init param in the __init__ (a string specifying which method to use), and we can have another param in the `fit` and `fit_transform`, either as:

* Single argument: this could all be grouped in a parameter, e.g. `kruskal_tensor_init=None`

* or Individual arguments: e.g. for CP, `weights_init` and `factors_init` for instance.

-------------------------

Keen to get feedback on this! @MarieRoald @yngvem @aarmey @cohenjer 