### PR TITLE
Copy cptensor

### DIFF
--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -71,6 +71,9 @@ class CPTensor(FactorizedTensor):
     def to_unfolded(self, mode):
         return cp_to_unfolded(self, mode)
 
+    def cp_copy(self):
+        return CPTensor((T.copy(self.weights), [T.copy(self.factors[i]) for i in range(len(self.factors))]))
+
     def mode_dot(self, matrix_or_vector, mode, keep_dim=False, copy=True):
         """n-mode product of a CP tensor and a matrix or vector at the specified mode
 

--- a/tensorly/tests/test_cp_tensor.py
+++ b/tensorly/tests/test_cp_tensor.py
@@ -285,3 +285,12 @@ def test_cp_lstsq_grad():
 
     cost_after = tl.norm(cp_to_tensor(cp_new) - dense)
     assert_(cost_before > cost_after)
+
+def test_cp_copy():
+    shape = (3, 4, 5)
+    rank = 4
+    cp_tensor = random_cp(shape, rank)
+    weights, factors = cp_tensor
+    weights_normalized, factors_normalized = cp_normalize(cp_tensor.cp_copy())
+    # Check that modifying copy tensor doesn't change the original tensor
+    assert_array_almost_equal(cp_to_tensor((weights, factors)), cp_to_tensor(cp_tensor))


### PR DESCRIPTION
This PR adds copy function for CPTensor class in order to avoid modification when `init` is a CPTensor for tensorly decomposition methods. Users can use this as in the following example;

```python          
weights_init, factors_init = initialize_cp(tensor, rank=rank)
cp_init = CPTensor((weights_init, factors_init))
weights, factors = parafac(tensor, rank=rank, init=cp_init.copy())
```