### PR TITLE
Backend refactoring - v2 : use a BackendManager class

### DIFF
--- a/tensorly/__init__.py
+++ b/tensorly/__init__.py
@@ -20,9 +20,11 @@ from .tt_matrix import (tt_matrix_to_tensor, tt_matrix_to_tensor, validate_tt_ma
 from .tr_tensor import tr_to_tensor, tr_to_unfolded, tr_to_vec, validate_tr_rank
 
 from .backend import (set_backend, get_backend,
-                      backend_context, _get_backend_dir,
-                      _get_backend_method, override_module_dispatch)
-
+                      #backend_context, 
+                      backend_manager,
+                    #    _get_backend_dir, _get_backend_method, 
+                      )
+# from . import backend as backend_manager
 from .backend import (context, tensor, is_tensor, shape, ndim, to_numpy, copy,
                       concatenate, reshape, transpose, moveaxis, arange, ones,
                       zeros, zeros_like, eye, where, clip, max, min, argmax,
@@ -31,18 +33,23 @@ from .backend import (context, tensor, is_tensor, shape, ndim, to_numpy, copy,
                       matmul, index_update, check_random_state, randomized_svd,
                       randn, randomized_range_finder, log2, sin, cos)
 
-
 # Deprecated
 from .cp_tensor import kruskal_to_tensor, kruskal_to_unfolded, kruskal_to_vec
 
-
 # Add Backend functions, dynamically dispatched
-def full_dir():
+def __dir__():
     """Returns the module's __dir__, including the local variables
         and augmenting it with the dynamically dispatched variables from backend.
     """
     static_items = list(sys.modules[__name__].__dict__.keys())
-    return _get_backend_dir() + static_items
+    return backend_manager.get_backend_dir() + static_items
+    # return _get_backend_dir() + static_items
 
-override_module_dispatch(__name__, _get_backend_method, full_dir)
-del override_module_dispatch, full_dir, _get_backend_method
+__getattr__ = backend_manager.__getattribute__
+
+
+# override_module_dispatch(__name__, 
+#                          backend_manager.__getattribute__,
+#                          full_dir)
+# # override_module_dispatch(__name__, _get_backend_method, full_dir)
+# del override_module_dispatch, full_dir#, _get_backend_method

--- a/tensorly/backend/core.py
+++ b/tensorly/backend/core.py
@@ -32,12 +32,27 @@ class Index():
 
     def __getitem__(self, indices):
         return indices
+
     @property
     def __name__(self):
         return 'Index'
 
-
 class Backend(object):
+    _available_backends = dict()
+
+    def __init_subclass__(cls, backend_name, **kwargs):
+        """When a subclass is created, register it in _known_backends"""
+        super().__init_subclass__(**kwargs)
+
+        if backend_name != '':
+            cls._available_backends[backend_name.lower()] = cls
+            cls.backend_name = backend_name
+        else:
+            warnings.warn(f'Creating a subclass of BaseBackend ({cls.__name__}) with no name.')
+
+    def __repr__(self):
+        return f'TensorLy {self.backend_name}-backend'
+
     @classmethod
     def register_method(cls, name, func):
         """Register a method with the backend.
@@ -1013,6 +1028,12 @@ class Backend(object):
             U = U * signs[:self.shape(U)[1]]
 
         return U, V
+
+    def svd(self, matrix):
+        raise NotImplementedError
+    
+    def eigh(self, matrix):
+        raise NotImplementedError
 
     def partial_svd(self, matrix, n_eigenvecs=None, flip=False, random_state=None, **kwargs):
         """Computes a fast partial SVD on `matrix`

--- a/tensorly/backend/cupy_backend.py
+++ b/tensorly/backend/cupy_backend.py
@@ -12,8 +12,7 @@ import numpy as np
 from .core import Backend
 
 
-class CupyBackend(Backend):
-    backend_name = 'cupy'
+class CupyBackend(Backend, backend_name='cupy'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -19,8 +19,7 @@ from .core import Backend
 
 
 
-class JaxBackend(Backend):
-    backend_name = 'jax'
+class JaxBackend(Backend, backend_name='jax'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -14,8 +14,7 @@ from .core import Backend
 mx.npx.set_np()
 
 
-class MxnetBackend(Backend):
-    backend_name = 'mxnet'
+class MxnetBackend(Backend, backend_name='mxnet'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -2,8 +2,7 @@ import numpy as np
 from .core import Backend
 
 
-class NumpyBackend(Backend):
-    backend_name = 'numpy'
+class NumpyBackend(Backend, backend_name='numpy'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -16,8 +16,7 @@ from .core import Backend
 linalg_lstsq_avail = LooseVersion(torch.__version__) >= LooseVersion('1.9.0')
 
 
-class PyTorchBackend(Backend):
-    backend_name = 'pytorch'
+class PyTorchBackend(Backend, backend_name='pytorch'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -12,8 +12,7 @@ import numpy as np
 from . import Backend
 
 
-class TensorflowBackend(Backend):
-    backend_name = 'tensorflow'
+class TensorflowBackend(Backend, backend_name='tensorflow'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/contrib/sparse/__init__.py
+++ b/tensorly/contrib/sparse/__init__.py
@@ -1,4 +1,4 @@
-from ...backend import set_backend, get_backend, override_module_dispatch
+from ...backend import set_backend, get_backend
 from ... import backend, base, cp_tensor, tucker_tensor, tt_tensor
 
 from .backend import (tensor, is_tensor, context, shape, ndim, to_numpy, copy,
@@ -11,12 +11,18 @@ from .backend import (tensor, is_tensor, context, shape, ndim, to_numpy, copy,
 from .core import wrap
 
 import sys
-from ...backend import _get_backend_method, _get_backend_dir
+# from ...backend import _get_backend_method, _get_backend_dir
+# from ...backend import backend
+from ...backend import backend_manager
 static_items = list(sys.modules[__name__].__dict__.keys())
-def sparse_dir():
-    return _get_backend_dir() + static_items
 
-override_module_dispatch(__name__, _get_backend_method, sparse_dir)
+def __dir__():
+    return backend_manager.get_backend_dir() + static_items
+    # return _get_backend_dir() + static_items
+
+__getattr__ = backend_manager.__getattribute__
+# override_module_dispatch(__name__, backend_manager.__getattribute__, sparse_dir)
+# override_module_dispatch(__name__, _get_backend_method, sparse_dir)
 
 unfold = wrap(base.unfold)
 fold = wrap(base.fold)

--- a/tensorly/contrib/sparse/backend/numpy_backend.py
+++ b/tensorly/contrib/sparse/backend/numpy_backend.py
@@ -21,8 +21,7 @@ def is_sparse(x):
     return isinstance(x, sparse.SparseArray)
 
 
-class NumpySparseBackend(Backend):
-    backend_name = 'numpy.sparse'
+class NumpySparseBackend(Backend, backend_name='numpy.sparse'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/tenalg/__init__.py
+++ b/tensorly/tenalg/__init__.py
@@ -19,7 +19,11 @@ from .core_tenalg import tensordot
 from . import core_tenalg as core
 from . import einsum_tenalg
 
-from ..backend import _LOCAL_STATE
+# from ..backend import backend
+# _LOCAL_STATE = backend._THREAD_LOCAL_DATA
+from ..backend import backend_manager 
+_LOCAL_STATE = backend_manager._THREAD_LOCAL_DATA
+# _THREAD_LOCAL_DATA as _LOCAL_STATE
 
 _DEFAULT_TENALG_BACKEND = 'core'
 


### PR DESCRIPTION
This version simply groups all the backend machinery in a backend manager class. A module __getattr__ and __dir__ are used for dynamic dispatching of functions and attributes. 

This version also adds an option to "turn off" dynamic dispatching and directly use the backend functions to minimize the overhead.