### PR TITLE
Hals feature

### DIFF
--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -297,7 +297,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
     """
     Non-negative CP decomposition via HALS
 
-    Uses HALS which updates each factor columnwise, fixing every other columns, see [1]_
+    Uses Hierarchical ALS (Alternating Least Squares) which updates each factor column-wise (one column at a time while keeping all other columns fixed), see [1]_
 
     Parameters
     ----------

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -356,8 +356,8 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
     norm_tensor = tl.norm(tensor, 2)
 
     n_modes = tl.ndim(tensor)
-    if sparsity_coefficient is None or isinstance(sparsity_coefficient, float):
-       sparsity_coefficient = [sparsity_coefficient]*n_modes
+    if sparsity_coefficients is None or isinstance(sparsity_coefficients, float):
+       sparsity_coefficients = [sparsity_coefficients]*n_modes
     
     if fixed_modes is None:
         fixed_modes = []

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -400,7 +400,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
                 factors[mode] = tl.transpose(
                     hals_nnls_exact(tl.transpose(mttkrp), pseudo_inverse, tl.transpose(factors[mode]),
                                      maxiter=5000)[0])
- 
+
         if tol:
             factors_norm = cp_norm((weights, factors))
             iprod = tl.sum(tl.sum(mttkrp*factor, axis=0)*weights)

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -20,7 +20,7 @@ from ..cp_tensor import (cp_to_tensor, CPTensor,
 
 
 def make_svd_non_negative(tensor, U, S, V, nntype):
-    """ Use NNDSVD method to transform SVD results into a non-negative form. This 
+    """ Use NNDSVD method to transform SVD results into a non-negative form. This
     method leads to more efficient solving with NNMF [1].
 
     Parameters
@@ -313,8 +313,8 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
           tolerance: the algorithm stops when the variation in
           the reconstruction error is less than the tolerance
         Default: 1e-8
-    sparsity_coefficients: array of float (as much as the number of modes)
-        The sparsity coefficients on U and V respectively.
+    sparsity_coefficients: array of float (of length the number of modes)
+        The sparsity coefficients on each factor.
         If set to None, the algorithm is computed without sparsity
         Default: [],
     fixed_modes: array of integers (between 0 and the number of modes)
@@ -681,7 +681,27 @@ class CPNN_Hals(DecompositionMixin):
         self.errors_ = errors
         return self.decomposition_
     def cp_to_tensor(self):
-        """
+        """Turns the Khatri-product of matrices into a full tensor
+
+            ``factor_matrices = [|U_1, ... U_n|]`` becomes
+            a tensor shape ``(U[1].shape[0], U[2].shape[0], ... U[-1].shape[0])``
+
+        Parameters
+        ----------
+        cp_tensor : CPTensor = (weight, factors)
+            factors is a list of factor matrices, all with the same number of columns
+            i.e. for all matrix U in factor_matrices:
+            U has shape ``(s_i, R)``, where R is fixed and s_i varies with i
+
+        mask : ndarray a mask to be applied to the final tensor. It should be
+            broadcastable to the shape of the final tensor, that is
+            ``(U[1].shape[0], ... U[-1].shape[0])``.
+
+        Returns
+        -------
+        ndarray
+            full tensor of shape ``(U[1].shape[0], ... U[-1].shape[0])``
+
         """
         return tl.cp_to_tensor(self.decomposition_)
 

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -398,14 +398,13 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
                              maxiter=100,sparsity_coefficient=sparsity_coefficients[mode])[0])
             elif hals=='exact':
                 factors[mode] = tl.transpose(
-                    hals_nnls_exact(tl.transpose(mttkrp), pseude_inverse, tl.transpose(factors[mode]),
+                    hals_nnls_exact(tl.transpose(mttkrp), pseudo_inverse, tl.transpose(factors[mode]),
                                      maxiter=5000)[0])
-            factors_norm = tl.sum(tl.sum(pseude_inverse * tl.dot(tl.conj(tl.transpose(factors[mode])), factors[mode])))
-            rec_error = norm_tensor ** 2 + factors_norm - 2 * tl.dot(tl.tensor_to_vec(factors[mode]),
-                                                                     tl.tensor_to_vec(mttkrp))
-            rec_error = rec_error ** (1 / 2) / norm_tensor
-
+ 
         if tol:
+            factors_norm = cp_norm((weights, factors))
+            iprod = tl.sum(tl.sum(mttkrp*factor, axis=0)*weights)
+            rec_error = tl.sqrt(tl.abs(norm_tensor**2 + factors_norm**2 - 2*iprod)) / norm_tensor
             rec_errors.append(rec_error)
 
             if iteration > 1:

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -357,8 +357,8 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
 
     nb_modes = len(tensor.shape)
     if sparsity_coefficients == None or len(sparsity_coefficients) != nb_modes:
-        print(
-            "Irrelevant number of sparsity coefficient (different from the number of modes), they have been set to None.")
+        #print(
+        #    "Irrelevant number of sparsity coefficient (different from the number of modes), they have been set to None.")
         sparsity_coefficients = [None for i in range(nb_modes)]
     if fixed_modes == None:
         fixed_modes = []

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -353,8 +353,8 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
     norm_tensor = tl.norm(tensor, 2)
 
     n_modes = tl.ndim(tensor)
-    if sparsity_coefficients == None or len(sparsity_coefficients) != n_modes:
-        sparsity_coefficients = [None for i in range(n_modes)]
+    if sparsity_coefficients is None or isinstance(sparsity_coefficients, float):
+        sparsity_coefficients = [sparsity_coefficients] * n_modes
 
     if fixed_modes is None:
         fixed_modes = []

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -643,6 +643,7 @@ class CP_NN_HALS(DecompositionMixin):
                  sparsity=None,
                  exact=False,
                  mask=None, svd_mask_repeats=5,
+                 return_errors=False,
                  cvg_criterion='abs_rec_error',
                  random_state=None,
                  verbose=0):
@@ -656,6 +657,7 @@ class CP_NN_HALS(DecompositionMixin):
         self.normalize_factors = normalize_factors
         self.mask = mask
         self.svd_mask_repeats = svd_mask_repeats
+        self.return_errors=return_errors
         self.cvg_criterion = cvg_criterion
         self.random_state = random_state
         self.verbose = verbose
@@ -681,7 +683,7 @@ class CP_NN_HALS(DecompositionMixin):
                                                       svd=self.svd,
                                                       exact=self.exact,
                                                       verbose=self.verbose,
-                                                      return_errors=True)
+                                                      return_errors=self.return_errors)
 
         self.decomposition_ = cp_tensor
         self.errors_ = errors

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -355,7 +355,6 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
 
     norm_tensor = tl.norm(tensor, 2)
 
-    # set init if problem
     nb_modes = len(tensor.shape)
     if sparsity_coefficients == None or len(sparsity_coefficients) != nb_modes:
         print(
@@ -373,18 +372,17 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
 
     # initialisation - declare local varaibles
     rec_errors = []
-    toc = []
 
-    # Iterate over one step of NTF
+    # Iteratation
     for iteration in range(n_iter_max):
         # One pass of least squares on each updated mode
         for mode in modes_list:
 
             # Computing Hadamard of cross-products
-            pseude_inverse = tl.tensor(tl.ones((rank, rank)), **tl.context(tensor))
+            pseudo_inverse = tl.tensor(tl.ones((rank, rank)), **tl.context(tensor))
             for i, factor in enumerate(factors):
                 if i != mode:
-                    pseude_inverse *= tl.dot(tl.transpose(factor), factor)
+                    pseudo_inverse = pseudo_inverse*tl.dot(tl.transpose(factor), factor)
 
             if not iteration and weights is not None:
                 # Take into account init weights
@@ -396,7 +394,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
             # Call the hals resolution with nnls, optimizing the current mode
             if hals=='approx':
                 factors[mode] = tl.transpose(
-                      hals_nnls_approx(tl.transpose(mttkrp), pseude_inverse, tl.transpose(factors[mode]),
+                      hals_nnls_approx(tl.transpose(mttkrp), pseudo_inverse, tl.transpose(factors[mode]),
                              maxiter=100,sparsity_coefficient=sparsity_coefficients[mode])[0])
             elif hals=='exact':
                 factors[mode] = tl.transpose(

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -336,8 +336,6 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
             element `i` is of shape ``(tensor.shape[i], rank)``
     errors: list
         A list of reconstruction errors at each iteration of the algorithm.
-    toc: list
-        A list with accumulated time at each iterations
 
     References
     ----------
@@ -422,9 +420,6 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
         return cp_tensor, rec_errors
     else:
         return cp_tensor
-
-
-
 
 
 class CPNN(DecompositionMixin):

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -295,7 +295,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
                               sparsity_coefficients=[], fixed_modes=[],hals='approx',
                               verbose=False, return_errors=False):
     """
-    Non-negative CP decomposition
+    Non-negative CP decomposition via HALS
 
     Uses HALS which updates each factor columnwise, fixing every other columns, see [1]_
 

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -360,7 +360,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
         #print(
         #    "Irrelevant number of sparsity coefficient (different from the number of modes), they have been set to None.")
         sparsity_coefficients = [None for i in range(nb_modes)]
-    if fixed_modes == None:
+    if fixed_modes is None:
         fixed_modes = []
 
     # Avoiding errors
@@ -368,7 +368,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
         sparsity_coefficients[fixed_value] = None
 
     # Generating the mode update sequence
-    modes_list = [mode for mode in range(tl.ndim(tensor)) if mode not in fixed_modes]
+    modes = [mode for mode in range(n_modes) if mode not in fixed_modes]
 
     # initialisation - declare local varaibles
     rec_errors = []
@@ -552,6 +552,7 @@ class CPNN(DecompositionMixin):
         self.decomposition_ = cp_tensor
         self.errors_ = errors
         return self.decomposition_
+
     def __repr__(self):
         return f'Rank-{self.rank} Non-Negative CP decomposition.'
 
@@ -680,6 +681,7 @@ class CPNN_Hals(DecompositionMixin):
         self.decomposition_ = cp_tensor
         self.errors_ = errors
         return self.decomposition_
+
     def cp_to_tensor(self):
         """Turns the Khatri-product of matrices into a full tensor
 

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -5,7 +5,7 @@ import tensorly as tl
 from ._base_decomposition import DecompositionMixin
 from ..random import random_cp
 from ..base import unfold
-from ..tenalg.proximal import soft_thresholding
+from ..tenalg.proximal import soft_thresholding,hals_nnls_acc
 from ..cp_tensor import (cp_to_tensor, CPTensor,
                          unfolding_dot_khatri_rao, cp_norm,
                          cp_normalize, validate_cp_rank)

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -355,7 +355,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
 
     norm_tensor = tl.norm(tensor, 2)
 
-    nb_modes = len(tensor.shape)
+    n_modes = tl.ndim(tensor)
     if sparsity_coefficients == None or len(sparsity_coefficients) != nb_modes:
         #print(
         #    "Irrelevant number of sparsity coefficient (different from the number of modes), they have been set to None.")

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -15,6 +15,9 @@ from ..cp_tensor import (cp_to_tensor, CPTensor,
 #          Sam Schneider <samjohnschneider@gmail.com>
 #          Aaron Meurer <asmeurer@gmail.com>
 #          Aaron Meyer <tensorly@ameyer.me>
+#          Jeremy Cohen <jeremy.cohen@irisa.fr>
+#          Axel Marmoret <axel.marmoret@inria.fr>
+#          Caglayan TUna <caglayantun@gmail.com>
 
 # License: BSD 3 clause
 
@@ -316,10 +319,12 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
     sparsity_coefficients: array of float (of length the number of modes)
         The sparsity coefficients on each factor.
         If set to None, the algorithm is computed without sparsity
-        Default: [],
+        Default: None,
     fixed_modes: array of integers (between 0 and the number of modes)
         Has to be set not to update a factor, 0 and 1 for U and V respectively
-        Default: []
+        Default: None
+    exact: If it is True, the algorithm gives a results with high precision but it needs high computational cost. If it is False, the algorithm gives an approximate solution
+        Default: False
     verbose: boolean
         Indicates whether the algorithm prints the successive
         reconstruction errors or not
@@ -328,6 +333,11 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
         Indicates whether the algorithm should return all reconstruction errors
         and computation time of each iteration or not
         Default: False
+    cvg_criterion : {'abs_rec_error', 'rec_error'}, optional
+       Stopping criterion for ALS, works if `tol` is not None. 
+       If 'rec_error',  ALS stops at current iteration if ``(previous rec_error - current rec_error) < tol``.
+       If 'abs_rec_error', ALS terminates when `|previous rec_error - current rec_error| < tol`.
+    sparsity : float or int
 
     Returns
     -------
@@ -422,7 +432,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
         return cp_tensor
 
 
-class CPNN(DecompositionMixin):
+class CP_NN(DecompositionMixin):
     """Non-Negative Candecomp-Parafac decomposition via Alternating-Least Square
 
         Computes a rank-`rank` decomposition of `tensor` [1]_ such that,
@@ -553,7 +563,7 @@ class CPNN(DecompositionMixin):
 
 
 
-class CPNN_HALS(DecompositionMixin):
+class CP_NN_HALS(DecompositionMixin):
     """Non-Negative Candecomp-Parafac decomposition via Alternating-Least Square
 
         Computes a rank-`rank` decomposition of `tensor` [1]_ such that,

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -162,7 +162,7 @@ def test_non_negative_parafac_hals():
     """
     tol_norm_2 = 10e-1
     tol_max_abs = 1
-    rng = check_random_state(1234)
+    rng = tl.check_random_state(1234)
     tensor = tl.tensor(rng.random_sample((3, 3, 3))+1)
     res = parafac(tensor, rank=3, n_iter_max=120)
     nn_res = non_negative_parafac_hals(tensor, rank=3, n_iter_max=100, tol=10e-4, init='svd', verbose=0)

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -5,7 +5,7 @@ import tensorly as tl
 from .._cp import (
     parafac, initialize_cp,
     sample_khatri_rao, randomised_parafac)
-from .._nn_cp import non_negative_parafac
+from .._nn_cp import non_negative_parafac, non_negative_parafac_hals
 from ...cp_tensor import cp_to_tensor
 from ...random import random_cp
 from ...tenalg import khatri_rao
@@ -156,6 +156,55 @@ def test_non_negative_parafac():
             'abs norm of difference between svd and random init too high')
 
 
+def test_non_negative_parafac_hals():
+    """Test for non-negative PARAFAC HALS
+    TODO: more rigorous test
+    """
+    tol_norm_2 = 10e-1
+    tol_max_abs = 1
+    rng = check_random_state(1234)
+    tensor = tl.tensor(rng.random_sample((3, 3, 3))+1)
+    res = parafac(tensor, rank=3, n_iter_max=120)
+    nn_res = non_negative_parafac_hals(tensor, rank=3, n_iter_max=100, tol=10e-4, init='svd', verbose=0)
+
+    # Make sure all components are positive
+    _, nn_factors = nn_res
+    for factor in nn_factors:
+        assert_(tl.all(factor >= 0))
+
+    reconstructed_tensor = tl.cp_to_tensor(res)
+    nn_reconstructed_tensor = tl.cp_to_tensor(nn_res)
+    error = tl.norm(reconstructed_tensor - nn_reconstructed_tensor, 2)
+    error /= tl.norm(reconstructed_tensor, 2)
+    assert_(error < tol_norm_2,
+            'norm 2 of reconstruction higher than tol')
+
+    # Test the max abs difference between the reconstruction and the tensor
+    assert_(tl.max(tl.abs(reconstructed_tensor - nn_reconstructed_tensor)) < tol_max_abs,
+            'abs norm of reconstruction error higher than tol')
+
+    # Test fixing mode 0 or 1 with given init
+    fixed_tensor = random_cp((3, 3, 3), rank=2)
+    for factor in fixed_tensor[1]:
+        factor = tl.abs(factor)
+    rec_svd_fixed_mode_0 = non_negative_parafac_hals(tensor, rank=2, n_iter_max=2, init=fixed_tensor, fixed_modes=[0])
+    rec_svd_fixed_mode_1 = non_negative_parafac_hals(tensor, rank=2, n_iter_max=2, init=fixed_tensor, fixed_modes=[1])
+    # Check if modified after 2 iterations
+    assert_array_equal(rec_svd_fixed_mode_0.factors[0], fixed_tensor.factors[0], err_msg='Fixed mode 0 was modified in candecomp_parafac')
+    assert_array_equal(rec_svd_fixed_mode_1.factors[1], fixed_tensor.factors[1], err_msg='Fixed mode 1 was modified in candecomp_parafac')
+
+    res_svd = non_negative_parafac_hals(tensor, rank=3, n_iter_max=100,
+                                       tol=10e-4, init='svd')
+    res_random = non_negative_parafac_hals(tensor, rank=3, n_iter_max=100, tol=10e-4,
+                                          init='random', verbose=0)
+    rec_svd = tl.cp_to_tensor(res_svd)
+    rec_random = tl.cp_to_tensor(res_random)
+    error = tl.norm(rec_svd - rec_random, 2)
+    error /= tl.norm(rec_svd, 2)
+    assert_(error < tol_norm_2,
+            'norm 2 of difference between svd and random init too high')
+    assert_(tl.max(tl.abs(rec_svd - rec_random)) < tol_max_abs,
+            'abs norm of difference between svd and random init too high')
 @pytest.mark.xfail(tl.get_backend() == 'tensorflow', reason='Fails on tensorflow')
 def test_sample_khatri_rao():
     """ Test for sample_khatri_rao

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -198,7 +198,7 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
     else:
         V = in_V
 
-    rho = 100000
+    rho = 1
     eps0 = 0
     cnt = 1
     eps = 1
@@ -355,7 +355,7 @@ def hals_nnls_exact(UtM, UtU, in_V, maxiter,delta=10e-12,sparsity_coefficient=No
     eps0 = 0
     cnt = 1
     eps = 1
-    delta=10e-12
+
     while eps >= delta * eps0 and cnt <= maxiter:
         nodelta = 0
         for k in range(r):

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -90,4 +90,170 @@ def procrustes(matrix):
     """
     U, _, V = tl.partial_svd(matrix, n_eigenvecs=min(matrix.shape))
     return tl.dot(U, V)
+def hals_nnls_acc(UtM, UtU, in_V, maxiter=500,
+                  sparsity_coefficient=None, normalize = False,nonzero=False):
+    ## Author : Axel Marmoret, based on Jeremy Cohen version's of Nicolas Gillis Matlab's code for HALS
+
+    """
+    =================================
+    Non Negative Least Squares (NNLS)
+    =================================
+
+    Computes an approximate solution of a nonnegative least
+    squares problem (NNLS) with an exact block-coordinate descent scheme.
+    M is m by n, U is m by r, V is r by n.
+    All matrices are nonnegative componentwise.
+
+    The NNLS unconstrained problem, as defined in [1], solve the following problem:
+
+            min_{V >= 0} ||M-UV||_F^2
+
+    The matrix V is updated linewise.
+
+    The update rule of the k-th line of V (V[k,:]) for this resolution is:
+
+            V[k,:]_(j+1) = V[k,:]_(j) + (UtM[k,:] - UtU[k,:] V_(j))/UtU[k,k]
+
+    with j the update iteration.
+
+    This problem can also be defined by adding a sparsity coefficient,
+    enhancing sparsity in the solution [2]. The problem thus becomes:
+
+            min_{V >= 0} ||M-UV||_F^2 + 2*sparsity_coefficient*(\sum\limits_{j = 0}^{r}||V[k,:]||_1)
+
+    NB: 2*sp for uniformization in the derivative
+
+    In this sparse version, the update rule for V[k,:] becomes:
+
+            V[k,:]_(j+1) = V[k,:]_(j) + (UtM[k,:] - UtU[k,:] V_(j) - sparsity_coefficient)/UtU[k,k]
+
+    This algorithm is defined in [1], as an accelerated version of the HALS algorithm.
+
+    It features two accelerations: an early stop stopping criterion, and a
+    complexity averaging between precomputations and loops, so as to use large
+    precomputations several times.
+
+    This function is made for being used repetively inside an
+    outer-loop alternating algorithm, for instance for computing nonnegative
+    matrix Factorization or tensor factorization.
+
+    Parameters
+    ----------
+    UtM: r-by-n array
+        Pre-computed product of the transposed of U and M, used in the update rule
+    UtU: r-by-r array
+        Pre-computed product of the transposed of U and U, used in the update rule
+    in_V: r-by-n initialization matrix (mutable)
+        Initialized V array
+        By default, is initialized with one non-zero entry per column
+        corresponding to the closest column of U of the corresponding column of M.
+    maxiter: Postivie integer
+        Upper bound on the number of iterations
+        Default: 500
+    alpha: Positive float
+        Ratio between outer computations and inner loops, typically set to 0.5 or 1.
+        Default: 0.5
+    delta : float in [0,1]
+        early stop criterion, while err_k > delta*err_0. Set small for
+        almost exact nnls solution, or larger (e.g. 1e-2) for inner loops
+        of a PARAFAC computation.
+        Default: 0.01
+    sparsity_coefficient: float or None
+        The coefficient controling the sparisty level in the objective function.
+        If set to None, the problem is solved unconstrained.
+        Default: None
+    nonzero: boolean
+        True if the lines of the V matrix can't be zero,
+        False if they can be zero
+        Default: False
+
+    Returns
+    -------
+    V: array
+        a r-by-n nonnegative matrix \approx argmin_{V >= 0} ||M-UV||_F^2
+    eps: float
+        number of loops authorized by the error stop criterion
+    cnt: integer
+        final number of update iteration performed
+    rho: float
+        number of loops authorized by the time stop criterion
+
+    References
+    ----------
+    [1]: N. Gillis and F. Glineur, Accelerated Multiplicative Updates and
+    Hierarchical ALS Algorithms for Nonnegative Matrix Factorization,
+    Neural Computation 24 (4): 1085-1105, 2012.
+
+    [2] J. Eggert, and E. Korner. "Sparse coding and NMF."
+    2004 IEEE International Joint Conference on Neural Networks
+    (IEEE Cat. No. 04CH37541). Vol. 4. IEEE, 2004.
+
+    """
+
+    r, n = tl.shape(UtM)
+    if not in_V.size:  # checks if V is empty
+        V = tl.solve(UtU, UtM)  # Least squares np.linalg.linalg.solve=> tl.solve
+
+        V[V < 0] = 0
+        # Scaling
+        scale = tl.sum(UtM * V) / tl.sum(
+            UtU * tl.dot(V, tl.transpose(V)))
+        V = tl.dot(scale, V)
+    else:
+        V = in_V.copy()
+
+    rho = 100000
+    eps0 = 0
+    cnt = 1
+    eps = 1
+    delta=0.01
+    alpha=0.5
+    # Start timer
+    tic = time.time()
+    while eps >= delta * eps0 and cnt <= 1 + alpha * rho and cnt <= maxiter:
+        nodelta = 0
+        for k in range(r):
+
+            if UtU[k, k] != 0:
+                if sparsity_coefficient != None: # Modifying the objective function for sparsification
+
+                    deltaV = tl.max([(UtM[k, :] - UtU[k, :] @ V - sparsity_coefficient * tl.ones(n)) / UtU[k, k],
+                                        -V[k, :]],axis=0)  # np.maximum => tl.max
+                    V[k, :] = V[k, :] + deltaV
+                else:  # without sparsity
+                    deltaV = tl.max([(UtM[k, :] - tl.dot(UtU[k, :], V)) / UtU[k, k],
+                                        -V[k, :]],axis=0)  # Element wise maximum -> good idea ?
+
+                    V[k, :] = V[k, :] + deltaV
+
+                nodelta = nodelta + tl.dot(deltaV, tl.transpose(deltaV))
+
+                # Safety procedure, if columns aren't allow to be zero
+                if nonzero and (V[k, :] == 0).all():
+                    V[k, :] = 1e-16 * tl.max(V)
+
+            elif nonzero:
+                raise ValueError("Column " + str(k) + " of U is zero with nonzero condition")
+
+            if normalize:
+                norm = tl.norm(V[k,:])
+                if norm != 0:
+                    V[k,:] /= norm
+                else:
+                    sqrt_n = 1/n ** (1/2)
+                    V[k,:] = [sqrt_n for i in range(n)]
+        if cnt == 1:
+            eps0 = nodelta
+            # End timer for one iteration
+            #btime = max(time.time() - tic, 10e-7) # Avoid division by 0
+            #if atime:  # atime is provided
+                # Number of loops authorized
+            #    rho = atime/btime
+        rho_up=np.count_nonzero(V)+tl.shape(V)[1]*r
+        rho_down=tl.shape(V)[0]*r+tl.shape(V)[0]
+        rho=1+(rho_up/rho_down)
+        eps = nodelta
+        cnt += 1
+
+    return V, eps, cnt, rho
 

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -208,8 +208,8 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
         nodelta = 0
         for k in range(r):
 
-            if UtU[k, k] != 0:
-                if sparsity_coefficient != None: # Modifying the objective function for sparsification
+            if UtU[k, k]:
+                if sparsity_coefficient is not None: # Modifying the objective function for sparsification
                     if tl.get_backend() == 'pytorch':
                         import torch
                         deltaV = torch.maximum((UtM[k, :] - UtU[k, :] @ V - sparsity_coefficient * tl.ones(n)) / UtU[k, k],
@@ -267,7 +267,6 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
 
     return V, eps, cnt, rho
 def hals_nnls_exact(UtM, UtU, in_V, maxiter,delta=10e-12,sparsity_coefficient=None):
-
     """
     =================================
     Non Negative Least Squares (NNLS)

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -188,7 +188,7 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
 
     r, n = tl.shape(UtM)
     if not in_V.size:  # checks if V is empty
-        V = tl.solve(UtU, UtM)  # Least squares np.linalg.linalg.solve=> tl.solve
+        V = tl.solve(UtU, UtM)
 
         V[V < 0] = 0
         # Scaling
@@ -322,7 +322,7 @@ def hals_nnls_exact(UtM, UtU, in_V, maxiter,delta=10e-12,sparsity_coefficient=No
 
     r, n = tl.shape(UtM)
     if not in_V.size:  # checks if V is empty
-        V = tl.solve(UtU, UtM)  # Least squares np.linalg.linalg.solve=> tl.solve
+        V = tl.solve(UtU, UtM)  
 
         V[V < 0] = 0
         # Scaling

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -207,10 +207,8 @@ def hals_nnls_acc(UtM, UtU, in_V, maxiter=500,
     cnt = 1
     eps = 1
     delta=0.01
-    alpha=0.5
-    # Start timer
-    tic = time.time()
-    while eps >= delta * eps0 and cnt <= 1 + alpha * rho and cnt <= maxiter:
+
+    while eps >= delta * eps0 and cnt <= 1 + 0.5* rho and cnt <= maxiter:
         nodelta = 0
         for k in range(r):
 
@@ -244,12 +242,8 @@ def hals_nnls_acc(UtM, UtU, in_V, maxiter=500,
                     V[k,:] = [sqrt_n for i in range(n)]
         if cnt == 1:
             eps0 = nodelta
-            # End timer for one iteration
-            #btime = max(time.time() - tic, 10e-7) # Avoid division by 0
-            #if atime:  # atime is provided
-                # Number of loops authorized
-            #    rho = atime/btime
-        rho_up=np.count_nonzero(V)+tl.shape(V)[1]*r
+
+        rho_up=tl.shape(V)[0]*tl.shape(V)[1]+tl.shape(V)[1]*r
         rho_down=tl.shape(V)[0]*r+tl.shape(V)[0]
         rho=1+(rho_up/rho_down)
         eps = nodelta

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -151,7 +151,7 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
         number of loops authorized by the error stop criterion
     iteration: integer
         final number of update iteration performed
-    cvg_criterion: float
+    complexity_ratio: float
         number of loops authorized by the stop criterion
 
     Notes
@@ -239,12 +239,12 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
 
         numerator = tl.shape(V)[0]*tl.shape(V)[1]+tl.shape(V)[1]*rank
         denominator = tl.shape(V)[0]*rank+tl.shape(V)[0]
-        cvg_criterion = 1+(numerator/denominator)
+        complexity_ratio = 1+(numerator/denominator)
         if exact:
             if rec_error < tol * rec_error0:
                 break
         else:
-            if rec_error < tol * rec_error0 or iteration > 1 + 0.5 * cvg_criterion:
+            if rec_error < tol * rec_error0 or iteration > 1 + 0.5 * complexity_ratio:
                 break
 
-    return V, rec_error, iteration, cvg_criterion
+    return V, rec_error, iteration, complexity_ratio

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -243,10 +243,10 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
                 nodelta = nodelta + tl.dot(deltaV, tl.transpose(deltaV))
 
                 # Safety procedure, if columns aren't allow to be zero
-                if nonzero and (V[k, :] == 0).all():
+                if nonzero_row and (V[k, :] == 0).all():
                     V[k, :] = 1e-16 * tl.max(V)
 
-            elif nonzero:
+            elif nonzero_row:
                 raise ValueError("Column " + str(k) + " of U is zero with nonzero condition")
 
             if normalize:

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -215,10 +215,20 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
                                         -V[k, :]],axis=0)
                     V[k, :] = V[k, :] + deltaV
                 else:  # without sparsity
-                    deltaV = tl.max([(UtM[k, :] - tl.dot(UtU[k, :], V)) / UtU[k, k],
-                                        -V[k, :]],axis=0)
 
-                    V[k, :] = V[k, :] + deltaV
+                    if tl.get_backend() == 'pytorch':
+                        import torch
+                        deltaV = torch.maximum((UtM[k, :] - tl.dot(UtU[k, :], V)) / UtU[k, k],
+                                         -V[k, :])
+                    else:
+                        deltaV = tl.max([(UtM[k, :] - tl.dot(UtU[k, :], V)) / UtU[k, k],
+                                         -V[k, :]], axis=0)
+                    if tl.get_backend()=='tensorflow':
+                        import tensorflow as tf
+                        V=tf.Variable(V,dtype='float')
+                        V[k, :].assign(V[k, :] + deltaV)
+                    else:
+                        V[k, :] = V[k, :] + deltaV
 
                 nodelta = nodelta + tl.dot(deltaV, tl.transpose(deltaV))
 

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -91,7 +91,7 @@ def procrustes(matrix):
     U, _, V = tl.partial_svd(matrix, n_eigenvecs=min(matrix.shape))
     return tl.dot(U, V)
 def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
-                  sparsity_coefficient=None, normalize = False,nonzero=False):
+                  sparsity_coefficient=None, normalize = False,nonzero_row=False):
 
     """
     =================================
@@ -158,7 +158,7 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
         The coefficient controling the sparisty level in the objective function.
         If set to None, the problem is solved unconstrained.
         Default: None
-    nonzero: boolean
+    nonzero_row: boolean
         True if the lines of the V matrix can't be zero,
         False if they can be zero
         Default: False
@@ -403,5 +403,3 @@ def hals_nnls_exact(UtM, UtU, in_V, maxiter,delta=10e-12,sparsity_coefficient=No
         cnt += 1
 
     return V, eps, cnt
-
-

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -158,7 +158,7 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
     -----
     We solve the following problem :math:`\\min_{V >= 0} ||M-UV||_F^2`
 
-    The matrix V is updated linewise. The update rule for this resolution is:
+    The matrix V is updated linewise. The update rule for this resolution is::
 
     .. math::
         \\begin{equation}
@@ -168,11 +168,11 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
     with j the update iteration.
 
     This problem can also be defined by adding a sparsity coefficient,
-    enhancing sparsity in the solution [2]. In this sparse version, the update rule becomes:
+    enhancing sparsity in the solution [2]. In this sparse version, the update rule becomes::
 
     .. math::
         \\begin{equation}
-            V[k,:]_(j+1) = V[k,:]_(j) + (UtM[k,:] - UtU[k,:] V_(j) - sparsity_coefficient)/UtU[k,k]
+            V[k,:]_(j+1) = V[k,:]_(j) + (UtM[k,:] - UtU[k,:]\\times V_(j) - sparsity_coefficient)/UtU[k,k]
         \\end{equation}
 
     References
@@ -210,7 +210,7 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
 
                     deltaV = tl.max([(tl.dot(UtM[k, :] - UtU[k, :], V) - sparsity_coefficient)
                                     / UtU[k, k], -V[k, :]], axis=0)
-                    tl.index_update(V, tl.index[k, :], V[k, :] + deltaV)
+                    V = tl.index_update(V, tl.index[k, :], V[k, :] + deltaV)
 
                 else:  # without sparsity
 

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -214,8 +214,8 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
 
                 else:  # without sparsity
 
-                    deltaV = tl.where(UtM[k, :] - tl.dot(UtU[k, :], V) / UtU[k, k] > -V[k, :],
-                                      UtM[k, :] - tl.dot(UtU[k, :], V) / UtU[k, k], -V[k, :])
+                    deltaV = tl.where((UtM[k, :] - tl.dot(UtU[k, :], V)) / UtU[k, k] > -V[k, :],
+                                      (UtM[k, :] - tl.dot(UtU[k, :], V)) / UtU[k, k], -V[k, :])
                     V = tl.index_update(V, tl.index[k, :], V[k, :] + deltaV)
 
                 rec_error = rec_error + tl.dot(deltaV, tl.transpose(deltaV))

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -208,14 +208,14 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
             if UtU[k, k]:
                 if sparsity_coefficient is not None:  # Modifying the function for sparsification
 
-                    deltaV = tl.max([(tl.dot(UtM[k, :] - UtU[k, :], V) - sparsity_coefficient)
-                                    / UtU[k, k], -V[k, :]], axis=0)
+                    deltaV = tl.where((UtM[k, :] - tl.dot(UtU[k, :], V) - sparsity_coefficient) / UtU[k, k] > -V[k, :],
+                                      (UtM[k, :] - tl.dot(UtU[k, :], V) - sparsity_coefficient) / UtU[k, k], -V[k, :])
                     V = tl.index_update(V, tl.index[k, :], V[k, :] + deltaV)
 
                 else:  # without sparsity
 
-                    deltaV = tl.max([(UtM[k, :] - tl.dot(UtU[k, :], V)) / UtU[k, k],
-                                    -V[k, :]], axis=0)
+                    deltaV = tl.where(UtM[k, :] - tl.dot(UtU[k, :], V) / UtU[k, k] > -V[k, :],
+                                      UtM[k, :] - tl.dot(UtU[k, :], V) / UtU[k, k], -V[k, :])
                     V = tl.index_update(V, tl.index[k, :], V[k, :] + deltaV)
 
                 rec_error = rec_error + tl.dot(deltaV, tl.transpose(deltaV))

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -283,7 +283,7 @@ def hals_nnls_exact(UtM, UtU, in_V, maxiter,delta=10e-12,sparsity_coefficient=No
 
     The matrix V is updated linewise.
 
-    The update rule of the k-th line of V (V[k,:]) for this resolution is:
+    The update rule of the k-th line of V (V[k,:]) for this resolution is::
 
             V[k,:]_(j+1) = V[k,:]_(j) + (UtM[k,:] - UtU[k,:] V_(j))/UtU[k,k]
 

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -1,6 +1,9 @@
 import tensorly as tl
 
 # Author: Jean Kossaifi
+#         Jeremy Cohen <jeremy.cohen@irisa.fr>
+#         Axel Marmoret <axel.marmoret@inria.fr>
+#         Caglayan TUna <caglayantun@gmail.com>
 
 # License: BSD 3 clause
 

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -187,7 +187,7 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
     """
 
     r, n = tl.shape(UtM)
-    if not in_V.size:  # checks if V is empty
+    if in_V is None:  # checks if V is empty
         V = tl.solve(UtU, UtM)
 
         V[V < 0] = 0
@@ -196,7 +196,7 @@ def hals_nnls_approx(UtM, UtU, in_V, maxiter=500,delta=10e-8,
             UtU * tl.dot(V, tl.transpose(V)))
         V = tl.dot(scale, V)
     else:
-        V = in_V.copy()
+        V = in_V
 
     rho = 100000
     eps0 = 0
@@ -322,7 +322,7 @@ def hals_nnls_exact(UtM, UtU, in_V, maxiter,delta=10e-12,sparsity_coefficient=No
 
     r, n = tl.shape(UtM)
     if not in_V.size:  # checks if V is empty
-        V = tl.solve(UtU, UtM)  
+        V = tl.solve(UtU, UtM)
 
         V[V < 0] = 0
         # Scaling

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -90,6 +90,8 @@ def procrustes(matrix):
     """
     U, _, V = tl.partial_svd(matrix, n_eigenvecs=min(matrix.shape))
     return tl.dot(U, V)
+
+
 def hals_nnls(UtM, UtU, V=None, n_iter_max=500,tol=10e-8,
                   sparsity_coefficient=None, normalize = False,nonzero_rows=False,exact=False):
 


### PR DESCRIPTION

# HALS for Tensorly
This pull request adds Hierarchical Alternating Least Square (HALS) algorithm and non-negative cp (NNCP) with HALS class. We adapted this code from  a matlab code (https://sites.google.com/site/nicolasgillis/) to tensorly library with @cohenjer.

# Motivation
First motivation is to have better NNCP algorithm in tensorly. In tensorly, NNCP uses multiplicative update (MU) algorithm. According to the literature (Gillis, 2012), HALS is more robust than MU. Our second motivation is to have sparse NNCP model using the same algorithm. 

We have tested our code with different publicly available image data (hyperspectral, multitemporal satellite images and a multispectral image) and we have obtained better RMSE and SSIM metric results with our HALS code compared to MU algorithm in tensorly. If it is necessary, we could share a notebook or we can submit another pull request to tensorly examples.

# Source Modification and Implementation Details
* **tenalg/proximal.py:** 

Here, we added *"hals_nnls_approx"* and *"hals_nnls_exact"* functions as nonnegative least square (nnls) algorithms. 

First one is an approximate solution. It has three stopping criteria and 500 iteration as default. One of the stopping criteria relies on *"delta"* value in the function which can be changed by the user. 

Second function is an exact solution. It has less stopping criteria (2) and more iteration compared to approximate solution. Although exact solution gives more precise result, process takes longer.


* **_nn_cp.py:**

Here, we added *"non_negative_parafac_hals"* function and *"CPNN_Hals"* class. 


First function calls nnls functions from proximal.py and it has an option to choose one of them. This option is 'approx' as default. There is a sparsity coefficient option in order to tackle with sparse data. To use this option, one should have a list of which length should equal to number of modes.

We have created a new class *"CPNN_Hals"* which is very similar to existing *"CPNN"* class in this file. Our class includes *"non_negative_parafac_hals"* function as a difference. Additionally, we have added *"cp_to_tensor"* function to this class in order to reconstruct tensor from extracted factors. For instance, this class can be used as:

```python
nncp=CPNN_Hals(rank=rank,init=init)
cptensor=nncp.fit_transform(tensor)
cp_reconstruction_hals = nncp.cp_to_tensor() 
``` 



* **test_cp.py:**

Lastly, we have added a test function *"test_non_negative_parafac_hals"* for *"non_negative_parafac_hals"* function. Simply, we have copied *"test_non_negative_parafac"* and changed related function. We have tested our function with this test function as well.

# Possible Improvements
At the moment, this code works with numpy, pytorch and tensorflow backends. However, in order to use our code with pytorch and tensorflow backends, we had to add some lines to nnls functions (such as lines 214 to 226 in proximal.py) which can be improved in the future. Here, we had to use *torch.maximum* function because we wanted to implement *tl.max* with other backends in order to be consistent with tensorly. However, pytorch backend doesn't allow to use *'axis'* option in *tl.max*. 

Other problem is item assignment with tensorflow. We need to assign values to each row V[k,:] in hals algorithm, however tensorflow doesn't allow us to implement such an assignment. Therefore, we have used 'tf. Variable' and '.assign' commands with tensorflow backend. 

Besides, code has failed with Mxnet backend in the same item assignment part and we haven't tried our code with other backends (JAX, Cupy) yet.

# Reference

1- Gillis, N., & Glineur, F. (2012). Accelerated multiplicative updates and hierarchical ALS algorithms for nonnegative matrix factorization. Neural computation, 24(4), 1085-1105.  [Link](https://www.mitpressjournals.org/doi/abs/10.1162/NECO_a_00256)
