### PR TITLE
Sign correction method for CP tensors

### DIFF
--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -334,12 +334,16 @@ def cp_fix_sign(cp_tensor, mode=0, func=None):
         func = T.mean
 
     for jj in range(0, len(factors)):
+        # Skip the target mode
+        if jj == mode:
+            continue
+
         # Calculate the sign of the current factor in each component
         means = T.sign(func(factors[jj], axis=0))
 
         # Update both the current and receiving factor
-        factors[mode] *= means[np.newaxis, :]
-        factors[jj] *= means[np.newaxis, :]
+        factors[mode] = factors[mode]*means[np.newaxis, :]
+        factors[jj] = factors[jj]*means[np.newaxis, :]
 
     return CPTensor((weights, factors))
 

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -339,11 +339,11 @@ def cp_fix_sign(cp_tensor, mode=0, func=None):
             continue
 
         # Calculate the sign of the current factor in each component
-        means = T.sign(func(factors[jj], axis=0))
+        column_signs = T.sign(func(factors[jj], axis=0))
 
         # Update both the current and receiving factor
-        factors[mode] = factors[mode]*means[np.newaxis, :]
-        factors[jj] = factors[jj]*means[np.newaxis, :]
+        factors[mode] = factors[mode]*column_signs[np.newaxis, :]
+        factors[jj] = factors[jj]*column_signs[np.newaxis, :]
 
     return CPTensor((weights, factors))
 

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -345,6 +345,11 @@ def cp_flip_sign(cp_tensor, mode=0, func=None):
         factors[mode] = factors[mode]*column_signs[np.newaxis, :]
         factors[jj] = factors[jj]*column_signs[np.newaxis, :]
 
+    # Check the weight signs
+    weight_signs = T.sign(weights)
+    factors[mode] = factors[mode]*weight_signs[np.newaxis, :]
+    weights = T.abs(weights)
+
     return CPTensor((weights, factors))
 
 

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -300,7 +300,7 @@ def cp_normalize(cp_tensor):
     return CPTensor((weights, normalized_factors))
 
 
-def cp_fix_sign(cp_tensor, mode=0, func=None):
+def cp_flip_sign(cp_tensor, mode=0, func=None):
     """Returns cp_tensor with factors flipped to have positive signs.
     The sign of a given column is determined by `func`, which is the mean
     by default. Any negative signs are assigned to the mode indicated by `mode`.

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -43,6 +43,12 @@ def initialize_decomposition(tensor_slices, rank, init='random', svd='numpy_svd'
             raise ValueError(message)
         padded_tensor = _pad_by_zeros(tensor_slices)
         A = T.ones((padded_tensor.shape[0], rank), **context)
+
+        unfolded_mode_2 = unfold(padded_tensor, 2)
+        if T.shape(unfolded_mode_2)[0] < rank:
+            raise ValueError("Cannot perform SVD init if rank ({}) is greater than the number of columns in each tensor slice ({})".format(
+                    rank, T.shape(unfolded_mode_2)[0]
+        ))
         C = svd_fun(unfold(padded_tensor, 2), n_eigenvecs=rank)[0]
         B = T.eye(rank, **context)
         projections = _compute_projections(tensor_slices, (A, B, C), svd_fun)

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -43,12 +43,6 @@ def initialize_decomposition(tensor_slices, rank, init='random', svd='numpy_svd'
             raise ValueError(message)
         padded_tensor = _pad_by_zeros(tensor_slices)
         A = T.ones((padded_tensor.shape[0], rank), **context)
-
-        unfolded_mode_2 = unfold(padded_tensor, 2)
-        if T.shape(unfolded_mode_2)[0] < rank:
-            raise ValueError("Cannot perform SVD init if rank ({}) is greater than the number of columns in each tensor slice ({})".format(
-                    rank, T.shape(unfolded_mode_2)[0]
-        ))
         C = svd_fun(unfold(padded_tensor, 2), n_eigenvecs=rank)[0]
         B = T.eye(rank, **context)
         projections = _compute_projections(tensor_slices, (A, B, C), svd_fun)

--- a/tensorly/tests/test_cp_tensor.py
+++ b/tensorly/tests/test_cp_tensor.py
@@ -6,7 +6,7 @@ from ..cp_tensor import (cp_to_tensor, cp_to_unfolded,
                               cp_to_vec, _validate_cp_tensor,
                               cp_normalize, CPTensor,
                               cp_mode_dot, unfolding_dot_khatri_rao,
-                              cp_norm,
+                              cp_norm, cp_fix_sign,
                               _cp_n_param, validate_cp_rank)
 from ..base import unfold, tensor_to_vec
 from tensorly.random import check_random_state, random_cp
@@ -23,7 +23,20 @@ def test_cp_normalize():
     for f in factors:
         assert_array_almost_equal(tl.norm(f, axis=0), expected_norm)
     assert_array_almost_equal(cp_to_tensor((weights, factors)), cp_to_tensor(cp_tensor))
-    
+
+
+def test_cp_fix_sign():
+    shape = (3, 4, 5)
+    rank = 4
+    cp_tensor = random_cp(shape, rank)
+    weights, factors = cp_fix_sign(cp_tensor)
+
+    assert_(tl.all(tl.mean(factors[1], axis=0) > 0))
+    assert_(tl.all(tl.mean(factors[2], axis=0) > 0))
+    assert_equal(cp_tensor.rank, cp_tensor.rank)
+    assert_array_equal(cp_tensor.weights, weights)
+    assert_array_almost_equal(cp_to_tensor((weights, factors)), cp_to_tensor(cp_tensor))
+
 
 def test_validate_cp_tensor():
     rng = check_random_state(12345)

--- a/tensorly/tests/test_cp_tensor.py
+++ b/tensorly/tests/test_cp_tensor.py
@@ -6,7 +6,7 @@ from ..cp_tensor import (cp_to_tensor, cp_to_unfolded,
                               cp_to_vec, _validate_cp_tensor,
                               cp_normalize, CPTensor,
                               cp_mode_dot, unfolding_dot_khatri_rao,
-                              cp_norm, cp_fix_sign,
+                              cp_norm, cp_flip_sign,
                               _cp_n_param, validate_cp_rank)
 from ..base import unfold, tensor_to_vec
 from tensorly.random import check_random_state, random_cp
@@ -25,11 +25,11 @@ def test_cp_normalize():
     assert_array_almost_equal(cp_to_tensor((weights, factors)), cp_to_tensor(cp_tensor))
 
 
-def test_cp_fix_sign():
+def test_cp_flip_sign():
     shape = (3, 4, 5)
     rank = 4
     cp_tensor = random_cp(shape, rank)
-    weights, factors = cp_fix_sign(cp_tensor)
+    weights, factors = cp_flip_sign(cp_tensor)
 
     assert_(tl.all(tl.mean(factors[1], axis=0) > 0))
     assert_(tl.all(tl.mean(factors[2], axis=0) > 0))


### PR DESCRIPTION
`cp_fix_sign` fixes the sign indeterminacy of CP-formatted tensors by forcing all but one factor to be positive. I keep implementing this in different projects, and so figure it would be helpful to include.