### PR TITLE
Minor fixes for PARAFAC2 (#263 and more)

### DIFF
--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -207,6 +207,11 @@ def parafac2(tensor_slices, rank, n_iter_max=2000, init='random', svd='numpy_svd
         That is, when the relative sum of squared error is less than the specified tolerance.
         The absolute tolerance is necessary for stopping the algorithm when used on noise-free
         data that follows the PARAFAC2 constraint.
+    nn_modes: None, 'all' or array of integers
+        (Default: None) Used to specify which modes to impose non-negativity constraints on.
+        We cannot impose non-negativity constraints on the the B-mode (mode 1) with the ALS
+        algorithm, so if this mode is among the constrained modes, then a warning will be shown
+        (see notes for more info).
     random_state : {None, int, np.random.RandomState}
     verbose : int, optional
         Level of verbosity
@@ -356,10 +361,6 @@ class Parafac2(DecompositionMixin):
 
     Parameters
     ----------
-    tensor_slices : ndarray or list of ndarrays
-        Either a third order tensor or a list of second order tensors that may have different number of rows.
-        Note that the second mode factor matrices are allowed to change over the first mode, not the
-        third mode as some other implementations use (see note below).
     rank : int
         Number of components.
     n_iter_max : int, optional
@@ -390,6 +391,11 @@ class Parafac2(DecompositionMixin):
         That is, when the relative sum of squared error is less than the specified tolerance.
         The absolute tolerance is necessary for stopping the algorithm when used on noise-free
         data that follows the PARAFAC2 constraint.
+    nn_modes: None, 'all' or array of integers
+        (Default: None) Used to specify which modes to impose non-negativity constraints on.
+        We cannot impose non-negativity constraints on the the B-mode (mode 1) with the ALS
+        algorithm, so if this mode is among the constrained modes, then a warning will be shown
+        (see notes for more info).
     random_state : {None, int, np.random.RandomState}
     verbose : int, optional
         Level of verbosity

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -181,6 +181,10 @@ def parafac2(tensor_slices, rank, n_iter_max=2000, init='random', svd='numpy_svd
         Number of components.
     n_iter_max : int, optional
         (Default: 2000) Maximum number of iteration
+
+        .. versionchanged:: TODO: set the version
+
+            Previously, the default maximum number of iterations was 100.
     init : {'svd', 'random', CPTensor, Parafac2Tensor}
         Type of factor matrix initialization. See `initialize_factors`.
     svd : str, default is 'numpy_svd'
@@ -365,6 +369,10 @@ class Parafac2(DecompositionMixin):
         Number of components.
     n_iter_max : int, optional
         (Default: 2000) Maximum number of iteration
+
+        .. versionchanged:: TODO: set the version
+
+            Previously, the default maximum number of iterations was 100.
     init : {'svd', 'random', CPTensor, Parafac2Tensor}
         Type of factor matrix initialization. See `initialize_factors`.
     svd : str, default is 'numpy_svd'

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -275,7 +275,7 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
                     print('PARAFAC2 reconstruction error={}, variation={}.'.format(
                         rec_errors[-1], rec_errors[-2] - rec_errors[-1]))
 
-                if tol and abs(rec_errors[-2]**2 - rec_errors[-1]**2) < (tol * rec_errors[-2]**2):
+                if abs(rec_errors[-2]**2 - rec_errors[-1]**2) < (tol * rec_errors[-2]**2):
                     if verbose:
                         print('converged in {} iterations.'.format(iteration))
                     break       

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -133,7 +133,7 @@ def _parafac2_reconstruction_error(tensor_slices, decomposition):
 
 
 def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd', normalize_factors=False,
-             tol=1e-8, random_state=None, verbose=False, return_errors=False, n_iter_parafac=5):
+             tol=1e-8, random_state=None, verbose=False, return_errors=False, n_iter_parafac=5, loss_decrease_tol='relative'):
     r"""PARAFAC2 decomposition [1]_ of a third order tensor via alternating least squares (ALS)
 
     Computes a rank-`rank` PARAFAC2 decomposition of the third-order tensor defined by 
@@ -187,14 +187,21 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
         there may be some inaccuracies in the component weights.
     tol : float, optional
         (Default: 1e-8) Relative reconstruction error tolerance. The
-        algorithm is considered to have found the global minimum when the
-        reconstruction error is less than `tol`.
+        algorithm is considered to have found the global minimum when
+        :math:`\left|\| X - \hat{X}_{n-1} \|^2 - \| X - \hat{X}_{n} \|^2\right| < \epsilon \| X - \hat{X}_{n-1} \|^2`.
+        That is, when the relative change in sum of squared error is less
+        than the tolerance.
+
+        .. versionchanged:: TODO: insert version
+
+            Previously, the stopping condition was
+            :math:`\left|\| X - \hat{X}_{n-1} \| - \| X - \hat{X}_{n} \|\right| < \epsilon`.
     random_state : {None, int, np.random.RandomState}
     verbose : int, optional
         Level of verbosity
     return_errors : bool, optional
         Activate return of iteration errors
-    n_iter_parafac: int, optional
+    n_iter_parafac : int, optional
         Number of PARAFAC iterations to perform for each PARAFAC2 iteration
 
     Returns
@@ -268,7 +275,7 @@ def parafac2(tensor_slices, rank, n_iter_max=100, init='random', svd='numpy_svd'
                     print('PARAFAC2 reconstruction error={}, variation={}.'.format(
                         rec_errors[-1], rec_errors[-2] - rec_errors[-1]))
 
-                if tol and abs(rec_errors[-2] - rec_errors[-1]) < tol:
+                if tol and abs(rec_errors[-2]**2 - rec_errors[-1]**2) < (tol * rec_errors[-2]**2):
                     if verbose:
                         print('converged in {} iterations.'.format(iteration))
                     break       

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -64,6 +64,33 @@ def test_parafac2(normalize_factors, init):
         rec_Bi = T.dot(rec_proj, rec.factors[1])*rec_A_sign[i]
         Bi_corr = congruence_coefficient(true_Bi, rec_Bi)[0]
         assert_(Bi_corr > 0.98)
+    
+    # Test convergence criterion
+    rec, err = parafac2(
+        slices,
+        rank,
+        random_state=rng,
+        init=init,
+        normalize_factors=normalize_factors,
+        tol=1e-10,
+        absolute_tol=1e-4,
+        return_errors=True
+    )
+    assert err[-1]**2 < 1e-4
+
+    noisy_slices = [slice_ + 0.001*rng.standard_normal(T.shape(slice_)) for slice_ in slices]
+    rec, err = parafac2(
+        noisy_slices,
+        rank,
+        random_state=rng,
+        init=init,
+        normalize_factors=normalize_factors,
+        tol=1e-4,
+        absolute_tol=-1,
+        return_errors=True,
+        n_iter_max=1000
+    )
+    assert abs(err[-2]**2 - err[-1]**2) < (1e-4 * err[-2]**2)
 
 
 def test_parafac2_nn():

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -78,7 +78,7 @@ def test_parafac2(normalize_factors, init):
     )
     assert err[-1]**2 < 1e-4
 
-    noisy_slices = [slice_ + 0.001*rng.standard_normal(T.shape(slice_)) for slice_ in slices]
+    noisy_slices = [slice_ + tl.tensor(0.001*rng.standard_normal(T.shape(slice_))) for slice_ in slices]
     rec, err = parafac2(
         noisy_slices,
         rank,


### PR DESCRIPTION
This pull request fixes some small issues with the PARAFAC2 code

- Changed to a relative loss decrease stopping condition
- Added an absolute loss decrease stopping condition which defaults to 1000 times the machine precision (necessary for convergence on noise-free PARAFAC2 tensors) (discussion here: #263 )
- Changed the default maximum number of iterations to 2000
- Added nn_modes to the docstring (thanks @IsabellLehmann :smiley:)
- Updated the `Parafac2` class to have the same arguments and docstring as the `parafac2` 
- Added tests for stopping conditions of PARAFAC2

The added absolute tolerance and new maximum number of iterations were also based on the MATLAB code by Rasmus Bro (available here: http://www.models.life.ku.dk/algorithms).

@JeanKossaifi, before we can merge this, we should update the version number in the documentation (see the todos on line 185, 203, 378 and 396 of the _parafac2.py file). What would be the right version number?

Also, when I built the sphinx documentation, I noticed that there were no special formatting for the `versionchanged` HTML class. Maybe we should update the CSS?