### PR TITLE
Added random_state to CP and NN_CP when init='random'

### DIFF
--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -44,7 +44,7 @@ def initialize_cp(tensor, rank, init='svd', svd='numpy_svd', random_state=None, 
     rng = tl.check_random_state(random_state)
 
     if init == 'random':
-        kt = random_cp(tl.shape(tensor), rank, normalise_factors=False, **tl.context(tensor))
+        kt = random_cp(tl.shape(tensor), rank, normalise_factors=False, random_state=rng, **tl.context(tensor))
 
     elif init == 'svd':
         try:

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -115,7 +115,7 @@ def initialize_nn_cp(tensor, rank, init='svd', svd='numpy_svd', random_state=Non
     rng = tl.check_random_state(random_state)
 
     if init == 'random':
-        kt = random_cp(tl.shape(tensor), rank, normalise_factors=False, **tl.context(tensor))
+        kt = random_cp(tl.shape(tensor), rank, normalise_factors=False, random_state=rng, **tl.context(tensor))
 
     elif init == 'svd':
         try:


### PR DESCRIPTION
This pull request added the option of passing random_state to CP and NN_CP decomposition. Although the option was implemented, it was working only for cases when init='svd' and not when init='random'.