### PR TITLE
Normalization

### DIFF
--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -338,6 +338,8 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',
             factor = tl.transpose(tl.solve(tl.transpose(pseudo_inverse),
                                   tl.transpose(mttkrp)))
             factors[mode] = factor
+            if normalize_factors and mode != modes_list[-1]:
+                   weights, factors = cp_normalize((weights, factors))
 
         # Will we be performing a line search iteration
         if linesearch and iteration % 2 == 0 and iteration > 5:

--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -180,7 +180,7 @@ def error_calc(tensor, norm_tensor, weights, factors, sparsity, mask, mttkrp=Non
 
             # mttkrp and factor for the last mode. This is equivalent to the
             # inner product <tensor, factorization>
-            iprod = tl.sum(tl.sum(mttkrp * factors[-1], axis=0) * weights)
+            iprod = tl.sum(tl.sum(mttkrp * factors[-1], axis=0))
             unnorml_rec_error = tl.sqrt(tl.abs(norm_tensor**2 + factors_norm**2 - 2 * iprod))
 
     return unnorml_rec_error, tensor, norm_tensor
@@ -332,17 +332,11 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',
                 if i != mode:
                     pseudo_inverse = pseudo_inverse * tl.dot(tl.transpose(factor), factor)
             pseudo_inverse += Id
-
-            mttkrp = unfolding_dot_khatri_rao(tensor, (None, factors), mode)
+            pseudo_inverse = tl.reshape(weights, (-1, 1)) * pseudo_inverse * tl.reshape(weights, (1, -1))
+            mttkrp = unfolding_dot_khatri_rao(tensor, (weights, factors), mode)
 
             factor = tl.transpose(tl.solve(tl.transpose(pseudo_inverse),
                                   tl.transpose(mttkrp)))
-
-            if normalize_factors:
-                scales = tl.norm(factor, 2, axis=0)
-                weights = tl.where(scales==0, tl.ones(tl.shape(scales), **tl.context(factor)), scales)
-                factor = factor / tl.reshape(weights, (1, -1))
-
             factors[mode] = factor
 
         # Will we be performing a line search iteration
@@ -415,7 +409,8 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',
             else:
                 if verbose:
                     print('reconstruction error={}'.format(rec_errors[-1]))
-
+        if normalize_factors:
+            weights, factors = cp_normalize((weights, factors))
     cp_tensor = CPTensor((weights, factors))
     
     if sparsity:

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -420,7 +420,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
                 factors[mode] = tl.transpose(factor)
         if tol:
             factors_norm = cp_norm((weights, factors))
-            iprod = tl.sum(tl.sum(mttkrp * factors[-1], axis=0) * weights)
+            iprod = tl.sum(tl.sum(mttkrp * factors[-1], axis=0))
             rec_error = tl.sqrt(tl.abs(norm_tensor**2 + factors_norm**2 - 2 * iprod)) / norm_tensor
             rec_errors.append(rec_error)
             if iteration >= 1:

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -652,7 +652,7 @@ class CP_NN_HALS(DecompositionMixin):
 
     def __init__(self, rank, n_iter_max=100, init="svd", svd='numpy_svd', tol=10e-8,
                  sparsity_coefficients=None, fixed_modes=None, nn_modes='all', exact=False,
-                 verbose=False, cvg_criterion='abs_rec_error'):
+                 verbose=False, normalize_factors=False, cvg_criterion='abs_rec_error'):
         self.rank = rank
         self.n_iter_max = n_iter_max
         self.init = init
@@ -663,6 +663,7 @@ class CP_NN_HALS(DecompositionMixin):
         self.nn_modes = nn_modes
         self.exact = exact
         self.verbose = verbose
+        self.normalize_factors = normalize_factors
         self.cvg_criterion = cvg_criterion
 
     def fit_transform(self, tensor):
@@ -691,6 +692,7 @@ class CP_NN_HALS(DecompositionMixin):
             nn_modes=self.nn_modes,
             exact=self.exact,
             verbose=self.verbose,
+            normalize_factors=self.normalize_factors,
             return_errors=True,
             cvg_criterion=self.cvg_criterion,
         )

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -41,6 +41,17 @@ def test_parafac(linesearch, orthogonalise, true_rank, rank, init, monkeypatch):
     assert_(T.max(T.abs(rec - tensor)) < tol_max_abs,
             f'abs norm of reconstruction error = {T.max(T.abs(rec - tensor))} higher than tolerance={tol_max_abs}')
 
+    # Test normalization
+    res = parafac(tensor, rank=rank, n_iter_max=200, normalize_factors=True, tol=10e-5, init='svd')
+    rec = cp_to_tensor(res)
+    error = T.norm(rec - tensor, 2)
+    error /= T.norm(tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+    # Test the max abs difference between the reconstruction and the tensor
+    assert_(T.max(T.abs(rec - tensor)) < tol_max_abs,
+            f'abs norm of reconstruction error = {T.max(T.abs(rec - tensor))} higher than tolerance={tol_max_abs}')
+
     # Test fixing mode 0 or 1 with given init
     fixed_tensor = random_cp((6, 8, 4), rank=true_rank, normalise_factors=False)
     rec_svd_fixed_mode_0 = parafac(tensor, rank=true_rank, n_iter_max=2, init=fixed_tensor, fixed_modes=[0], linesearch=linesearch)
@@ -135,6 +146,14 @@ def test_non_negative_parafac(monkeypatch):
     assert_(T.max(T.abs(reconstructed_tensor - nn_reconstructed_tensor)) < tol_max_abs,
             'abs norm of reconstruction error higher than tol')
 
+    # Test normalization
+    nn_res = non_negative_parafac(tensor, rank=3, normalize_factors=True, tol=10e-4, init='svd')
+    nn_reconstructed_tensor = cp_to_tensor(nn_res)
+    error = T.norm(reconstructed_tensor - nn_reconstructed_tensor, 2)
+    error /= T.norm(reconstructed_tensor, 2)
+    assert_(error < tol_norm_2,
+            'norm 2 of reconstruction higher than tol')
+
     # Test fixing mode 0 or 1 with given init
     fixed_tensor = random_cp((3, 3, 3), rank=2)
     for factor in fixed_tensor[1]:
@@ -198,6 +217,14 @@ def test_non_negative_parafac_hals(monkeypatch):
     # Test the max abs difference between the reconstruction and the tensor
     assert_(tl.max(tl.abs(reconstructed_tensor - nn_reconstructed_tensor)) < tol_max_abs,
             'abs norm of reconstruction error higher than tol')
+
+    # Test normalization
+    nn_res = non_negative_parafac_hals(tensor, rank=3, normalize_factors=True, tol=10e-4, init='svd')
+    nn_reconstructed_tensor = cp_to_tensor(nn_res)
+    error = T.norm(reconstructed_tensor - nn_reconstructed_tensor, 2)
+    error /= T.norm(reconstructed_tensor, 2)
+    assert_(error < tol_norm_2,
+            'norm 2 of reconstruction higher than tol')
 
     # Test fixing mode 0 or 1 with given init
     fixed_tensor = random_cp((3, 3, 3), rank=2)


### PR DESCRIPTION
This pull request is related to issue #264. We suggest some updates in _nn_cp and _cp.py files in order to have consistent normalization options for non_negative_parafac, non_negative_parafac_hals and parafac functions. In these 3 functions, we added weights to mttkrp and pseudo_inverse (accum for non_negative_parafac) computation; 

```python
mttkrp = unfolding_dot_khatri_rao(tensor, (weights, factors), mode)
pseudo_inverse = tl.reshape(weights, (-1, 1)) * pseudo_inverse * tl.reshape(weights, (1, -1))
``` 

Since we have used weights to compute mttkrp, we removed the weights from the iprod computation;

```python
iprod = tl.sum(tl.sum(mttkrp * factors[-1], axis=0))
```


Finally, we suggest to use cp_normalize function after the error computation for all functions. 

According to our experiments, we don't observe any error as in issue #264 with these modifications.