### PR TITLE
Non negativity in only some modes

### DIFF
--- a/doc/modules/api.rst
+++ b/doc/modules/api.rst
@@ -382,6 +382,7 @@ Functions
 
     regression.MSE
     regression.RMSE
+    factors.congruence_coefficient
 
 
 :mod:`tensorly.random`: Sampling tensors

--- a/tensorly/decomposition/__init__.py
+++ b/tensorly/decomposition/__init__.py
@@ -4,7 +4,7 @@ tensor decomposition such as CANDECOMP-PARAFAC and Tucker.
 """
 
 from ._cp import (parafac, CP, RandomizedCP, randomised_parafac, sample_khatri_rao)
-from ._nn_cp import non_negative_parafac
+from ._nn_cp import non_negative_parafac, non_negative_parafac_hals
 from ._tucker import tucker, partial_tucker, non_negative_tucker, Tucker
 from .robust_decomposition import robust_pca
 from ._tt import TensorTrain, tensor_train, tensor_train_matrix

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import tensorly as tl
 from ._base_decomposition import DecompositionMixin
 from tensorly.random import random_parafac2
@@ -156,6 +158,7 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
 
     where :math:`P_i` is a :math:`J_i \times R` orthogonal matrix and :math:`B` is a
     :math:`R \times R` matrix.
+    
 
     An alternative formulation of the PARAFAC2 decomposition is that the tensor element
     :math:`X_{ijk}` is given by
@@ -224,6 +227,11 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
     [1]_, the second mode changes over the third mode. We made this change since that means
     that the function accept both lists of matrices and a single nd-array as input without
     any reordering of the modes.
+
+    Because of the reformulation above, :math:`B_i = P_i B`, the :math:`B_i` matrices
+    cannot be constrained to be non-negative with ALS. If this mode is constrained to be
+    non-negative, then :math:`B` will be non-negative, but not the orthogonal `P_i` matrices.
+    Consequently, the `B_i` matrices are unlikely to be non-negative.
     """
     weights, factors, projections = initialize_decomposition(tensor_slices, rank, init=init, svd=svd, random_state=random_state)
 
@@ -231,18 +239,20 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
     norm_tensor = tl.sqrt(sum(tl.norm(tensor_slice, 2)**2 for tensor_slice in tensor_slices))
     svd_fun = _get_svd(svd)
 
-    if nn_modes is not None:
+    # If nn_modes is set, we use HALS, otherwise, we use the standard parafac implementation.
+    if nn_modes is None:
         def parafac_updates(X, w, f):
                 return parafac(X, rank, n_iter_max=n_iter_parafac,
                                init=(w, f), svd=svd, orthogonalise=False, verbose=verbose,
                                return_errors=False, normalize_factors=False, mask=None,
                                random_state=random_state, tol=1e-100)[1]
     else:
+        if nn_modes == 'all' or 1 in nn_modes:
+            warn("Mode `1` of PARAFAC2 fitted with ALS cannot be constrained to be truly non-negative. See the documentation for more info.")
         def parafac_updates(X, w, f):
                 return non_negative_parafac_hals(
                     X, rank, n_iter_max=n_iter_parafac, init=(w, f), svd=svd, nn_modes=nn_modes,
                     verbose=verbose, return_errors=False, tol=1e-100)[1]
-
 
 
     projected_tensor = tl.zeros([factor.shape[0] for factor in factors], **T.context(factors[0]))
@@ -255,9 +265,7 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
 
         projections = _compute_projections(tensor_slices, factors, svd_fun, out=projections)
         projected_tensor = _project_tensor_slices(tensor_slices, projections, out=projected_tensor)
-        _, factors = parafac(projected_tensor, rank, n_iter_max=n_iter_parafac, init=(weights, factors),
-                             svd=svd, orthogonalise=False, verbose=verbose, return_errors=False,
-                             normalize_factors=False, mask=None, random_state=random_state, tol=1e-100)
+        factors = parafac_updates(projected_tensor, weights, factors)
 
         if normalize_factors:
             new_factors = []

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -176,7 +176,7 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
         Either a third order tensor or a list of second order tensors that may have different number of rows.
         Note that the second mode factor matrices are allowed to change over the first mode, not the
         third mode as some other implementations use (see note below).
-    rank  : int
+    rank : int
         Number of components.
     n_iter_max : int
         Maximum number of iteration

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -255,6 +255,9 @@ def test_non_negative_parafac_hals_one_unconstrained():
     assert_(best_congruence(B, nn_estimate[1][1]) > 0.99, "Factor recovery not high enough")
     assert_(best_congruence(C, nn_estimate[1][2]) > 0.99, "Factor recovery not high enough")
 
+    assert_(T.all(nn_estimate[1][0] > -1e-10))
+    assert_(T.all(nn_estimate[1][2] > -1e-10))
+
 
 @pytest.mark.xfail(tl.get_backend() == 'tensorflow', reason='Fails on tensorflow')
 def test_sample_khatri_rao():

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -246,7 +246,7 @@ def test_non_negative_parafac_hals_one_unconstrained():
     X = cp_to_tensor(cp_tensor)
 
     nn_estimate, errs = non_negative_parafac_hals(
-        X, rank=3, n_iter_max=1000, tol=1e-5, init='svd', verbose=0, nn_modes={0, 2}, return_errors=True
+        X, rank=3, n_iter_max=100, tol=0, init='svd', verbose=0, nn_modes={0, 2}, return_errors=True
     )
     X_hat = cp_to_tensor(nn_estimate)
     assert_(tl.norm(X - X_hat,) < 1e-3, "Error was too high")

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -12,29 +12,7 @@ from ...random import random_cp
 from ...tenalg import khatri_rao
 from ... import backend as T
 from ...testing import assert_array_equal, assert_
-
-
-def tucker_congruence(A, B):
-    As = A/T.norm(A, axis=0)
-    Bs = B/T.norm(B, axis=0)
-
-    return T.dot(T.transpose(As), Bs)
-
-
-def best_congruence(A, B):
-    _, r = T.shape(A)
-    corr_matrix = T.abs(tucker_congruence(A, B))
-
-    best_corr = 0
-    for permutation in itertools.permutations(range(r)):
-        corr = 1
-        for i, j in zip(range(r), permutation):
-            corr *= corr_matrix[i, j]
-        
-        if corr > best_corr:
-            best_corr = corr
-    
-    return best_corr
+from ...metrics.factors import congruence_coefficient
 
 
 @pytest.mark.parametrize("linesearch", [True, False])
@@ -251,9 +229,9 @@ def test_non_negative_parafac_hals_one_unconstrained():
     X_hat = cp_to_tensor(nn_estimate)
     assert_(tl.norm(X - X_hat,) < 1e-3, "Error was too high")
     
-    assert_(best_congruence(A, nn_estimate[1][0]) > 0.99, "Factor recovery not high enough")
-    assert_(best_congruence(B, nn_estimate[1][1]) > 0.99, "Factor recovery not high enough")
-    assert_(best_congruence(C, nn_estimate[1][2]) > 0.99, "Factor recovery not high enough")
+    assert_(congruence_coefficient(A, nn_estimate[1][0], absolute_value=True)[0] > 0.99, "Factor recovery not high enough")
+    assert_(congruence_coefficient(B, nn_estimate[1][1], absolute_value=True)[0] > 0.99, "Factor recovery not high enough")
+    assert_(congruence_coefficient(C, nn_estimate[1][2], absolute_value=True)[0] > 0.99, "Factor recovery not high enough")
 
     assert_(T.all(nn_estimate[1][0] > -1e-10))
     assert_(T.all(nn_estimate[1][2] > -1e-10))

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -7,7 +7,7 @@ from .._cp import (
     parafac, initialize_cp,
     sample_khatri_rao, randomised_parafac)
 from .._nn_cp import non_negative_parafac, non_negative_parafac_hals
-from ...cp_tensor import cp_to_tensor, CPTensor
+from ...cp_tensor import cp_to_tensor
 from ...random import random_cp
 from ...tenalg import khatri_rao
 from ... import backend as T
@@ -239,11 +239,11 @@ def test_non_negative_parafac_hals_one_unconstrained():
     t_shape = (8, 9, 10)
     rank = 3
     weights = rng.uniform(size=rank)
-    A = rng.uniform(size=(t_shape[0], rank))
-    B = rng.standard_normal(size=(t_shape[1], rank))
-    C = rng.uniform(0.1, 1.1, size=(t_shape[2], rank))
+    A = T.tensor(rng.uniform(size=(t_shape[0], rank)))
+    B = T.tensor(rng.standard_normal(size=(t_shape[1], rank)))
+    C = T.tensor(rng.uniform(0.1, 1.1, size=(t_shape[2], rank)))
     cp_tensor = (weights, (A, B, C))
-    X = cp_to_tensor(CPTensor(cp_tensor))
+    X = cp_to_tensor(cp_tensor)
 
     nn_estimate, errs = non_negative_parafac_hals(
         X, rank=3, n_iter_max=1000, tol=1e-5, init='svd', verbose=0, nn_modes={0, 2}, return_errors=True

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -7,7 +7,7 @@ from .._cp import (
     parafac, initialize_cp,
     sample_khatri_rao, randomised_parafac)
 from .._nn_cp import non_negative_parafac, non_negative_parafac_hals
-from ...cp_tensor import cp_to_tensor
+from ...cp_tensor import cp_to_tensor, CPTensor
 from ...random import random_cp
 from ...tenalg import khatri_rao
 from ... import backend as T
@@ -243,7 +243,7 @@ def test_non_negative_parafac_hals_one_unconstrained():
     B = rng.standard_normal(size=(t_shape[1], rank))
     C = rng.uniform(0.1, 1.1, size=(t_shape[2], rank))
     cp_tensor = (weights, (A, B, C))
-    X = cp_to_tensor(cp_tensor)
+    X = cp_to_tensor(CPTensor(cp_tensor))
 
     nn_estimate, errs = non_negative_parafac_hals(
         X, rank=3, n_iter_max=1000, tol=1e-5, init='svd', verbose=0, nn_modes={0, 2}, return_errors=True

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -238,7 +238,7 @@ def test_non_negative_parafac_hals_one_unconstrained():
     rng = tl.check_random_state(1234)
     t_shape = (8, 9, 10)
     rank = 3
-    weights = rng.uniform(size=rank)
+    weights = T.tensor(rng.uniform(size=rank))
     A = T.tensor(rng.uniform(size=(t_shape[0], rank)))
     B = T.tensor(rng.standard_normal(size=(t_shape[1], rank)))
     C = T.tensor(rng.uniform(0.1, 1.1, size=(t_shape[2], rank)))

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -137,6 +137,12 @@ def test_parafac2_nn():
     C_corr = best_correlation(random_parafac2_tensor.factors[2], rec.factors[2])
     assert_(T.prod(C_corr) > 0.98**rank)
 
+    for i, (true_proj, rec_proj) in enumerate(zip(random_parafac2_tensor.projections, rec.projections)):
+        true_Bi = T.dot(true_proj, random_parafac2_tensor.factors[1])
+        rec_Bi = T.dot(rec_proj, rec.factors[1])
+        Bi_corr = best_correlation(true_Bi, rec_Bi)
+        assert_(T.prod(Bi_corr) > 0.98**rank)
+
     assert_(T.all(rec[1][0] > -1e-10))
     assert_(T.all(rec[1][2] > -1e-10))
 

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -137,6 +137,9 @@ def test_parafac2_nn():
     C_corr = best_correlation(random_parafac2_tensor.factors[2], rec.factors[2])
     assert_(T.prod(C_corr) > 0.98**rank)
 
+    assert_(T.all(rec[1][0] > -1e-10))
+    assert_(T.all(rec[1][2] > -1e-10))
+
 
 def test_parafac2_slice_and_tensor_input():
     rank = 3

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -149,6 +149,8 @@ def test_parafac2_nn():
         rank=rank,
         random_state=rng
     )
+    # The default random parafac2 tensor has non-negative A and C
+    # wet therefore multiply them randomly with -1, 0 or 1 to get both positive and negative components
     factors = [factors[0] * rng.randint(-1, 2, factors[0].shape), factors[1], factors[2] * rng.randint(-1, 2, factors[2].shape)]
     slices = parafac2_to_slices((weights, factors, projections))
     rec, err = parafac2(

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -126,8 +126,10 @@ def test_parafac2_nn():
         random_state=rng
     )
     # The default random parafac2 tensor has non-negative A and C
-    # wet therefore multiply them randomly with -1, 0 or 1 to get both positive and negative components
-    factors = [factors[0] * rng.randint(-1, 2, factors[0].shape), factors[1], factors[2] * rng.randint(-1, 2, factors[2].shape)]
+    # we therefore multiply them randomly with -1, 0 or 1 to get both positive and negative components
+    factors = [factors[0] * T.tensor(rng.randint(-1, 2, factors[0].shape)),
+               factors[1],
+               factors[2] * T.tensor(rng.randint(-1, 2, factors[2].shape))]
     slices = parafac2_to_slices((weights, factors, projections))
     rec, err = parafac2(
         slices,

--- a/tensorly/metrics/__init__.py
+++ b/tensorly/metrics/__init__.py
@@ -5,3 +5,4 @@ The :mod:`tensorly.metrics` module includes utilities to measure performance
 
 from .regression import RMSE, MSE
 from .entropy import vonneumann_entropy, tt_vonneumann_entropy, cp_vonneumann_entropy
+from .factors import congruence_coefficient

--- a/tensorly/metrics/factors.py
+++ b/tensorly/metrics/factors.py
@@ -1,0 +1,44 @@
+from scipy.optimize import linear_sum_assignment
+from .. import backend as T
+
+
+def congruence_coefficient(matrix1, matrix2, absolute_value=True):
+    """Compute the optimal mean (Tucker) congruence coefficient between the columns of two matrices.
+
+    Another name for the congruence coefficient is the cosine similarity.
+
+    The congruence coefficient between two vectors, :math:`\\mathbf{v}_1, \\mathbf{v}_2`, is given by
+
+    .. math::
+
+        \\frac{\\mathbf{v}_1^T \\mathbf{v}_1^T}{\\|\\mathbf{v}_1^T\\| \\|\\mathbf{v}_1^T\\|}
+
+    When we compute the congruence between two matrices, we find the optimal permutation of
+    the columns and return the mean congruence and the permutation.
+
+    Arguments
+    ---------
+    matrix1 : tensorly.Tensor
+    matrix2 : tensorly.Tensor
+    absolute_value : bool
+        Whether to take the absolute value of all vector products before finding the optimal permutation.
+
+    Returns
+    -------
+    congruence : float
+    permutation : list
+    """
+    num_cols = T.shape(matrix1)[1]
+    if T.shape(matrix1) != T.shape(matrix2):
+        raise ValueError("Matrices must have same shape")
+
+    matrix1 = matrix1/T.norm(matrix1, axis=0)
+    matrix2 = matrix2/T.norm(matrix2, axis=0)
+    all_congruences = T.dot(T.transpose(matrix1), matrix2)
+    if absolute_value:
+        all_congruences = T.abs(all_congruences)
+    all_congruences = T.to_numpy(all_congruences)
+    row_ind, col_ind = linear_sum_assignment(-all_congruences)   # Use -corr because scipy didn't doesn't support maximising prior to v1.4
+    indices = dict(zip(row_ind, col_ind))
+    permutation = [indices[i] for i in range(num_cols)]
+    return all_congruences[row_ind, col_ind].mean(), permutation

--- a/tensorly/metrics/factors.py
+++ b/tensorly/metrics/factors.py
@@ -16,8 +16,8 @@ def congruence_coefficient(matrix1, matrix2, absolute_value=True):
     When we compute the congruence between two matrices, we find the optimal permutation of
     the columns and return the mean congruence and the permutation.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     matrix1 : tensorly.Tensor
     matrix2 : tensorly.Tensor
     absolute_value : bool

--- a/tensorly/metrics/tests/test_factors.py
+++ b/tensorly/metrics/tests/test_factors.py
@@ -39,8 +39,8 @@ def _congruence_coefficient_slow(A, B, absolute_value):
 )
 def test_congruence_coefficient(I, R, absolute_value):
     rng = tl.check_random_state(1234)
-    A = rng.standard_normal((I, R))
-    B = rng.standard_normal((I, R))
+    A = tl.tensor(rng.standard_normal((I, R)))
+    B = tl.tensor(rng.standard_normal((I, R)))
 
     fast_congruence, fast_permutation = congruence_coefficient(A, B, absolute_value=absolute_value)
     slow_congruence, slow_permutation = _congruence_coefficient_slow(A, B, absolute_value=absolute_value)

--- a/tensorly/metrics/tests/test_factors.py
+++ b/tensorly/metrics/tests/test_factors.py
@@ -1,0 +1,49 @@
+import itertools
+
+import pytest
+import tensorly as tl
+
+from ..factors import congruence_coefficient
+
+
+def _tucker_congruence(A, B):
+    As = A/tl.norm(A, axis=0)
+    Bs = B/tl.norm(B, axis=0)
+
+    return tl.dot(tl.transpose(As), Bs)
+
+
+def _congruence_coefficient_slow(A, B, absolute_value):
+    _, r = tl.shape(A)
+    corr_matrix = _tucker_congruence(A, B)
+    if absolute_value:
+        corr_matrix = tl.abs(corr_matrix)
+
+    best_corr = None
+    best_permutation = None
+    for permutation in itertools.permutations(range(r)):
+        corr = 0
+        for i, j in zip(range(r), permutation):
+            corr += corr_matrix[i, j] / r
+        
+        if best_corr is None or corr > best_corr:
+            best_corr = corr
+            best_permutation = permutation
+    
+    return best_corr, best_permutation
+
+
+@pytest.mark.parametrize(
+    ("I", "R", "absolute_value"),
+     itertools.product((1, 3, 5, 10, 100), (1, 3, 5), (True, False),)
+)
+def test_congruence_coefficient(I, R, absolute_value, return_permutation):
+    rng = tl.check_random_state(1234)
+    A = rng.standard_normal((I, R))
+    B = rng.standard_normal((I, R))
+
+    fast_congruence, fast_permutation = congruence_coefficient(A, B, absolute_value=absolute_value)
+    slow_congruence, slow_permutation = _congruence_coefficient_slow(A, B, absolute_value=absolute_value)
+    assert fast_congruence == pytest.approx(slow_congruence)
+    if I != 1:
+        assert fast_permutation == list(slow_permutation)

--- a/tensorly/metrics/tests/test_factors.py
+++ b/tensorly/metrics/tests/test_factors.py
@@ -37,7 +37,7 @@ def _congruence_coefficient_slow(A, B, absolute_value):
     ("I", "R", "absolute_value"),
      itertools.product((1, 3, 5, 10, 100), (1, 3, 5), (True, False),)
 )
-def test_congruence_coefficient(I, R, absolute_value, return_permutation):
+def test_congruence_coefficient(I, R, absolute_value):
     rng = tl.check_random_state(1234)
     A = rng.standard_normal((I, R))
     B = rng.standard_normal((I, R))

--- a/tensorly/metrics/tests/test_factors.py
+++ b/tensorly/metrics/tests/test_factors.py
@@ -18,6 +18,7 @@ def _congruence_coefficient_slow(A, B, absolute_value):
     corr_matrix = _tucker_congruence(A, B)
     if absolute_value:
         corr_matrix = tl.abs(corr_matrix)
+    corr_matrix = tl.to_numpy(corr_matrix)
 
     best_corr = None
     best_permutation = None


### PR DESCRIPTION
Often, it is useful to impose non-negativity in only some of the modes of our tensor decomposition models. For example, if we center our data across a mode, then we cannot impose non-negativity in that mode, but we can still constrain the uncentered modes.

This is also useful for PARAFAC2 models, where constraining all modes are difficult, and require some other update scheme than the traditional ALS algorithm. 

Luckily, with the newly implemented CP-HALS algorithm (thank you @caglayantuna and @cohenjer!), we can implement CP with non-negativity in only some modes with only minor modifications. Also, since PARAFAC2 uses CP behind-the-scenes, we can also implement non-negativity in only some mode for PARAFAC2.

This pull request adds the `nn_modes` argument to `non_negative_parafac_hals` and `parafac2`, which can be a list of constrained modes, `None` or the string `'all'` for all modes (defaults to 'all' for `non_negative_parafac_hals` and `None` for `parafac2`).