### PR TITLE
Test utility for class wrappers and some small bugfixes

### DIFF
--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -663,32 +663,25 @@ class CP(DecompositionMixin):
     .. [3] R. Bro, "Multi-Way Analysis in the Food Industry: Models, Algorithms, and 
            Applications", PhD., University of Amsterdam, 1998
     """
-    def __init__(self, rank, n_iter_max=100, tol=1e-08, 
-                 init='svd', svd='numpy_svd',
-                 l2_reg=0,
-                 linesearch=False,
-                 fixed_modes=None,
-                 normalize_factors=False, 
-                 orthogonalise=False, 
-                 sparsity=None,
-                 mask=None, svd_mask_repeats=5,
-                 cvg_criterion='abs_rec_error',
-                 random_state=None, 
-                 verbose=0):
+    def __init__(self, rank, n_iter_max=100, init='svd', svd='numpy_svd', normalize_factors=False, orthogonalise=False,
+                 tol=1e-8, random_state=None, verbose=0, sparsity=None, l2_reg=0,  mask=None,
+                 cvg_criterion='abs_rec_error', fixed_modes=None, svd_mask_repeats=5, linesearch=False):
         self.rank = rank
         self.n_iter_max = n_iter_max
-        self.tol = tol
-        self.l2_reg = l2_reg
         self.init = init
-        self.linesearch = linesearch
         self.svd = svd
         self.normalize_factors = normalize_factors
         self.orthogonalise = orthogonalise
-        self.mask = mask
-        self.svd_mask_repeats = svd_mask_repeats
-        self.cvg_criterion = cvg_criterion
+        self.tol = tol
         self.random_state = random_state
         self.verbose = verbose
+        self.sparsity = sparsity
+        self.l2_reg = l2_reg
+        self.mask = mask
+        self.cvg_criterion = cvg_criterion
+        self.fixed_modes = fixed_modes
+        self.svd_mask_repeats = svd_mask_repeats
+        self.linesearch = linesearch
 
     
     def fit_transform(self, tensor):
@@ -704,19 +697,26 @@ class CP(DecompositionMixin):
         CPTensor
             decomposed tensor
         """
-        cp_tensor, errors = parafac(tensor, rank=self.rank,
-                                    n_iter_max=self.n_iter_max,
-                                    tol=self.tol,
-                                    init=self.init,
-                                    svd=self.svd,
-                                    normalize_factors=self.normalize_factors,
-                                    orthogonalise=self.orthogonalise,
-                                    mask=self.mask,
-                                    linesearch=self.linesearch,
-                                    cvg_criterion=self.cvg_criterion,
-                                    random_state=self.random_state,
-                                    verbose=self.verbose,
-                                    return_errors=True)
+        cp_tensor, errors = parafac(
+            tensor,
+            rank=self.rank,
+            n_iter_max=self.n_iter_max,
+            init=self.init,
+            svd=self.svd,
+            normalize_factors=self.normalize_factors,
+            orthogonalise=self.orthogonalise,
+            tol=self.tol,
+            random_state=self.random_state,
+            verbose=self.verbose,
+            sparsity=self.sparsity,
+            l2_reg=self.l2_reg,
+            mask=self.mask,
+            cvg_criterion=self.cvg_criterion,
+            fixed_modes=self.fixed_modes,
+            svd_mask_repeats=self.svd_mask_repeats,
+            linesearch=self.linesearch,
+            return_errors=True,
+        )
         self.decomposition_ = cp_tensor 
         self.errors_ = errors
         return self.decomposition_

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -524,28 +524,20 @@ class CP_NN(DecompositionMixin):
                 Applications", PhD., University of Amsterdam, 1998
     """
 
-    def __init__(self, rank, n_iter_max=100, tol=1e-08,
-                 init='svd', svd='numpy_svd',
-                 l2_reg=0,
-                 fixed_modes=None,
-                 normalize_factors=False,
-                 sparsity=None,
-                 mask=None, svd_mask_repeats=5,
-                 cvg_criterion='abs_rec_error',
-                 random_state=None,
-                 verbose=0):
-        self.rank = rank
+    def __init__(self, rank, n_iter_max=100, init='svd', svd='numpy_svd',
+                 tol=10e-7, random_state=None, verbose=0, normalize_factors=False,
+                 mask=None, cvg_criterion='abs_rec_error',
+                 fixed_modes=None):
         self.n_iter_max = n_iter_max
-        self.tol = tol
-        self.l2_reg = l2_reg
         self.init = init
         self.svd = svd
-        self.normalize_factors = normalize_factors
-        self.mask = mask
-        self.svd_mask_repeats = svd_mask_repeats
-        self.cvg_criterion = cvg_criterion
+        self.tol = tol
         self.random_state = random_state
         self.verbose = verbose
+        self.normalize_factors = normalize_factors
+        self.mask = mask
+        self.cvg_criterion = cvg_criterion
+        self.fixed_modes = fixed_modes
 
     def fit_transform(self, tensor):
         """Decompose an input tensor
@@ -561,17 +553,20 @@ class CP_NN(DecompositionMixin):
             decomposed tensor
         """
 
-        cp_tensor, errors = non_negative_parafac(tensor, rank=self.rank,
-                                                 n_iter_max=self.n_iter_max,
-                                                 tol=self.tol,
-                                                 init=self.init,
-                                                 svd=self.svd,
-                                                 normalize_factors=self.normalize_factors,
-                                                 mask=self.mask,
-                                                 cvg_criterion=self.cvg_criterion,
-                                                 random_state=self.random_state,
-                                                 verbose=self.verbose,
-                                                 return_errors=True)
+        cp_tensor, errors = non_negative_parafac(
+            tensor, 
+            n_iter_max=self.n_iter_max,
+            init=self.init,
+            svd=self.svd,
+            tol=self.tol,
+            random_state=self.random_state,
+            verbose=self.verbose,
+            normalize_factors=self.normalize_factors,
+            mask=self.mask,
+            cvg_criterion=self.cvg_criterion,
+            fixed_modes=self.fixed_modes,
+            return_errors=True,
+        )
 
         self.decomposition_ = cp_tensor
         self.errors_ = errors
@@ -654,34 +649,20 @@ class CP_NN_HALS(DecompositionMixin):
                 Applications", PhD., University of Amsterdam, 1998
     """
 
-    def __init__(self, rank, n_iter_max=100, tol=1e-08,
-                 init='svd', svd='numpy_svd',
-                 l2_reg=0,
-                 fixed_modes=None,
-                 nn_modes='all',
-                 normalize_factors=False,
-                 sparsity=None,
-                 exact=False,
-                 mask=None,
-                 svd_mask_repeats=5,
-                 return_errors=True,
-                 cvg_criterion='abs_rec_error',
-                 random_state=None,
-                 verbose=0):
-        self.exact = exact
+    def __init__(self, rank, n_iter_max=100, init="svd", svd='numpy_svd', tol=10e-8,
+                 sparsity_coefficients=None, fixed_modes=None, nn_modes='all', exact=False,
+                 verbose=False, cvg_criterion='abs_rec_error'):
         self.rank = rank
         self.n_iter_max = n_iter_max
-        self.tol = tol
-        self.l2_reg = l2_reg
         self.init = init
         self.svd = svd
-        self.normalize_factors = normalize_factors
-        self.mask = mask
-        self.svd_mask_repeats = svd_mask_repeats
-        self.return_errors = return_errors
-        self.cvg_criterion = cvg_criterion
-        self.random_state = random_state
+        self.tol = tol
+        self.sparsity_coefficients = sparsity_coefficients
+        self.fixed_modes = fixed_modes
+        self.nn_modes = nn_modes
+        self.exact = exact
         self.verbose = verbose
+        self.cvg_criterion = cvg_criterion
 
     def fit_transform(self, tensor):
         """Decompose an input tensor
@@ -697,14 +678,21 @@ class CP_NN_HALS(DecompositionMixin):
             decomposed tensor
         """
 
-        cp_tensor, errors = non_negative_parafac_hals(tensor, rank=self.rank,
-                                                      n_iter_max=self.n_iter_max,
-                                                      tol=self.tol,
-                                                      init=self.init,
-                                                      svd=self.svd,
-                                                      exact=self.exact,
-                                                      verbose=self.verbose,
-                                                      return_errors=self.return_errors)
+        cp_tensor, errors = non_negative_parafac_hals(
+            tensor,
+            rank=self.rank,
+            n_iter_max=self.n_iter_max,
+            init=self.init,
+            svd=self.svd,
+            tol=self.tol,
+            sparsity_coefficients=self.sparsity_coefficients,
+            fixed_modes=self.fixed_modes,
+            nn_modes=self.nn_modes,
+            exact=self.exact,
+            verbose=self.verbose,
+            return_errors=True,
+            cvg_criterion=self.cvg_criterion,
+        )
 
         self.decomposition_ = cp_tensor
         self.errors_ = errors

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -309,9 +309,6 @@ class Tucker(DecompositionMixin):
         rank : None, int or int list
             size of the core tensor, ``(len(ranks) == tensor.ndim)``
             if int, the same rank is used for all modes
-        non_negative : bool, default is False
-            if True, uses a non-negative Tucker via iterative multiplicative updates
-            otherwise, uses a Higher-Order Orthogonal Iteration.
         fixed_factors : int list or None, default is None
             if not None, list of modes for which to keep the factors fixed.
             Only valid if a Tucker tensor is provided as init.
@@ -339,13 +336,13 @@ class Tucker(DecompositionMixin):
 
         References
         ----------
-        .. [1] tl.G.Kolda and B.W.Bader, "Tensor Decompositions and Applications",
+        .. [1] T.G.Kolda and B.W.Bader, "Tensor Decompositions and Applications",
         SIAM REVIEW, vol. 51, n. 3, pp. 455-500, 2009.
         """
-    def __init__(self, rank=None, n_iter_max=100,
-                 init='svd', svd='numpy_svd', tol=10e-5, fixed_factors=None,
-                 random_state=None, mask=None, verbose=False):
+    def __init__(self, rank, fixed_factors=None, n_iter_max=100, init='svd',
+                 svd='numpy_svd', tol=10e-5, random_state=None, mask=None, verbose=False):
         self.rank = rank
+        self.fixed_factors = fixed_factors
         self.n_iter_max = n_iter_max
         self.init = init
         self.svd = svd
@@ -355,14 +352,18 @@ class Tucker(DecompositionMixin):
         self.verbose = verbose
 
     def fit_transform(self, tensor):
-        tucker_tensor = tucker(tensor, rank=self.rank,
-                            n_iter_max=self.n_iter_max,
-                            init=self.init,
-                            svd=self.svd,
-                            tol=self.tol,
-                            random_state=self.random_state,
-                            mask=self.mask,
-                            verbose=self.verbose)        
+        tucker_tensor = tucker(
+            tensor,
+            rank=self.rank,
+            fixed_factors=self.fixed_factors,
+            n_iter_max=self.n_iter_max,
+            init=self.init,
+            svd=self.svd,
+            tol=self.tol,
+            random_state=self.random_state,
+            mask=self.mask,
+            verbose=self.verbose,
+        )        
         self.decomposition_ = tucker_tensor
         return tucker_tensor
 

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -5,13 +5,13 @@ import pytest
 import tensorly as tl
 from .._cp import (
     parafac, initialize_cp,
-    sample_khatri_rao, randomised_parafac)
-from .._nn_cp import non_negative_parafac, non_negative_parafac_hals
+    sample_khatri_rao, randomised_parafac, CP, RandomizedCP)
+from .._nn_cp import non_negative_parafac, non_negative_parafac_hals, CP_NN, CP_NN_HALS
 from ...cp_tensor import cp_to_tensor
 from ...random import random_cp
 from ...tenalg import khatri_rao
 from ... import backend as T
-from ...testing import assert_array_equal, assert_
+from ...testing import assert_array_equal, assert_, assert_class_wrapper_correctly_passes_arguments
 from ...metrics.factors import congruence_coefficient
 
 
@@ -19,7 +19,7 @@ from ...metrics.factors import congruence_coefficient
 @pytest.mark.parametrize("orthogonalise", [True, False])
 @pytest.mark.parametrize("true_rank,rank", [(1, 1), (3, 5)])
 @pytest.mark.parametrize("init", ['svd', 'random'])
-def test_parafac(linesearch, orthogonalise, true_rank, rank, init):
+def test_parafac(linesearch, orthogonalise, true_rank, rank, init, monkeypatch):
     """Test for the CANDECOMP-PARAFAC decomposition
     """
     rng = tl.check_random_state(1234)
@@ -64,6 +64,8 @@ def test_parafac(linesearch, orthogonalise, true_rank, rank, init):
     with np.testing.assert_raises(ValueError):
         _, _ = initialize_cp(tensor, rank, init='bogus init type')
 
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, parafac, CP, ignore_args={'return_errors'}, rank=3)
+
 
 @pytest.mark.parametrize("linesearch", [True, False])
 def test_masked_parafac(linesearch):
@@ -106,7 +108,7 @@ def test_parafac_linesearch():
                                              'CP with line-search seems to have converged more slowly.')
 
 
-def test_non_negative_parafac():
+def test_non_negative_parafac(monkeypatch):
     """Test for non-negative PARAFAC
 
     TODO: more rigorous test
@@ -157,8 +159,10 @@ def test_non_negative_parafac():
     assert_(T.max(T.abs(rec_svd - rec_random)) < tol_max_abs,
             'abs norm of difference between svd and random init too high')
 
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, non_negative_parafac, CP_NN, ignore_args={'return_errors'}, rank=3)
 
-def test_non_negative_parafac_hals():
+
+def test_non_negative_parafac_hals(monkeypatch):
     """Test for non-negative PARAFAC HALS
     TODO: more rigorous test
     """
@@ -207,6 +211,8 @@ def test_non_negative_parafac_hals():
             'norm 2 of difference between svd and random init too high')
     assert_(tl.max(tl.abs(rec_svd - rec_random)) < tol_max_abs,
             'abs norm of difference between svd and random init too high')
+
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, non_negative_parafac_hals, CP_NN_HALS, ignore_args={'return_errors'}, rank=3)
 
 
 def test_non_negative_parafac_hals_one_unconstrained():
@@ -264,7 +270,7 @@ def test_sample_khatri_rao():
 
 
 @pytest.mark.xfail(tl.get_backend() == 'tensorflow', reason='Fails on tensorflow')
-def test_randomised_parafac():
+def test_randomised_parafac(monkeypatch):
     """ Test for randomised_parafac
     """
     rng = tl.check_random_state(1234)
@@ -285,3 +291,5 @@ def test_randomised_parafac():
     reconstruction = cp_to_tensor(cp_tensor)
     error = float(T.norm(reconstruction - tensor, 2)/T.norm(tensor, 2))
     assert_(error < tolerance, msg='reconstruction of {} (higher than tolerance of {})'.format(error, tolerance))
+
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, randomised_parafac, RandomizedCP, ignore_args={'return_errors'}, rank=3, n_samples=100)

--- a/tensorly/decomposition/tests/test_cp_power.py
+++ b/tensorly/decomposition/tests/test_cp_power.py
@@ -1,11 +1,11 @@
 import tensorly as tl
 from ...random import random_cp
-from ...testing import assert_
+from ...testing import assert_, assert_class_wrapper_correctly_passes_arguments
 
-from .._cp_power import parafac_power_iteration
+from .._cp_power import parafac_power_iteration, CPPower
 
 
-def test_parafac_power_iteration():
+def test_parafac_power_iteration(monkeypatch):
     """Test for symmetric Parafac optimized with robust tensor power iterations"""
     rng = tl.check_random_state(1234)
     tol_norm_2 = 10e-1
@@ -23,3 +23,6 @@ def test_parafac_power_iteration():
     error = tl.max(tl.abs(rec - tensor))
     assert_(error < tol_max_abs,
             f'Absolute norm of reconstruction error={error} higher than tol={tol_max_abs}.')
+
+    
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, parafac_power_iteration, CPPower, ignore_args={}, rank=3)

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -6,8 +6,8 @@ import pytest
 import tensorly as tl
 from ...random import random_parafac2
 from ... import backend as T
-from ...testing import assert_array_equal, assert_
-from .._parafac2 import parafac2, initialize_decomposition, _pad_by_zeros
+from ...testing import assert_array_equal, assert_, assert_class_wrapper_correctly_passes_arguments
+from .._parafac2 import Parafac2, parafac2, initialize_decomposition, _pad_by_zeros
 from ...parafac2_tensor import Parafac2Tensor, parafac2_to_tensor, parafac2_to_slices
 from ...metrics.factors import congruence_coefficient
 
@@ -16,7 +16,7 @@ from ...metrics.factors import congruence_coefficient
     ("normalize_factors", "init"),
      itertools.product([True, False], ["random", "svd"])
 )
-def test_parafac2(normalize_factors, init):
+def test_parafac2(monkeypatch, normalize_factors, init):
     rng = tl.check_random_state(1234)
     tol_norm_2 = 10e-2
     rank = 3
@@ -64,6 +64,8 @@ def test_parafac2(normalize_factors, init):
         rec_Bi = T.dot(rec_proj, rec.factors[1])*rec_A_sign[i]
         Bi_corr = congruence_coefficient(true_Bi, rec_Bi)[0]
         assert_(Bi_corr > 0.98)
+
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, parafac2, Parafac2, ignore_args={'return_errors'}, rank=3)
 
 
 def test_parafac2_nn():

--- a/tensorly/decomposition/tests/test_symmetric_cp.py
+++ b/tensorly/decomposition/tests/test_symmetric_cp.py
@@ -1,10 +1,10 @@
 import tensorly as tl
-from ...testing import assert_
+from ...testing import assert_, assert_class_wrapper_correctly_passes_arguments
 
-from .._symmetric_cp import symmetric_parafac_power_iteration
+from .._symmetric_cp import symmetric_parafac_power_iteration, SymmetricCP
 
 
-def test_symmetric_parafac_power_iteration():
+def test_symmetric_parafac_power_iteration(monkeypatch):
     """Test for symmetric Parafac optimized with robust tensor power iterations"""
     rng = tl.check_random_state(1234)
     tol_norm_2 = 10e-1
@@ -25,3 +25,4 @@ def test_symmetric_parafac_power_iteration():
     # Test the max abs difference between the reconstruction and the tensor
     assert_(tl.max(tl.abs(rec - tensor)) < tol_max_abs,
             'abs norm of reconstruction error higher than tol')
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, symmetric_parafac_power_iteration, SymmetricCP, ignore_args={}, rank=3)

--- a/tensorly/decomposition/tests/test_tt_decomposition.py
+++ b/tensorly/decomposition/tests/test_tt_decomposition.py
@@ -1,11 +1,11 @@
 import tensorly as tl
-from .._tt import tensor_train, tensor_train_matrix
+from .._tt import tensor_train, tensor_train_matrix, TensorTrain
 from ...tt_matrix import tt_matrix_to_tensor
 from ...random import random_tt
-from ...testing import assert_, assert_array_almost_equal
+from ...testing import assert_, assert_array_almost_equal, assert_class_wrapper_correctly_passes_arguments
 
 
-def test_tensor_train():
+def test_tensor_train(monkeypatch):
     """ Test for tensor_train """
     rng = tl.check_random_state(1234)
 
@@ -59,6 +59,8 @@ def test_tensor_train():
     error /= tl.norm(tensor, 2)
     assert_(error < tol,
               'norm 2 of reconstruction higher than tol')
+
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, tensor_train, TensorTrain, ignore_args={}, rank=3)
 
 
 def test_tensor_train_matrix():

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -1,10 +1,10 @@
 import numpy as np
 import tensorly as tl
-from .._tucker import tucker, partial_tucker, non_negative_tucker
+from .._tucker import tucker, partial_tucker, non_negative_tucker, Tucker, TuckerNN
 from ...tucker_tensor import tucker_to_tensor
 from ...tenalg import multi_mode_dot
 from ...random import random_tucker
-from ...testing import assert_equal, assert_, assert_array_equal
+from ...testing import assert_equal, assert_, assert_array_equal, assert_class_wrapper_correctly_passes_arguments
 
 
 def test_partial_tucker():
@@ -41,7 +41,7 @@ def test_partial_tucker():
         assert_array_equal(factor1, factor2)
 
 
-def test_tucker():
+def test_tucker(monkeypatch):
     """Test for the Tucker decomposition"""
     rng = tl.check_random_state(1234)
 
@@ -86,6 +86,7 @@ def test_tucker():
             'norm 2 of difference between svd and random init too high')
     assert_(tl.max(tl.abs(rec_svd - rec_random)) < tol_max_abs,
             'abs norm of difference between svd and random init too high')
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, tucker, Tucker, ignore_args={}, rank=3)
 
 def test_masked_tucker():
     """Test for the masked Tucker decomposition.
@@ -115,7 +116,7 @@ def test_masked_tucker():
 
     assert_(mask_err < 0.001, 'norm 2 of reconstruction higher than 0.001')
 
-def test_non_negative_tucker():
+def test_non_negative_tucker(monkeypatch):
     """Test for non-negative Tucker"""
     rng = tl.check_random_state(1234)
 
@@ -162,3 +163,5 @@ def test_non_negative_tucker():
         expected_shape = (tl.shape(tensor)[i], rank)
         assert_(tl.shape(f) == expected_shape, '{}-th factor has the wrong shape, got {}, but expected {}.'.format(
                 i, tl.shape(f), expected_shape))
+
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, non_negative_tucker, TuckerNN, ignore_args={}, rank=3)

--- a/tensorly/testing.py
+++ b/tensorly/testing.py
@@ -1,3 +1,6 @@
+import sys
+from inspect import getfullargspec
+
 import numpy as np
 
 from tensorly import backend as T
@@ -25,5 +28,66 @@ def assert_equal(actual, desired, *args, **kwargs):
                             *args, **kwargs)
 
 
+def _get_defaultkwargs(func):
+    """Returns a Parameter instance for the specified argument.
+    """
+    argspec = getfullargspec(func)
+
+    arguments = argspec.args
+    defaults = argspec.defaults
+    kwonlydefaults = argspec.kwonlydefaults
+    if defaults is None:
+        defaults = tuple()
+    if kwonlydefaults is None:
+        kwonlydefaults = {}
+
+    start_defaults_idx = len(arguments) - len(defaults)
+    arguments = arguments[start_defaults_idx:]
+    default_args = {argument: default for argument, default in zip(arguments, defaults)}
+
+    return {**default_args, **kwonlydefaults,}
+
+
+def _get_decomposition_checker(supposed_kwargs, output_length):
+    def decomposition_function(*args, **kwargs):
+        for argument, supposed_default in supposed_kwargs.items():
+            np.testing.assert_(argument in kwargs, "All arguments with a default must be passed as keyword argument when the decomposition class calls the decomposition function")
+            np.testing.assert_(kwargs[argument] == supposed_default)
+        return [None for _ in range(output_length)]
+    return decomposition_function
+
+
+def assert_class_wrapper_correctly_passes_arguments(
+        monkeypatch, decomposition_function, DecompositionClass, ignore_args=None, decomposition_output_length=2, **extra_args
+    ):
+    """Used to ensure that all arguments are passed correctly from the decomposition class to the decomposition function
+
+    Arguments:
+    ----------
+    monkeypatch : pytest.monkeypatch
+        Monkeypatch fixture
+    decomposition_function : Function
+        Decomposition function wrapped by the class
+    DecompositionClass : Class
+        Class that wraps the function
+    ignore_args : iterable
+        List of arguments that shouldn't be checked
+    decomposition_output_length : int
+        Number of outputs from the decomposition function
+    **extra_args
+        Extra keyword-arguments passed to the decomposition class
+    """
+    kwargs = _get_defaultkwargs(decomposition_function)
+    test_kwargs = {argument: 'this_is_used_to_test_correct_passing_of_arguments' for argument in kwargs}
+    if ignore_args is not None:
+        for arg in ignore_args:
+            del test_kwargs[arg]
+    decomposition_checker = _get_decomposition_checker(test_kwargs, decomposition_output_length)
+
+    decomposition_module = sys.modules[decomposition_function.__module__]
+    monkeypatch.setattr(decomposition_module, decomposition_function.__name__, decomposition_checker)
+    DecompositionClass(**extra_args, **test_kwargs).fit(None)
+
+    
 assert_ = np.testing.assert_
 assert_raises = np.testing.assert_raises


### PR DESCRIPTION
I noticed that many of the small class wrappers for the decomposition functions had outdated signatures, so I made a test utility to automatically compare the decomposition function and the wrapped class. It essentially works like this

1. Inspect the decomposition function to find all arguments with default values (`_get_defaultkwargs`)
1. Create a function that checks all the given keyword arguments against a predefined dictionary (generated via a factory function that takes this dictionary as input in the `_get_decomposition_checker`)
1. Use the `monkeypatch` fixture in PyTest to monkeypatch the check function created in step 2 to replace the specified decomposition function
1. Create a decomposition object where each argument of the decomposition function that had a default value are specified with a keyword-argument, setting it equal to a test-string
1. Fit this model. However, since the decomposition function is monkeypatched, we instead check that all arguments are set correctly

I tested this and found inconsistent signatures for many of the decomposition classes, and fixed these inconsistencies in all cases except for `Parafac2`, since I know @marieroald has fixed that in #267.