### PR TITLE
Non-negative tucker with HALS

### DIFF
--- a/tensorly/decomposition/__init__.py
+++ b/tensorly/decomposition/__init__.py
@@ -5,7 +5,7 @@ tensor decomposition such as CANDECOMP-PARAFAC and Tucker.
 
 from ._cp import parafac, CP, RandomizedCP, randomised_parafac, sample_khatri_rao
 from ._nn_cp import non_negative_parafac, non_negative_parafac_hals, CP_NN_HALS, CP_NN
-from ._tucker import tucker, partial_tucker, non_negative_tucker, Tucker
+from ._tucker import tucker, partial_tucker, non_negative_tucker, non_negative_tucker_hals, Tucker
 from .robust_decomposition import robust_pca
 from ._tt import TensorTrain, tensor_train, tensor_train_matrix
 from ._parafac2 import parafac2, Parafac2

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -7,6 +7,7 @@ import tensorly.tenalg as tlg
 from ..tenalg.proximal import hals_nnls, active_set_nnls, fista
 from math import sqrt
 import warnings
+from tensorly.decomposition._nn_cp import make_svd_non_negative
 
 # Author: Jean Kossaifi <jean.kossaifi+tensors@gmail.com>
 

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -452,7 +452,7 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
             UtM = tl.transpose(MtU)
 
             # Call the hals resolution with nnls, optimizing the current mode
-            nn_factor, _, _, _ = hals_nnls(UtM, UtU, tl.transpose(factors[mode]),
+            nn_factor, _, _, _ = hals_nnls(UtM, UtU, tl.transpose(nn_factors[mode]),
                                            n_iter_max=100, sparsity_coefficient=sparsity_coefficients[mode],
                                            exact=exact)
             nn_factors[mode] = tl.transpose(nn_factor)
@@ -470,7 +470,6 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
             pseudo_inverse[-1] = tl.dot(tl.transpose(nn_factors[-1]), nn_factors[-1])
             AtB = tl.base.tensor_to_vec(tl.tenalg.mode_dot(tensor_cross, tl.transpose(nn_factors[modes[-1]]), modes[-1]))
             AtA = tl.tenalg.kronecker(pseudo_inverse)
-            nn_core = active_set_nnls(AtA, AtB, x=nn_core, n_iter_max=n_iter_max)
             vectorcore = active_set_nnls(AtA, AtB, x=nn_core, n_iter_max=n_iter_max)
             nn_core = tl.reshape(vectorcore, tl.shape(nn_core))
         

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -74,6 +74,7 @@ def initialize_tucker(tensor, rank, modes, random_state, init='svd', svd='numpy_
  
     return core, factors
     
+
 def partial_tucker(tensor, modes, rank=None, n_iter_max=100, init='svd', tol=10e-5,
                    svd='numpy_svd', random_state=None, verbose=False, mask=None):
     """Partial tucker decomposition via Higher Order Orthogonal Iteration (HOI)
@@ -419,26 +420,26 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
     -----
     Tucker decomposes a tensor into a core tensor and list of factors:
     .. math::
-        \begin{equation}
+        \\begin{equation}
             tensor = [| core; factors[0], ... ,factors[-1] |]
-        \end{equation}
+        \\end{equation}
 
     We solve the following problem for each factor:
     .. math::
-        \begin{equation}
-            \min_{tensor >= 0} ||tensor_[i] - factors[i]\times core_[i] \times (\prod_{i\neq j}(factors[j]))^T||^2
-        \end{equation}
+        \\begin{equation}
+            \\min_{tensor >= 0} ||tensor_[i] - factors[i]\\times core_[i] \\times (\\prod_{i\\neq j}(factors[j]))^T||^2
+        \\end{equation}
 
     If we define two variables such as:
     .. math::
-            U = core_[i] \times (\prod_{i\neq j}(factors[j]))^T \\
+            U = core_[i] \\times (\\prod_{i\\neq j}(factors[j]))^T \\
             M = tensor_[i]
 
     Gradient of the problem becomes:
         .. math::
-        \begin{equation}
-            \delta = -U^TM + factors[i] \times U^TU
-        \end{equation}
+        \\begin{equation}
+            \\delta = -U^TM + factors[i] \\times U^TU
+        \\end{equation}
 
     References
     ----------

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -296,9 +296,9 @@ def non_negative_tucker(tensor, rank, n_iter_max=10, init='svd', tol=10e-5,
 
     return TuckerTensor((nn_core, nn_factors))
     
-def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd",svd='numpy_svd', tol=1e-8,
-                              sparsity_coefficients=None, fixed_modes=None,random_state=None,
-                              verbose=False, normalize_factors=False, return_errors=False,exact=False):
+def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='numpy_svd', tol=1e-8,
+                             sparsity_coefficients=None, fixed_modes=None, random_state=None,
+                             verbose=False, normalize_factors=False, return_errors=False, exact=False):
     """
     Non-negative Tucker decomposition
 
@@ -349,20 +349,17 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd",svd='numpy
     Hierarchical ALS Algorithms for Nonnegative Matrix Factorization,
     Neural Computation 24 (4): 1085-1105, 2012.
     """
-    
-    rank = validate_tucker_rank(tl.shape(tensor), rank=rank) 
+    rank = validate_tucker_rank(tl.shape(tensor), rank=rank)
     n_modes = tl.ndim(tensor)
-            
-    if sparsity_coefficients == None or len(sparsity_coefficients) != n_modes:
+    if sparsity_coefficients is None or len(sparsity_coefficients) != n_modes:
         sparsity_coefficients = [sparsity_coefficients] * n_modes
 
-    if fixed_modes == None:
+    if fixed_modes is None:
         fixed_modes = []
 
     # Avoiding errors
     for fixed_value in fixed_modes:
         sparsity_coefficients[fixed_value] = None
-      
     # Generating the mode update sequence
     modes = [mode for mode in range(tl.ndim(tensor)) if mode not in fixed_modes]
 
@@ -372,7 +369,6 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd",svd='numpy
         message = 'Got svd={}. However, for the current backend ({}), the possible choices are {}'.format(
                 svd, tl.get_backend(), tl.SVD_FUNS)
         raise ValueError(message)
-            
     # Initialisation
     if init == 'svd':
         factors = []
@@ -417,14 +413,14 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd",svd='numpy
             # Call the hals resolution with nnls, optimizing the current mode
             nn_factors[mode] = tl.transpose(
                 hals_nnls(UtM, UtU, tl.transpose(nn_factors[mode]),
-                              n_iter_max=100, sparsity_coefficient=sparsity_coefficients[mode],exact=exact)[0])
+                          n_iter_max=100, sparsity_coefficient=sparsity_coefficients[mode],
+                          exact=exact)[0])
 
         # Adding the l1 norm value to the reconstruction error
         sparsity_error = 0
         for index, sparse in enumerate(sparsity_coefficients):
             if sparse:
                 sparsity_error += 2 * (sparse * tl.norm(factors[index], order=1))
-        
         # error computation
         rec_error = tl.norm(tensor - tucker_to_tensor((nn_core, nn_factors)), 2) / norm_tensor
         rec_errors.append(rec_error)
@@ -439,7 +435,7 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd",svd='numpy
                     print('converged in {} iterations.'.format(iteration))
                 break
 
-    tensor=TuckerTensor((core, factors))
+    tensor = TuckerTensor((core, factors))
     if return_errors:
         return tensor, rec_errors
     else:

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -1,7 +1,7 @@
 import tensorly as tl
 from ._base_decomposition import DecompositionMixin
 from ..base import unfold
-from ..tenalg import multi_mode_dot, mode_dot
+from ..tenalg import multi_mode_dot, mode_dot, hals_nnls	
 from ..tucker_tensor import tucker_to_tensor, TuckerTensor, validate_tucker_rank
 import tensorly.tenalg as tlg
 from math import sqrt
@@ -366,7 +366,7 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
         svd_fun = tl.SVD_FUNS[svd]
     except KeyError:
         message = 'Got svd={}. However, for the current backend ({}), the possible choices are {}'.format(
-                svd, tl.get_backend(), tl.SVD_FUNS)
+                  svd, tl.get_backend(), tl.SVD_FUNS)
         raise ValueError(message)
     # Initialisation
     if init == 'svd':

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -460,19 +460,19 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
             nn_factors[mode] = tl.transpose(nn_factor)
         # updating core
         if algorithm == 'fista':
-            pseudo_inverse[-1] = tl.dot(tl.transpose(nn_factors[-1]), nn_factors[-1])  # all_MtM
+            pseudo_inverse[-1] = tl.dot(tl.transpose(nn_factors[-1]), nn_factors[-1])
             core_estimation = multi_mode_dot(tensor, nn_factors, transpose=True)
             learning_rate = 1
             
             for MtM in pseudo_inverse:
                 learning_rate *= 1 / (tl.partial_svd(MtM)[1][0])
-            nn_core = fista(core_estimation, pseudo_inverse, x=nn_core, n_iter_max=n_iter_max, lr=learning_rate,
-                            sparsity_coef=sparsity_coefficients[-1])
+            nn_core = fista(core_estimation, pseudo_inverse, x=nn_core, n_iter_max=n_iter_max,
+                            sparsity_coef=sparsity_coefficients[-1], lr=learning_rate,)
         if algorithm == 'active_set':
             pseudo_inverse[-1] = tl.dot(tl.transpose(nn_factors[-1]), nn_factors[-1])
             core_estimation_vec = tl.base.tensor_to_vec(tl.tenalg.mode_dot(tensor_cross, tl.transpose(nn_factors[modes[-1]]), modes[-1]))
-            AtA = tl.tenalg.kronecker(pseudo_inverse)
-            vectorcore = active_set_nnls(AtA, core_estimation_vec, x=nn_core, n_iter_max=n_iter_max)
+            pseudo_inverse_kr = tl.tenalg.kronecker(pseudo_inverse)
+            vectorcore = active_set_nnls(pseudo_inverse_kr, core_estimation_vec, x=nn_core, n_iter_max=n_iter_max)
             nn_core = tl.reshape(vectorcore, tl.shape(nn_core))
         
         # Adding the l1 norm value to the reconstruction error

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -362,15 +362,16 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
     """
     Non-negative Tucker decomposition
 
-    Uses HALS which updates each factor columnwise, fixing every other columns, see [1]_
-
+    Uses HALS to update each factor columnwise and uses
+    fista or active set algorithm to update the core, see [1]_ 
+    
     Parameters
     ----------
     tensor : ndarray
     rank   : int
             number of components
     n_iter_max : int
-                 maximum number of iteration
+            maximum number of iteration
     init : {'svd', 'random'}, optional
     svd : str, default is 'numpy_svd'
         function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
@@ -379,9 +380,10 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
           the reconstruction error is less than the tolerance
         Default: 1e-8
     sparsity_coefficients : array of float (as much as the number of modes)
-        The sparsity coefficients on U and V respectively.
+        The sparsity coefficients are used for each factor
+        If algorithm is fista, last coefficient is used when updating core
         If set to None, the algorithm is computed without sparsity
-        Default: None,
+        Default: None
     fixed_modes : array of integers (between 0 and the number of modes)
         Has to be set not to update a factor, 0 and 1 for U and V respectively
         Default: None
@@ -393,8 +395,8 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
         Indicates whether the algorithm should return all reconstruction errors
         and computation time of each iteration or not
         Default: False
-    exact : If it is True, the algorithm gives a results with high precision but it needs high computational cost. 
-        If it is False, the algorithm gives an approximate solution
+    exact : If it is True, the HALS nnls subroutines give results with high precision but it needs high computational cost. 
+        If it is False, the algorithm gives an approximate solution.
         Default: False
     algorithm : {'fista', 'as'}
          Non negative least square solution to update the core. 
@@ -409,8 +411,8 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
 
     References
     ----------
-    [1] Tamara G Kolda and Brett W Bader. "Tensor decompositions and applications",
-        SIAM review 51.3 (2009), pp. 455{500.
+    .. [1] tl.G.Kolda and B.W.Bader, "Tensor Decompositions and Applications",
+       SIAM REVIEW, vol. 51, n. 3, pp. 455-500, 2009.
     """
     rank = validate_tucker_rank(tl.shape(tensor), rank=rank)
     n_modes = tl.ndim(tensor)

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -432,15 +432,27 @@ def non_negative_tucker_hals(tensor, rank, n_iter_max=100, init="svd", svd='nump
 
     If we define two variables such as:
     .. math::
-            U = core_[i] \\times (\\prod_{i\\neq j}(factors[j]))^T \\
+            U = core_[i] \\times (\\prod_{i\\neq j}(factors[j]\\times factors[j]^T)) \\
             M = tensor_[i]
 
     Gradient of the problem becomes:
-        .. math::
+    .. math::
         \\begin{equation}
             \\delta = -U^TM + factors[i] \\times U^TU
         \\end{equation}
 
+    In order to calculate UTU and UTM, we define two variables:
+    .. math::
+        \\begin{equation}
+            core_cross = \prod_{i\\neq j}(core_[i] \\times (\\prod_{i\\neq j}(factors[j]\\times factors[j]^T)) \\
+            tensor_cross =  \prod_{i\\neq j} tensor_[i] \\times factors_[i]
+        \\end{equation}
+    Then UTU and UTM becomes:
+    .. math::
+        \\begin{equation}
+            UTU = core_cross_[j] \\times core_[j]^T  \\
+            UTM =  (tensor_cross_[j] \\times \\times core_[j]^T)^T
+        \\end{equation}
     References
     ----------
     .. [1] tl.G.Kolda and B.W.Bader, "Tensor Decompositions and Applications",

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -1,6 +1,6 @@
 import numpy as np
 import tensorly as tl
-from .._tucker import tucker, partial_tucker, non_negative_tucker
+from .._tucker import tucker, partial_tucker, non_negative_tucker, non_negative_tucker_hals
 from ...tucker_tensor import tucker_to_tensor
 from ...tenalg import multi_mode_dot
 from ...random import random_tucker

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -162,3 +162,53 @@ def test_non_negative_tucker():
         expected_shape = (tl.shape(tensor)[i], rank)
         assert_(tl.shape(f) == expected_shape, '{}-th factor has the wrong shape, got {}, but expected {}.'.format(
                 i, tl.shape(f), expected_shape))
+
+def test_non_negative_tucker_hals():
+    """Test for non-negative Tucker wih HALS"""
+    rng = tl.check_random_state(1234)
+
+    tol_norm_2 = 10e-1
+    tol_max_abs = 10e-1
+    tensor = tl.tensor(rng.random_sample((3, 4, 3)) + 1)
+    core, factors = tucker(tensor, rank=[3, 4, 3], n_iter_max=200)
+    nn_core, nn_factors = non_negative_tucker_hals(tensor, rank=[3, 4, 3], n_iter_max=100)
+
+    # Make sure all components are positive
+    for factor in nn_factors:
+        assert_(tl.all(factor >= 0))
+    assert_(tl.all(nn_core >= 0))
+
+    reconstructed_tensor = tucker_to_tensor((core, factors))
+    nn_reconstructed_tensor = tucker_to_tensor((nn_core, nn_factors))
+    error = tl.norm(reconstructed_tensor - nn_reconstructed_tensor, 2)
+    error /= tl.norm(reconstructed_tensor, 2)
+    assert_(error < tol_norm_2,
+            'norm 2 of reconstruction error higher than tol')
+
+    # Test the max abs difference between the reconstruction and the tensor
+    assert_(tl.norm(reconstructed_tensor - nn_reconstructed_tensor, 'inf') < tol_max_abs,
+              'abs norm of reconstruction error higher than tol')
+
+    core_svd, factors_svd = non_negative_tucker_hals(tensor, rank=[3, 4, 3], n_iter_max=500, init='svd')
+    core_random, factors_random = non_negative_tucker_hals(tensor, rank=[3, 4, 3], n_iter_max=200, init='random',           random_state=1234)
+    rec_svd = tucker_to_tensor((core_svd, factors_svd))
+    rec_random = tucker_to_tensor((core_random, factors_random))
+    error = tl.norm(rec_svd - rec_random, 2)
+    error /= tl.norm(rec_svd, 2)
+    assert_(error < tol_norm_2,
+            'norm 2 of difference between svd and random init too high')
+    assert_(tl.norm(rec_svd - rec_random, 'inf') < tol_max_abs,
+            'abs norm of difference between svd and random init too high')
+
+    # Test for a single rank passed
+    # (should be used for all modes)
+    rank = 3
+    target_shape = (rank, )*tl.ndim(tensor)
+    core, factors = non_negative_tucker_hals(tensor, rank=rank)
+    assert_(tl.shape(core) == target_shape, 'core has the wrong shape, got {}, but expected {}.'.format(tl.shape(core), target_shape))
+    for i, f in enumerate(factors):
+        expected_shape = (tl.shape(tensor)[i], rank)
+        assert_(tl.shape(f) == expected_shape, '{}-th factor has the wrong shape, got {}, but expected {}.'.format(
+                i, tl.shape(f), expected_shape))                
+                
+           

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -261,7 +261,7 @@ def fista(AtB, pseudo_inverse, x=None, n_iter_max=100, non_negative=True, sparsi
     ----------
     AtB : ndarray
        Pre-computed product of the transposed of A and B.
-    pseudo_inverse: ndarray
+    pseudo_inverse: ndarray list
        Pre-computed product of the transposed of A and A.
     x : init
        Default: None
@@ -290,7 +290,7 @@ def fista(AtB, pseudo_inverse, x=None, n_iter_max=100, non_negative=True, sparsi
         sparsity_coef = 0
     
     if x is None:
-        x = tl.zeros([tl.shape(pseudo_inverse)[0], tl.shape(AtB)[1]])
+        x = tl.zeros(tl.shape(AtB))
 
     # Parameters
     momentum_old = tl.tensor(1.0)

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -255,7 +255,7 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
     
 
 def fista(UtM, UtU, x=None, n_iter_max=100, non_negative=True, sparsity_coef=0,
-          lr=10e-3, tol=10e-8):
+          lr=None, tol=10e-8):
     """
     Fast Iterative Shrinkage Thresholding Algorithm (FISTA)
 
@@ -276,6 +276,7 @@ def fista(UtM, UtU, x=None, n_iter_max=100, non_negative=True, sparsity_coef=0,
                    if True, result will be non-negative
     lr : float
         learning rate
+        Default : None
     sparsity_coef : float or None
     tol : float
         stopping criterion
@@ -299,7 +300,8 @@ def fista(UtM, UtU, x=None, n_iter_max=100, non_negative=True, sparsity_coef=0,
     
     if x is None:
         x = tl.zeros(tl.shape(UtM), **tl.context(UtM))
-
+    if lr is None:
+        lr = 1 / (tl.partial_svd(UtU)[1][0])
     # Parameters
     momentum_old = tl.tensor(1.0)
     norm_0 = 0.0

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -367,7 +367,10 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
            least squares algorithm. Journal of Chemometrics: A Journal of
            the Chemometrics Society, 11(5), 393-401.
      """
-    
+    if tl.get_backend() == 'tensorflow':
+        raise ValueError(
+            "Active set is not supported with the tensorflow backend. Consider using fista method with tensorflow.")
+
     if x is None:
         x_vec = tl.zeros(tl.shape(UtU)[1], **tl.context(UtU))
     else:

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -264,7 +264,7 @@ def fista(AtB, pseudo_inverse, x=None, n_iter_max=100, non_negative=True, gradie
     pseudo_inverse: ndarray
        Pre-computed product of the transposed of A and A.
     x: initialized array
-       Default: NOne
+       Default: None
     n_iter_max : int
         Maximum number of iteration
         Default: 100
@@ -332,7 +332,7 @@ def active_set_nnls(AtA, AtB, x=None, n_iter_max=100, tol=10e-8):
      AtB: ndarray
         Pre-computed product of the transposed of A and B.
      x: initialized array
-        Default: NOne
+        Default: None
      n_iter_max : int
          Maximum number of iteration
          Default: 100

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -284,6 +284,10 @@ def fista(UtM, UtU, x=None, n_iter_max=100, non_negative=True, sparsity_coef=0,
     -------
     x : approximate solution such that Ux = M
 
+    Notes
+    -----
+    We solve the following problem :math: `1/2 ||m - Ux ||_2^2 + \\lambda |x|_1`
+
     Reference
     ----------
     [1] : Beck, A., & Teboulle, M. (2009). A fast iterative

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -301,12 +301,12 @@ def fista(AtB, pseudo_inverse, x=None, n_iter_max=100, non_negative=True, gradie
     x_upd = tl.copy(x)
 
     for iteration in range(n_iter_max):
-        gradient = - AtB + tl.tenalg.multi_mode_dot(x_upd, pseudo_inverse, transpose=False)
+        gradient = - AtB + tl.tenalg.multi_mode_dot(x_upd, pseudo_inverse, transpose=False) + sparse
 
         if non_negative is True:
-            delta_x = tl.where(gradient_step * gradient < x, gradient_step * gradient, x_upd) + sparse
+            delta_x = tl.where(gradient_step * gradient < x, gradient_step * gradient, x_upd)
         else:
-            delta_x = gradient_step * gradient + sparse
+            delta_x = gradient_step * gradient
 
         xnew = x_upd - delta_x
         momentum = (1 + tl.sqrt(1 + 4 * momentum_old ** 2)) / 2

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -198,7 +198,8 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
         # Scaling
         scale = tl.sum(UtM * V) / tl.sum(
                        UtU * tl.dot(V, tl.transpose(V)))
-        V = tl.dot(scale, V)
+        V = V * scale
+
     if exact:
         n_iter_max = 50000
         tol = 10e-16
@@ -293,7 +294,7 @@ def fista(UtM, UtU, x=None, n_iter_max=100, non_negative=True, sparsity_coef=0,
         sparsity_coef = 0
     
     if x is None:
-        x = tl.zeros(tl.shape(UtM))
+        x = tl.zeros(tl.shape(UtM), **tl.context(UtM))
 
     # Parameters
     momentum_old = tl.tensor(1.0)
@@ -368,7 +369,7 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
      """
     
     if x is None:
-        x_vec = tl.zeros(tl.shape(UtU)[1])
+        x_vec = tl.zeros(tl.shape(UtU)[1], **tl.context(UtU))
     else:
         x_vec = tl.base.tensor_to_vec(x)
 

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -298,7 +298,10 @@ def fista(UtM, UtU, x=None, n_iter_max=100, non_negative=True, sparsity_coef=0,
     x_update = tl.copy(x)
 
     for iteration in range(n_iter_max):
-        x_gradient = - UtM + tl.tenalg.multi_mode_dot(x_update, UtU, transpose=False) + sparsity_coef
+        if isinstance(UtU, list):
+            x_gradient = - UtM + tl.tenalg.multi_mode_dot(x_update, UtU, transpose=False) + sparsity_coef
+        else:
+            x_gradient = - UtM + tl.dot(UtU, x_update) + sparsity_coef
 
         if non_negative is True:
             x_gradient = tl.where(lr * x_gradient < x_update, x_gradient, x_update/lr)

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -251,7 +251,7 @@ def hals_nnls(UtM, UtU, V=None, n_iter_max=500, tol=10e-8,
     
 
 def fista(UtM, UtU, x=None, n_iter_max=100, non_negative=True, sparsity_coef=0,
-          lr=10e-3, tol=10e-2):
+          lr=10e-3, tol=10e-8):
     """
     Fast Iterative Shrinkage Thresholding Algorithm (FISTA)
 
@@ -327,7 +327,7 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
 
      Parameters
      ----------
-     Utm : ndarray
+     Utm : vectorized ndarray
         Pre-computed product of the transposed of U and m
      UtU : ndarray
         Pre-computed Kronecker product of the transposed of U and U
@@ -336,12 +336,26 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
      n_iter_max : int
          Maximum number of iteration
          Default: 100
-    tol : float
+     tol : float
          Early stopping criterion
 
      Returns
      -------
      x : ndarray
+
+     Notes
+     -----
+     This function solves following problem:
+     .. math::
+        \\begin{equation}
+             \\min_{x} ||Ux - m||^2
+        \\end{equation}
+
+     According to [1], non-negativity-constrained least square estimation problem becomes:
+     .. math::
+        \\begin{equation}
+             x' = (Utm) - (UTU)\\times x
+        \\end{equation}
 
      Reference
      ----------

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -391,9 +391,9 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
             for i in range(tl.shape(support_vec)[0]):
                 if passive_set[i]:
                     indice_list.append(i)
-                    support_vector = tl.index_update(support_vec, tl.index[int(i)], passive_solution[len(indice_list) - 1])
+                    support_vec = tl.index_update(support_vec, tl.index[int(i)], passive_solution[len(indice_list) - 1])
                 else:
-                    support_vector = tl.index_update(support_vec, tl.index[int(i)], 0)
+                    support_vec = tl.index_update(support_vec, tl.index[int(i)], 0)
         # Start from zeros if solve is not achieved  
         except:
             x_vec = tl.zeros(tl.shape(UtU)[1])

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -76,7 +76,7 @@ def test_hals_nnls():
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    x_hals = hals_nnls(atb, ata, exact=True)[0]
+    x_hals = hals_nnls(atb, ata)[0]
     assert_array_almost_equal(true_res, x_hals, decimal=2)
 
 

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -90,8 +90,7 @@ def test_fista():
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    lr = 1 / (T.norm(ata))
-    x_fista = fista(atb, ata, tol=10e-16, n_iter_max=5000, lr=lr)
+    x_fista = fista(atb, ata, tol=10e-16, n_iter_max=5000)
     assert_array_almost_equal(true_res, x_fista, decimal=2)
 
 

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -85,12 +85,13 @@ def test_hals_nnls():
 
 def test_fista():
     """Test for fista operator"""
-    a = T.tensor(np.random.rand(10, 10))
+    a = T.tensor(np.random.rand(20, 10))
     true_res = T.tensor(np.random.rand(10, 1))
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    x_fista = fista(atb, ata, tol=10e-10, n_iter_max=5000)
+    lr = 1 / (T.norm(ata))
+    x_fista = fista(atb, ata, tol=10e-16, n_iter_max=5000, lr=lr)
     assert_array_almost_equal(true_res, x_fista, decimal=2)
 
 

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -68,6 +68,7 @@ def test_procrustes():
     res = procrustes(U)
     assert_array_almost_equal(true_res, res)
 
+
 def test_hals_nnls():
     """Test for hals_nnls operator"""
     a = T.tensor(np.random.rand(10, 10))
@@ -75,8 +76,7 @@ def test_hals_nnls():
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    xinit = T.zeros(T.shape(atb))
-    x_hals = hals_nnls(atb, ata, V=xinit, exact=True)[0]
+    x_hals = hals_nnls(atb, ata, exact=True)[0]
     assert_array_almost_equal(true_res, x_hals, decimal=2)
 
 
@@ -87,8 +87,8 @@ def test_fista():
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    x_fista = fista(atb, ata, tol=10e-10, n_iter_max=20000)
-    assert_array_almost_equal(true_res, x_fista, decimal=3)
+    x_fista = fista(atb, ata, tol=10e-10, n_iter_max=5000)
+    assert_array_almost_equal(true_res, x_fista, decimal=2)
 
 
 def test_active_set_nnls():
@@ -100,4 +100,4 @@ def test_active_set_nnls():
     ata = T.dot(T.transpose(a), a)
     x_as = active_set_nnls(tensor_to_vec(atb), ata)
     x_as = T.reshape(x_as, T.shape(atb))
-    assert_array_almost_equal(true_res, x_as, decimal=3)
+    assert_array_almost_equal(true_res, x_as, decimal=2)

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -5,9 +5,12 @@ from ..proximal import svd_thresholding, soft_thresholding, hals_nnls, fista, ac
 from ..proximal import procrustes
 from ...testing import assert_array_equal, assert_array_almost_equal
 from tensorly import tensor_to_vec
+import pytest
 
 # Author: Jean Kossaifi
 
+skip_tensorflow = pytest.mark.skipif((T.get_backend() == "tensorflow"),
+                                     reason=f"Indexing with list not supported in TensorFlow")
 
 def test_soft_thresholding():
     """Test for shrinkage"""
@@ -91,6 +94,7 @@ def test_fista():
     assert_array_almost_equal(true_res, x_fista, decimal=2)
 
 
+@skip_tensorflow
 def test_active_set_nnls():
     """Test for active_set_nnls operator"""
     a = T.tensor(np.random.rand(10, 10))

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -76,7 +76,7 @@ def test_hals_nnls():
     ata = T.dot(T.transpose(a), a)
     xinit = T.zeros(T.shape(atb))
     x_hals = hals_nnls(atb, ata, V=xinit, exact=True)[0]
-    assert_array_almost_equal(true_res, x_hals)
+    assert_array_almost_equal(true_res, x_hals, decimal=2)
 
 
 def test_fista():
@@ -86,8 +86,8 @@ def test_fista():
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    x_fista = fista(atb, ata, n_iter_max=10000)
-    assert_array_almost_equal(true_res, x_fista, decimal=3)
+    x_fista = fista(atb, ata, tol=10e-10, n_iter_max=20000)
+    assert_array_almost_equal(true_res, x_fista, decimal=2)
 
 
 def test_active_set_nnls():
@@ -97,6 +97,6 @@ def test_active_set_nnls():
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    x_as = active_set_nnls(T.tensor_to_vec(atb), ata)
+    x_as = active_set_nnls(T.base.tensor_to_vec(atb), ata)
     x_as = T.reshape(x_as, T.shape(atb))
-    assert_array_almost_equal(true_res, x_as)
+    assert_array_almost_equal(true_res, x_as, decimal=2)

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -69,34 +69,34 @@ def test_procrustes():
 
 def test_hals_nnls():
     """Test for hals_nnls operator"""
-    a = T.tensor(np.random.rand(20, 20))
-    true_res = T.tensor(np.random.rand(20, 1))
+    a = T.tensor(np.random.rand(10, 10))
+    true_res = T.tensor(np.random.rand(10, 1))
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
     xinit = T.zeros(T.shape(atb))
     x_hals = hals_nnls(atb, ata, V=xinit, exact=True)[0]
-    assert_array_almost_equal(true_res, x_hals, decimal=2)
+    assert_array_almost_equal(true_res, x_hals, decimal=3)
 
 
 def test_fista():
     """Test for fista operator"""
-    a = T.tensor(np.random.rand(20, 20))
-    true_res = T.tensor(np.random.rand(20, 1))
+    a = T.tensor(np.random.rand(10, 10))
+    true_res = T.tensor(np.random.rand(10, 1))
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
     x_fista = fista(atb, ata, tol=10e-10, n_iter_max=20000)
-    assert_array_almost_equal(true_res, x_fista, decimal=2)
+    assert_array_almost_equal(true_res, x_fista, decimal=3)
 
 
 def test_active_set_nnls():
     """Test for active_set_nnls operator"""
-    a = T.tensor(np.random.rand(20, 20))
-    true_res = T.tensor(np.random.rand(20, 1))
+    a = T.tensor(np.random.rand(10, 10))
+    true_res = T.tensor(np.random.rand(10, 1))
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    x_as = active_set_nnls(T.base.tensor_to_vec(atb), ata)
+    x_as = active_set_nnls(T.tensor_to_vec(atb), ata)
     x_as = T.reshape(x_as, T.shape(atb))
-    assert_array_almost_equal(true_res, x_as, decimal=2)
+    assert_array_almost_equal(true_res, x_as, decimal=3)

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ... import backend as T
-from ..proximal import svd_thresholding, soft_thresholding
+from ..proximal import svd_thresholding, soft_thresholding, hals_nnls, fista, active_set_nnls
 from ..proximal import procrustes
 from ...testing import assert_array_equal, assert_array_almost_equal
 
@@ -66,3 +66,37 @@ def test_procrustes():
     true_res = T.dot(S, V)
     res = procrustes(U)
     assert_array_almost_equal(true_res, res)
+
+def test_hals_nnls():
+    """Test for hals_nnls operator"""
+    a = T.tensor(np.random.rand(20, 20))
+    true_res = T.tensor(np.random.rand(20, 1))
+    b = T.dot(a, true_res)
+    atb = T.dot(T.transpose(a), b)
+    ata = T.dot(T.transpose(a), a)
+    xinit = T.zeros(T.shape(atb))
+    x_hals = hals_nnls(atb, ata, V=xinit, exact=True)[0]
+    assert_array_almost_equal(true_res, x_hals)
+
+
+def test_fista():
+    """Test for fista operator"""
+    a = T.tensor(np.random.rand(20, 20))
+    true_res = T.tensor(np.random.rand(20, 1))
+    b = T.dot(a, true_res)
+    atb = T.dot(T.transpose(a), b)
+    ata = T.dot(T.transpose(a), a)
+    x_fista = fista(atb, ata, n_iter_max=10000)
+    assert_array_almost_equal(true_res, x_fista, decimal=3)
+
+
+def test_active_set_nnls():
+    """Test for active_set_nnls operator"""
+    a = T.tensor(np.random.rand(20, 20))
+    true_res = T.tensor(np.random.rand(20, 1))
+    b = T.dot(a, true_res)
+    atb = T.dot(T.transpose(a), b)
+    ata = T.dot(T.transpose(a), a)
+    x_as = active_set_nnls(T.base.tensor_to_vec(atb), ata)
+    x_as = T.reshape(x_as, T.shape(atb))
+    assert_array_almost_equal(true_res, x_as)

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -4,6 +4,7 @@ from ... import backend as T
 from ..proximal import svd_thresholding, soft_thresholding, hals_nnls, fista, active_set_nnls
 from ..proximal import procrustes
 from ...testing import assert_array_equal, assert_array_almost_equal
+from tensorly import tensor_to_vec
 
 # Author: Jean Kossaifi
 
@@ -76,7 +77,7 @@ def test_hals_nnls():
     ata = T.dot(T.transpose(a), a)
     xinit = T.zeros(T.shape(atb))
     x_hals = hals_nnls(atb, ata, V=xinit, exact=True)[0]
-    assert_array_almost_equal(true_res, x_hals, decimal=3)
+    assert_array_almost_equal(true_res, x_hals, decimal=2)
 
 
 def test_fista():
@@ -97,6 +98,6 @@ def test_active_set_nnls():
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    x_as = active_set_nnls(T.tensor_to_vec(atb), ata)
+    x_as = active_set_nnls(tensor_to_vec(atb), ata)
     x_as = T.reshape(x_as, T.shape(atb))
     assert_array_almost_equal(true_res, x_as, decimal=3)

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -97,6 +97,6 @@ def test_active_set_nnls():
     b = T.dot(a, true_res)
     atb = T.dot(T.transpose(a), b)
     ata = T.dot(T.transpose(a), a)
-    x_as = active_set_nnls(T.base.tensor_to_vec(atb), ata)
+    x_as = active_set_nnls(T.tensor_to_vec(atb), ata)
     x_as = T.reshape(x_as, T.shape(atb))
     assert_array_almost_equal(true_res, x_as)


### PR DESCRIPTION
# HALS for Non-negative Tucker
This pull request adds a non-negative tucker with HALS algorithm to `_tucker.py` file. In our previous PR, we added `hals_nnls` function and here we use it for tucker decomposition. We added `non_negative_tucker_hals` and `initialize_tucker` function to `_tucker.py` file. Additionally, we added two nonnegative least square algorithms to proximal.py in order to update core for nonnegative tucker decomposition.

# Motivation
Using HALS for non-negative Tucker decomposition gives more accurate results according to our experiments and the literature. We compared our algorithms with the current nonnegative Tucker in Tensorly and we observed pretty good improvement. We are planning to submit an example based PR soon which will include our experiments.

# Source Modification 
* **decomposition/_tucker.py:**

First, we added `initialize_tucker` function in order to have initializing function such as `initialize_cp` for Tucker. In this function, if non_negative is True, it returns non-negative core and factors. Otherwise, it can be used for unconstrained `Tucker` decomposition as well.

We added `non_negative_tucker_hals` function which uses `hals_nnls` algorithm to calculate factors for tucker decomposition.

To compare our function, we added return_error option to `non_negative_tucker`. We also include this version in this PR.

* **tenalg/_proximal.py:**

To update core during the iteration in `non_negative_tucker_hals`, we added two fast gradient algorithms which are active set and Fast Iterative Shrinkage Thresholding Algorithm (FISTA). These functions return updated nonnegative core for `non_negative_tucker_hals`. Besides, these functions can be used for different nonnegative least square problems in the future.

* **test_tucker.py:**

Lastly, we have added a test function *"test_non_negative_tucker_hals()"* for *"non_negative_tucker_hals"* function. Simply, we have copied *"test_non_negative_tucker"* and changed related function. We have tested our function with this test function as well.

# References

1-  Bro, R., & De Jong, S. (1997). A fast non‐negativity‐constrained least squares algorithm. Journal of Chemometrics: A Journal of the Chemometrics Society, 11(5), 393-401. [Link](http://xrm.phys.northwestern.edu/research/pdf_papers/1997/bro_chemometrics_1997.pdf)

2- Beck, A., & Teboulle, M. (2009). A fast iterative shrinkage-thresholding algorithm for linear inverse problems. SIAM journal on imaging sciences, 2(1), 183-202.  [Link](https://epubs.siam.org/doi/abs/10.1137/080716542)