### PR TITLE
Bugfix:HALS convergence checking fails when non-negativity is not imposed on final mode

### DIFF
--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -420,7 +420,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
                 factors[mode] = tl.transpose(factor)
         if tol:
             factors_norm = cp_norm((weights, factors))
-            iprod = tl.sum(tl.sum(mttkrp * factor, axis=0) * weights)
+            iprod = tl.sum(tl.sum(mttkrp * factors[-1], axis=0) * weights)
             rec_error = tl.sqrt(tl.abs(norm_tensor**2 + factors_norm**2 - 2 * iprod)) / norm_tensor
             rec_errors.append(rec_error)
             if iteration >= 1:

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -208,6 +208,14 @@ def test_non_negative_parafac_hals():
     assert_(tl.max(tl.abs(rec_svd - rec_random)) < tol_max_abs,
             'abs norm of difference between svd and random init too high')
 
+    # Regression test: used wrong variable for convergence checking
+    # Used mttkrp*factor instead of mttkrp*factors[-1], which resulted in
+    # error when mode 2 was not constrained and erroneous convergence checking
+    # when mode 2 was constrained.
+    tensor = tl.tensor(rng.random_sample((3, 3, 3))+1)
+    nn_estimate, errs = non_negative_parafac_hals(
+        tensor, rank=2, n_iter_max=2, tol=1e-10, init='svd', verbose=0, nn_modes={0,}, return_errors=True
+    )
 
 def test_non_negative_parafac_hals_one_unconstrained():
     """Test for non-negative PARAFAC HALS


### PR DESCRIPTION
@IsabellLehmann informed me of a bug in the convergence checking of NN CP HALS. If non-negativity is not imposed on the final factor matrix, then the convergence checking will fail, and if non-negativity is imposed, then the loss computation will be off by one iteration. The culprit is line 423 in _nn_cp.py, which says

    iprod=tl.sum(tl.sum(mttkrp*factor, axis=0) *weights)

This works only accidentally when non-negativity is imposed on all modes, since the final factor matrix of the previous iterate is stored in a variable named factor. If non-negativity is not imposed on the final mode, we get an error because the line

    factor=tl.solve(tl.transpose(pseudo_inverse), tl.transpose(mttkrp))

which sets `factor` to the transposed factor matrix. Fixing it is simple, we only change 

    iprod=tl.sum(tl.sum(mttkrp*factor, axis=0) *weights)

to be

    iprod=tl.sum(tl.sum(mttkrp*factors[-1], axis=0) *weights)

I added this fix and a simple test.