### PR TITLE
Bugfix: Initialising non-negative CP with precomputed decomposition erroneously modified the initialisation

### DIFF
--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -364,8 +364,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
 
     weights, factors = initialize_nn_cp(tensor, rank, init=init, svd=svd,
                                         random_state=None,
-                                        normalize_factors=False,
-                                        nn_modes=nn_modes)
+                                        normalize_factors=False)
 
     norm_tensor = tl.norm(tensor, 2)
 

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -88,7 +88,7 @@ def make_svd_non_negative(tensor, U, S, V, nntype):
 
 
 def initialize_nn_cp(tensor, rank, init='svd', svd='numpy_svd', random_state=None,
-                     normalize_factors=False, nntype='nndsvda', nn_modes='all'):
+                     normalize_factors=False, nntype='nndsvda'):
     r"""Initialize factors used in `parafac`.
 
     The type of initialization is set using `init`. If `init == 'random'` then

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -6,8 +6,8 @@ import tensorly as tl
 from .._cp import (
     parafac, initialize_cp,
     sample_khatri_rao, randomised_parafac)
-from .._nn_cp import non_negative_parafac, non_negative_parafac_hals
-from ...cp_tensor import cp_to_tensor
+from .._nn_cp import non_negative_parafac, non_negative_parafac_hals, initialize_nn_cp
+from ...cp_tensor import cp_to_tensor, CPTensor
 from ...random import random_cp
 from ...tenalg import khatri_rao
 from ... import backend as T
@@ -156,6 +156,17 @@ def test_non_negative_parafac():
             'norm 2 of difference between svd and random init too high')
     assert_(T.max(T.abs(rec_svd - rec_random)) < tol_max_abs,
             'abs norm of difference between svd and random init too high')
+
+
+def test_initialize_nn_cp():
+    """Test that if we initialise with an existing init, then it isn't modified.
+    """
+    init = CPTensor([None, [-tl.ones((30, 3)), -tl.ones((20, 3)), -tl.ones((10, 3))]])
+    tensor = cp_to_tensor(init)
+    initialised_tensor = initialize_nn_cp(tensor, 3, init=init)
+    for factor_matrix, init_factor_matrix in zip(init[1], initialised_tensor[1]):
+        assert_array_equal(factor_matrix, init_factor_matrix)
+    assert_array_equal(tensor, cp_to_tensor(initialised_tensor))
 
 
 def test_non_negative_parafac_hals():


### PR DESCRIPTION
Here is another bugfix to a bug encountered by @IsabellLehmann. When we initialised non-negative CP with a pre-computed decomposition, the pre-computed decomposition was modified before fitting. Specifically, this line led to problems

    kt.factors = [tl.abs(f) for f in kt[1]]

Since it took the absolute value of all factor matrices. If we input a pre-defined decomposition, then it shouldn't be modified by the initialisation function. This led to problematic behaviour for PARAFAC2, when some factor matrices had negative elements.
