### PR TITLE
Added random seed for tensor_train_cross

### DIFF
--- a/tensorly/contrib/decomposition/_tt_cross.py
+++ b/tensorly/contrib/decomposition/_tt_cross.py
@@ -3,7 +3,7 @@ from ...tt_tensor import tt_to_tensor
 import numpy as np
 
 
-def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100):
+def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100, random_state=None):
     """TT (tensor-train) decomposition via cross-approximation (TTcross) [1]
 
     Decomposes `input_tensor` into a sequence of order-3 tensors of given rank. (factors/cores)
@@ -30,6 +30,7 @@ def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100):
             accuracy threshold for outer while-loop
     n_iter_max : int
             maximum iterations of outer while-loop (the 'crosses' or 'sweeps' sampled)
+    random_state : {None, int, np.random.RandomState}
 
     Returns
     -------
@@ -115,8 +116,7 @@ def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100):
     # list row_idx: row indices    (left indices)  for skeleton-decomposition: indicate which rows used in each core.
 
     # Initialize indice: random selection of column indices
-    random_seed = None
-    rng = tl.check_random_state(random_seed)
+    rng = tl.check_random_state(random_state)
 
     col_idx = [None] * tensor_order
     for k_col_idx in range(tensor_order - 1):

--- a/tensorly/contrib/decomposition/tests/test_mps_decomposition_cross.py
+++ b/tensorly/contrib/decomposition/tests/test_mps_decomposition_cross.py
@@ -28,7 +28,7 @@ def test_tensor_train_cross_1():
 
     # Find TT decomposition of the tensor
     rank = [1, 3, 3, 1]
-    factors = tensor_train_cross(tensor, rank, tol=1e-5, n_iter_max=10)
+    factors = tensor_train_cross(tensor, rank, tol=1e-5, n_iter_max=10, random_state=1234)
     assert(len(factors) == d), "Number of factors should be 4, currently has " + str(len(factors))
 
     # Check that the ranks are correct and that the second mode of each factor
@@ -52,7 +52,7 @@ def test_tensor_train_cross_2():
 
     # Find TT decomposition of the tensor
     rank = [1, 2, 2, 3, 2, 2, 1]
-    factors = tensor_train_cross(tensor, rank)
+    factors = tensor_train_cross(tensor, rank, random_state=rng)
 
     for k in range(6):
         (r_prev, n_k, r_k) = factors[k].shape
@@ -75,7 +75,7 @@ def test_tensor_train_cross_3():
     ## Test 3
     tol = 10e-5
     tensor = tl.tensor(rng.random_sample([3, 3, 3]))
-    factors = tensor_train_cross(tensor, (1, 3, 3, 1))
+    factors = tensor_train_cross(tensor, (1, 3, 3, 1), random_state=rng)
     reconstructed_tensor = tt_to_tensor(factors)
     error = tl.norm(reconstructed_tensor - tensor, 2)
     error /= tl.norm(tensor, 2)
@@ -129,7 +129,7 @@ def test_tensor_train_cross_4():
 
     # Find TT decomposition of the tensor
     rank = [1, 4, 4, 4, 1]
-    factors = tensor_train_cross(value, rank, tol=tol)
+    factors = tensor_train_cross(value, rank, tol=tol, random_state=rng)
 
     approx = tt_to_tensor(factors)
     error = tl.norm(approx-value,2)


### PR DESCRIPTION
`tensor_train_cross` did not accept a random seed despite using randomly initialised components. This led to some tests failing randomly.

This pull request adds an optional `random_state` argument to the `tensor_train_cross`-function and seeding to the tests, hopefully avoiding randomly failing tests.