### PR TITLE
adding tl.trace and tl.cumsum functions

### DIFF
--- a/tensorly/backend/core.py
+++ b/tensorly/backend/core.py
@@ -332,6 +332,34 @@ class Backend(object):
         raise NotImplementedError
 
     @staticmethod
+    def trace(tensor):
+        """Returns sum of the elements on the diagonal of the tensor.
+
+        Parameters
+        ----------
+        tensor : tensor
+
+        Returns
+        -------
+        out : scalar or tensor
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def cumsum(tensor, axis=None):
+        """Computes the cumulative sum of a tensor, optionally along an axis.
+
+        Parameters
+        ----------
+        tensor : tensor
+
+        Returns
+        -------
+        tensor
+        """
+        raise NotImplementedError
+
+    @staticmethod
     def where(condition, x, y):
         """Return elements, either from `x` or `y`, depending on `condition`.
 

--- a/tensorly/backend/cupy_backend.py
+++ b/tensorly/backend/cupy_backend.py
@@ -54,9 +54,9 @@ class CupyBackend(Backend):
 
 
 for name in ['float64', 'float32', 'int64', 'int32', 'complex128', 'complex64', 'reshape', 'moveaxis',
-             'transpose', 'copy', 'ones', 'zeros', 'zeros_like', 'eye', 'any', 
+             'transpose', 'copy', 'ones', 'zeros', 'zeros_like', 'eye', 'trace', 'any',
              'arange', 'where', 'dot', 'kron', 'concatenate', 'max', 'flip',
-             'min', 'all', 'mean', 'sum', 'prod', 'sign', 'abs', 'sqrt', 'stack',
+             'min', 'all', 'mean', 'sum', 'cumsum', 'prod', 'sign', 'abs', 'sqrt', 'stack',
              'conj', 'diag', 'einsum', 'log2', 'tensordot']:
     CupyBackend.register_method(name, getattr(cp, name))
 

--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -78,9 +78,9 @@ class JaxBackend(Backend):
             return np.sort(tensor, axis=axis)
 
 for name in ['int64', 'int32', 'float64', 'float32', 'complex128', 'complex64', 'reshape', 'moveaxis',
-             'where', 'transpose', 'arange', 'ones', 'zeros', 'flip', 'any',
+             'where', 'transpose', 'arange', 'ones', 'zeros', 'flip', 'trace', 'any',
              'zeros_like', 'eye', 'kron', 'concatenate', 'max', 'min',
-             'all', 'mean', 'sum', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
+             'all', 'mean', 'sum', 'cumsum', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
              'argmax', 'stack', 'conj', 'diag', 'clip', 'einsum', 'log2', 'tensordot', 'sin', 'cos']:
     JaxBackend.register_method(name, getattr(np, name))
 

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -101,9 +101,9 @@ class MxnetBackend(Backend):
 
 
 for name in ['int64', 'int32', 'float64', 'float32', 'reshape', 'moveaxis',
-             'where', 'copy', 'transpose', 'arange', 'ones', 'zeros', 'any',
+             'where', 'copy', 'transpose', 'arange', 'ones', 'zeros', 'trace', 'any',
              'zeros_like', 'eye', 'concatenate', 'max', 'min', 'flip',
-             'all', 'mean', 'sum', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
+             'all', 'mean', 'sum', 'cumsum', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
              'argmax', 'stack', 'diag', 'einsum', 'log2', 'tensordot', 'sin', 'cos']:
     MxnetBackend.register_method(name, getattr(np, name))
 

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -61,10 +61,10 @@ class NumpyBackend(Backend):
             return np.sort(tensor, axis=axis)
 
 for name in ['int64', 'int32', 'float64', 'float32', 'complex128', 'complex64', 
-             'reshape', 'moveaxis', 'any',
+             'reshape', 'moveaxis', 'any', 'trace',
              'where', 'copy', 'transpose', 'arange', 'ones', 'zeros', 'flip',
              'zeros_like', 'eye', 'kron', 'concatenate', 'max', 'min',
-             'all', 'mean', 'sum', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
+             'all', 'mean', 'sum', 'cumsum', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
              'argmax', 'stack', 'conj', 'diag', 'einsum', 'log2', 'tensordot', 'sin', 'cos']:
     NumpyBackend.register_method(name, getattr(np, name))
 

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -187,7 +187,7 @@ class PyTorchBackend(Backend):
 
 # Register the other functions
 for name in ['float64', 'float32', 'int64', 'int32', 'complex128', 'complex64',
-             'is_tensor', 'ones', 'zeros', 'any', 
+             'is_tensor', 'ones', 'zeros', 'any', 'trace', 'cumsum',
              'zeros_like', 'reshape', 'eye', 'max', 'min', 'prod', 'abs', 
              'sqrt', 'sign', 'where', 'conj', 'diag', 'finfo', 'einsum', 'log2', 'sin', 'cos']:
     PyTorchBackend.register_method(name, getattr(torch, name))

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -183,6 +183,7 @@ _FUN_NAMES = [
     (tf.sqrt, 'sqrt'),
     (tf.linalg.qr, 'qr'),
     (tf.linalg.eigh, 'eigh'),
+    (tf.linalg.trace, 'trace'),
     (tf.argmin, 'argmin'),
     (tf.argmax, 'argmax'),
     (tf.stack, 'stack'),
@@ -199,6 +200,7 @@ _FUN_NAMES = [
     (tf.tensordot, 'tensordot'),
     (tfm.sin, 'sin'),
     (tfm.cos, 'cos'),
+    (tfm.cumsum, 'cumsum'),
     (tfm.reduce_any, 'any')
     ]
 for source_fun, target_fun_name in _FUN_NAMES:


### PR DESCRIPTION
For another PR that I am planning to submit soon, I need to use trace and cumsum functions for some algorithms. Since these functions could be useful for other algorithms as well, I wanted to add them to Tensorly. According to my experiments, I haven't seen any issue with the backends.