### PR TITLE
Adding check for all modes fixed case and if true then to just return the initialization

### DIFF
--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -302,6 +302,10 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',
         fixed_modes.remove(tl.ndim(tensor)-1)
     modes_list = [mode for mode in range(tl.ndim(tensor)) if mode not in fixed_modes]
 
+    if fixed_modes == range(tl.ndim(tensor)): # Check If all modes are fixed
+        cp_tensor = CPTensor((weights, factors)) # No need to run optimization algorithm, just return the initialization
+        return cp_tensor
+        
     if sparsity:
         sparse_component = tl.zeros_like(tensor)
         if isinstance(sparsity, float):

--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -296,15 +296,15 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',
     
     if fixed_modes is None:
         fixed_modes = []
+    
+    if fixed_modes == list(range(tl.ndim(tensor))): # Check If all modes are fixed
+        cp_tensor = CPTensor((weights, factors)) # No need to run optimization algorithm, just return the initialization
+        return cp_tensor
 
     if tl.ndim(tensor)-1 in fixed_modes:
         warnings.warn('You asked for fixing the last mode, which is not supported.\n The last mode will not be fixed. Consider using tl.moveaxis()')
         fixed_modes.remove(tl.ndim(tensor)-1)
     modes_list = [mode for mode in range(tl.ndim(tensor)) if mode not in fixed_modes]
-
-    if fixed_modes == range(tl.ndim(tensor)): # Check If all modes are fixed
-        cp_tensor = CPTensor((weights, factors)) # No need to run optimization algorithm, just return the initialization
-        return cp_tensor
         
     if sparsity:
         sparse_component = tl.zeros_like(tensor)


### PR DESCRIPTION
This pull request adds check for case where all modes are fixed and if true, then just returns the initialization without running the optimization algorithm. This is part of solution to issue #292 (Allow last mode to be fixed in decompositions) 