### PR TITLE
Feature/mpca

### DIFF
--- a/doc/modules/api.rst
+++ b/doc/modules/api.rst
@@ -241,6 +241,7 @@ Functions
     partial_tucker
     non_negative_tucker
     robust_pca
+    mpca
     tensor_train
     tensor_train_matrix
     parafac2

--- a/tensorly/decomposition/__init__.py
+++ b/tensorly/decomposition/__init__.py
@@ -7,6 +7,7 @@ from ._cp import (parafac, non_negative_parafac, CP, RandomizedCP,
                                 randomised_parafac, sample_khatri_rao)
 from ._tucker import tucker, partial_tucker, non_negative_tucker, Tucker
 from .robust_decomposition import robust_pca
+from .mpca import mpca, compute_modek_total_scatter
 from ._tt import TensorTrain, tensor_train, tensor_train_matrix
 from .parafac2 import parafac2, Parafac2
 from ._symmetric_cp import symmetric_parafac_power_iteration, symmetric_power_iteration, SymmetricCP

--- a/tensorly/decomposition/mpca.py
+++ b/tensorly/decomposition/mpca.py
@@ -64,19 +64,19 @@ def mpca(X, ranks, n_iters=5, zero_mean=True):
     ###############
     # check correct # of ranks have been supplied
     ###############
-    assert len(ranks) == len(X.shape[1:]), 'Expected number of ranks: {}. \
-        But number supplied is {}'.format(len(X.shape[1:]), len(ranks))
+    assert len(ranks) == len(T.shape(X)[1:]), 'Expected number of ranks: {}. \
+        But number supplied is {}'.format(len(T.shape(X)[1:]), len(ranks))
 
     if zero_mean:
         # first, zero-mean the tensor data
         X = X - T.mean(X, axis=0)
 
     # the first mode is the 'sample' mode
-    num_modes = len(X.shape) - 1
+    num_modes = len(T.shape(X)) - 1
 
     # initialise the factor matrices as 1-matrices
-    factors = [T.ones((dim, X.shape[i + 1]), **T.context(X))
-               for i, dim in enumerate(list(X.shape)[1:])]
+    factors = [T.ones((dim, T.shape(X)[i + 1]), **T.context(X))
+               for i, dim in enumerate(list(T.shape(X))[1:])]
 
     for t in range(1, n_iters + 1):
         # for each iteration compute partial projections for mode k,
@@ -136,18 +136,18 @@ def compute_modek_total_scatter(X, mode, factors):
     ###############
     # check that all factor matrices have been supplied
     ###############
-    assert len(factors) == len(X.shape[1:]), 'Expected number of factor matrices: {}. \
-        But number found is {}'.format(len(X.shape[1:]), len(factors))
+    assert len(factors) == len(T.shape(X)[1:]), 'Expected number of factor matrices: {}. \
+        But number found is {}'.format(len(T.shape(X)[1:]), len(factors))
 
     ###############
     # check that dimensions of factor matrices are compatible
     ###############
-    for i in range(len(X.shape) - 1):
-        assert X.shape[i + 1] == factors[i].shape[0], 'Incompatible dimensions for factor matrix {}. \
-            U_k must be of size ({}, P_k), but is of size ({}, P_k)'.format(i, X.shape[i + 1], factors[i].shape[0])
+    for i in range(len(T.shape(X)) - 1):
+        assert T.shape(X)[i + 1] == T.shape(factors[i])[0], 'Incompatible dimensions for factor matrix {}. \
+            U_k must be of size ({}, P_k), but is of size ({}, P_k)'.format(i, T.shape(X)[i + 1], T.shape(factors[i])[0])
 
     # loop over each data point, building the mode-n total scatter matrix
-    for m in range(len(X)):
+    for m in range(T.shape(X)[0]):
         proj_but_k = unfold(multi_mode_dot(X[m], factors, transpose=True, skip=mode), mode)
         scatter += T.dot(proj_but_k, T.transpose(proj_but_k))
 

--- a/tensorly/decomposition/mpca.py
+++ b/tensorly/decomposition/mpca.py
@@ -1,0 +1,154 @@
+import numpy as np
+from .. import backend as T
+from ..base import fold, unfold
+from ..tenalg import multi_mode_dot
+
+
+# Author: James Oldfield
+
+# License: BSD 3 clause
+
+
+def mpca(X, ranks, n_iters=5, zero_mean=True):
+    """Multilinear Principal Component Analysis, via Alternating Partial Projections.
+
+        Learns a projection matrix for each mode of the data tensor
+        to project the input tensor into a low-dimensional tensor subspace
+        where the total scatter is maximised.
+
+        Note: the first dimension is the sample dimension.
+
+    Parameters
+    ----------
+    X : ndarray
+        tensor data of shape (n_samples, N1, ..., NS)
+    ranks : list
+        list of integers determining the dimension of the subspace for mode-k.
+    n_iters : int, optional, default is 5
+        number of steps to employ the APP scheme for.
+    zero_mean : bool, optional, default is True
+        The sample-wise mean needs to be removed (along 0th axis).
+        Pass `zero_mean=False` if this has already been removed.
+
+    Returns
+    -------
+    factors : list
+        list of the learnt projection matrices for each mode
+
+    Notes
+    -----
+    In a similar manner to regular PCA, *Multilinear PCA* (MPCA) seeks a projection onto a (tensor) subspace where the total scatter is maximised [1]. In contrast to PCA, MPCA seeks not a single projection matrix, but :math:`k` projection matrices :math:`\\mathbf{U}^{(k)}` for each mode :math:`k` of a higher-order tensor, :math:`\\mathcal{X}\\in\\mathbb{R}^{I_1\\times I_2\\times\\cdots\\times I_{N}}`.
+
+    The total scatter maximisation objective defined for the projection matrices as
+
+    .. math::
+       :nowrap:
+
+        \\begin{equation*}
+        \\begin{aligned}
+            J(\\mathbf{U}^{(k)}) = \\underset{\\mathbf{U}^{(k)}}{\\arg\\max}
+                \\sum_{m=1}^M || \\tilde{\\mathcal{X}}_m \\prod_{n=1}^N \\times_n {\\mathbf{U}^{(n)}}^\\top ||^2_F,
+        \\end{aligned}
+        \\end{equation*}
+
+    where :math:`\\tilde{\mathcal{X}}_m` is the :math:`m` th data point with the sample mean :math:`\\bar{\\mathcal{X}} = \\frac{1}{M} \\sum_{m=1}^{M}\\mathcal{X}_m` subtracted.
+
+    For example, for a tensor of 4th order, one can project each sample onto its low-dimensional tensor subspace using::
+
+        tl.tenalg.multi_mode_dot(X, factors, modes=[1, 2, 3], transpose=True)
+
+    - [1] Haiping Lu, K. N. Plataniotis, and A. N. Venetsanopoulos, ‘MPCA: Multilinear Principal Component Analysis of Tensor Objects’, IEEE Trans. Neural Netw., vol. 19, no. 1, pp. 18–39, Jan. 2008, doi: 10.1109/TNN.2007.901277.
+
+    """
+
+    ###############
+    # check correct # of ranks have been supplied
+    ###############
+    assert len(ranks) == len(X.shape[1:]), 'Expected number of ranks: {}. \
+        But number supplied is {}'.format(len(X.shape[1:]), len(ranks))
+
+    if zero_mean:
+        # first zero-mean the tensor data
+        X -= T.mean(X, axis=0, **T.context(X))
+
+    # the first mode is the 'sample' mode
+    num_modes = len(X.shape) - 1
+
+    # initialise the factor matrices as 1-matrices
+    factors = [T.ones((dim, X.shape[i + 1]), **T.context(X))
+               for i, dim in enumerate(list(X.shape)[1:])]
+
+    for t in range(1, n_iters + 1):
+        # for each iteration compute partial projections for mode k,
+        # i.e. project along all modes but k.
+        for k in range(num_modes):
+            scatter = compute_modek_total_scatter(X, k, factors)
+
+            # set the factor matrices equal to the top-`ranks[k]` number of eigenvectors
+            # note: scatter is a positive definite matrix, thus the left-singular vectors
+            # are the same as its eigenvectors (up to a sign).
+            U, _, _ = T.partial_svd(scatter)
+            factors[k] = U[:, :ranks[k]]
+
+    return factors
+
+
+def compute_modek_total_scatter(X, mode, factors):
+    """Computes the mode-n total scatter matrix for the partial projections of :math:`\\mathcal{X}_m` along all modes but :math:`n`.
+
+    Parameters
+    ----------
+    X : ndarray
+        tensor data of shape (n_samples, N1, ..., NS)
+    mode : int
+        desired mode to compute mode-n total scatter for.
+    factors : list
+        list of tensorly tensors (matrices) containing the projection matrices.
+
+    Returns
+    -------
+    scatter : ndarray
+        the mode-n total scatter (matrix)
+
+    Notes
+    -----
+    Following [1], this is defined as
+
+    .. math::
+       :nowrap:
+
+        \\begin{equation*}
+        \\begin{aligned}
+        \\mathbf{S}^{(n)}_{T_{\\hat{\\mathcal{Y}}}} =
+            \\sum_{m=1}^{M}
+                \\left( \\mathbf{\\hat{Y}}_{m[n]} - \\mathbf{\\bar{\\hat{Y}}}_{[n]} \\right)
+                \\left( \\mathbf{\\hat{Y}}_{m[n]} - \\mathbf{\\bar{\\hat{Y}}}_{[n]} \\right)^\\top,
+        \\end{aligned}
+        \\end{equation*}
+
+    where :math:`\\bar{\\hat{\\mathbf{Y}}}_{[n]}` is the mode-n unfolding of the projection of the mean tensor :math:`\\bar{\\mathcal{X}}` along all modes but :math:`n`.
+
+    - [1] Multilinear Subspace Learning: Dimensionality Reduction of Multidimensional Data, Haiping Lu, K. N. Plataniotis, and A. N. Venetsanopoulos, Chapman & Hall/CRC Press Machine Learning and Pattern Recognition Series, Taylor and Francis, ISBN: 978-1-4398572-4-3, December 2013.
+
+    """
+    scatter = 0
+
+    ###############
+    # check that all factor matrices have been supplied
+    ###############
+    assert len(factors) == len(X.shape[1:]), 'Expected number of factor matrices: {}. \
+        But number found is {}'.format(len(X.shape[1:]), len(factors))
+
+    ###############
+    # check that dimensions of factor matrices are compatible
+    ###############
+    for i in range(len(X.shape) - 1):
+        assert X.shape[i + 1] == factors[i].shape[0], 'Incompatible dimensions for factor matrix {}. \
+            U_k must be of size ({}, P_k), but is of size ({}, P_k)'.format(i, X.shape[i + 1], factors[i].shape[0])
+
+    # loop over each data point, building the mode-n total scatter matrix
+    for m in range(len(X)):
+        proj_but_k = unfold(multi_mode_dot(X[m], factors, transpose=True, skip=mode), mode)
+        scatter += T.dot(proj_but_k, proj_but_k.T)
+
+    return scatter

--- a/tensorly/decomposition/mpca.py
+++ b/tensorly/decomposition/mpca.py
@@ -1,6 +1,6 @@
 import numpy as np
 from .. import backend as T
-from ..base import fold, unfold
+from ..base import unfold
 from ..tenalg import multi_mode_dot
 
 
@@ -68,8 +68,8 @@ def mpca(X, ranks, n_iters=5, zero_mean=True):
         But number supplied is {}'.format(len(X.shape[1:]), len(ranks))
 
     if zero_mean:
-        # first zero-mean the tensor data
-        X -= T.mean(X, axis=0, **T.context(X))
+        # first, zero-mean the tensor data
+        X = X - T.mean(X, axis=0)
 
     # the first mode is the 'sample' mode
     num_modes = len(X.shape) - 1
@@ -149,6 +149,6 @@ def compute_modek_total_scatter(X, mode, factors):
     # loop over each data point, building the mode-n total scatter matrix
     for m in range(len(X)):
         proj_but_k = unfold(multi_mode_dot(X[m], factors, transpose=True, skip=mode), mode)
-        scatter += T.dot(proj_but_k, proj_but_k.T)
+        scatter += T.dot(proj_but_k, T.transpose(proj_but_k))
 
     return scatter

--- a/tensorly/decomposition/tests/test_mpca.py
+++ b/tensorly/decomposition/tests/test_mpca.py
@@ -1,0 +1,53 @@
+import numpy as np
+from numpy.linalg import inv, eig
+
+import tensorly as tl
+from ..mpca import mpca, compute_modek_total_scatter
+from ...testing import assert_array_almost_equal
+
+from ...tenalg import multi_mode_dot
+
+
+def test_mpca():
+    """Test for MPCA
+
+    (1) Compute the (square) projection matrices for each mode.
+        Then check we recover the original data with the inverse projections.
+
+    (2) Test the numerical equivalence of the np eigendecomp and tl.partial_svd
+        for (positive definite) scatter matrices.
+
+    """
+    tol = 1e-3
+
+    np.random.seed(1234)
+
+    # 10 random 3rd-order tensors
+    X = tl.tensor(np.random.randn(10, 5, 5, 5))
+
+    ###########################################
+    # (1) Check reconstruction of original data
+    ###########################################
+    factors = mpca(X, ranks=[5, 5, 5], n_iters=5)
+
+    # project onto MPCA tensor subspace
+    Z = multi_mode_dot(X, factors, modes=[1, 2, 3], transpose=True)
+
+    # recover X, using the inverse projection matrices
+    X_hat = multi_mode_dot(Z, [tl.tensor(inv(tl.to_numpy(f))) for f in factors], modes=[1, 2, 3], transpose=True)
+
+    assert_array_almost_equal(X, X_hat, decimal=tol)
+
+    #####################################################
+    # (2) Check left-singular vector / eigenvector equiv.
+    #     for scatter matrix (up to a sign)
+    #####################################################
+    scatter = compute_modek_total_scatter(X, mode=0, factors=factors)
+
+    _, U_eig = eig(tl.to_numpy(scatter))
+    U_svd, _, _ = tl.partial_svd(scatter)
+
+    assert_array_almost_equal(
+        tl.abs(tl.tensor(U_eig)),
+        tl.abs(U_svd),
+        decimal=tol)


### PR DESCRIPTION
Hey folks!

I thought an implementation of Haiping Lu's Multilinear PCA could go nicely into `tensorly.decomposition`--what do you think? (I can also add a notebook demo using it for identity classification if that suits. Where is a good place to put this?)

I've added a unit test to confirm we can reconstruct the original tensors from the inverse projection matrices (inspired by the robustPCA's unit tests), and one to confirm the numerical equivalence of the eigendecomp+SVD for the total scatter matrices (with `tl.partial_svd` preferred for its being backend-agnostic?). Unfortunately, I can't run cupy on my machine... but the tests for all the other backends pass!

Any suggestions? or more ideas for unit tests?

Looking forward to hearing your feedback :-)!