### PR TITLE
Gradient of the difference norm between a CP and dense tensor

### DIFF
--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -359,13 +359,13 @@ def cp_lstsq_grad(cp_tensor, tensor, return_loss=False, mask=None):
 
     .. math::
 
-        \nabla 0.5 ||\mathcal{X} - [\mathbf{w}; \mathbf{A}, \mathbf{B}, \mathbf{C}]||^2
+        \nabla 0.5 ||\\mathcal{X} - [\\mathbf{w}; \\mathbf{A}, \\mathbf{B}, \\mathbf{C}]||^2
 
-    where :math:`[\mathbf{w}; \mathbf{A}, \mathbf{B}, \mathbf{C}]` is the CP decomposition with weights
-    :math:`\mathbf{w}` and factor matrices :math:`\mathbf{A}`, :math:`\mathbf{B}` and :math:`\mathbf{C}`.
+    where :math:`[\\mathbf{w}; \\mathbf{A}, \\mathbf{B}, \\mathbf{C}]` is the CP decomposition with weights
+    :math:`\\mathbf{w}` and factor matrices :math:`\\mathbf{A}`, :math:`\\mathbf{B}` and :math:`\\mathbf{C}`.
 
     Note that this does not return the gradient with respect to the weights even if CP is normalized.
-    
+
     Parameters
     ----------
     cp_tensor : CPTensor = (weight, factors)

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -5,7 +5,7 @@ Core operations on CP tensors.
 from . import backend as T
 from .base import fold, tensor_to_vec
 from ._factorized_tensor import FactorizedTensor
-from .tenalg import khatri_rao, multi_mode_dot, inner
+from .tenalg import khatri_rao, multi_mode_dot
 from .utils import DefineDeprecated
 
 import numpy as np

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -356,6 +356,8 @@ def cp_flip_sign(cp_tensor, mode=0, func=None):
 
 def cp_lstsq_grad(cp_tensor, tensor, mask=None):
     """Returns the gradient of the least squares difference between a CP and dense tensor.
+
+    Note that this does not return the gradient with respect to the weights even if CP is normalized.
     
     Parameters
     ----------
@@ -370,10 +372,13 @@ def cp_lstsq_grad(cp_tensor, tensor, mask=None):
 
     Returns
     -------
-    
+    cp_gradient : CPTensor = (None, factors)
+        factors is a list of factor matrix gradients, all with the same number of columns
+        i.e. for all matrix U in factor_matrices:
+        U has shape ``(s_i, R)``, where R is fixed and s_i varies with i
     """
     _validate_cp_tensor(cp_tensor)
-    weights, factors = cp_tensor
+    _, factors = cp_tensor
 
     diff = tensor - cp_to_tensor(cp_tensor)
 
@@ -381,7 +386,7 @@ def cp_lstsq_grad(cp_tensor, tensor, mask=None):
         diff = diff * mask
 
     grad_fac = [-unfolding_dot_khatri_rao(diff, cp_tensor, ii) for ii in range(len(factors))]
-    return CPTensor((weights, grad_fac))
+    return CPTensor((None, grad_fac))
 
 
 def cp_to_tensor(cp_tensor, mask=None):

--- a/tensorly/tests/test_cp_tensor.py
+++ b/tensorly/tests/test_cp_tensor.py
@@ -7,7 +7,8 @@ from ..cp_tensor import (cp_to_tensor, cp_to_unfolded,
                               cp_normalize, CPTensor,
                               cp_mode_dot, unfolding_dot_khatri_rao,
                               cp_norm, cp_flip_sign,
-                              _cp_n_param, validate_cp_rank
+                              _cp_n_param, validate_cp_rank,
+                              cp_lstsq_grad
                         )
 from ..base import unfold, tensor_to_vec
 from tensorly.random import random_cp
@@ -263,3 +264,14 @@ def testvalidate_cp_rank():
     n_param = _cp_n_param(tensor_shape, rank)
     assert_(n_param >= n_param_tensor)
 
+def test_cp_lstsq_grad():
+    """Validate the gradient calculation between a CP and dense tensor."""
+    shape = (3, 4, 5)
+    rank = 4
+    cp_tensor = random_cp(shape, rank, normalise_factors=False)
+    tensor = cp_to_tensor(cp_tensor)
+
+    cp_grad = cp_lstsq_grad(cp_tensor, tensor)
+
+    # If we're taking the gradient of comparison with self it should be 0
+    assert_(cp_norm(cp_grad) <= 10e-5)

--- a/tensorly/tests/test_cp_tensor.py
+++ b/tensorly/tests/test_cp_tensor.py
@@ -266,8 +266,8 @@ def testvalidate_cp_rank():
 
 def test_cp_lstsq_grad():
     """Validate the gradient calculation between a CP and dense tensor."""
-    shape = (3, 4, 5)
-    rank = 4
+    shape = (2, 3, 4)
+    rank = 2
     cp_tensor = random_cp(shape, rank, normalise_factors=False)
 
     # If we're taking the gradient of comparison with self it should be 0
@@ -281,7 +281,7 @@ def test_cp_lstsq_grad():
     cp_grad = cp_lstsq_grad(cp_tensor, dense)
     cp_new = CPTensor(cp_tensor)
     for ii in range(len(shape)):
-        cp_new.factors[ii] = cp_tensor.factors[ii] - 1e-9 * cp_grad.factors[ii]
+        cp_new.factors[ii] = cp_tensor.factors[ii] - 1e-3 * cp_grad.factors[ii]
 
     cost_after = tl.norm(cp_to_tensor(cp_new) - dense)
     assert_(cost_before > cost_after)


### PR DESCRIPTION
A few notes:

- This does not take the gradient with respect to the weights.
- This only solves for the l2 norm difference. Adding other norms, if useful, probably wouldn't be too much work.
- In testing, I figured that comparing to numerical differencing would be slow, so I check that the negative gradient is a direction of descent with some small perturbation.
- There might be faster ways to calculate this... this is just what I came across in a literature search.