### PR TITLE
Backend refactoring - v3 : use a BackendManager class and use it directly as tensorly.backend's Module class

### DIFF
--- a/tensorly/__init__.py
+++ b/tensorly/__init__.py
@@ -20,9 +20,11 @@ from .tt_matrix import (tt_matrix_to_tensor, tt_matrix_to_tensor, validate_tt_ma
 from .tr_tensor import tr_to_tensor, tr_to_unfolded, tr_to_vec, validate_tr_rank
 
 from .backend import (set_backend, get_backend,
-                      backend_context, _get_backend_dir,
-                      _get_backend_method, override_module_dispatch)
-
+                      #backend_context, 
+                      # backend_manager,
+                    #    _get_backend_dir, _get_backend_method, 
+                      )
+# from . import backend as backend_manager
 from .backend import (context, tensor, is_tensor, shape, ndim, to_numpy, copy,
                       concatenate, reshape, transpose, moveaxis, arange, ones,
                       zeros, zeros_like, eye, where, clip, max, min, argmax,
@@ -31,18 +33,24 @@ from .backend import (context, tensor, is_tensor, shape, ndim, to_numpy, copy,
                       matmul, index_update, check_random_state, randomized_svd,
                       randn, randomized_range_finder, log2, sin, cos)
 
-
 # Deprecated
 from .cp_tensor import kruskal_to_tensor, kruskal_to_unfolded, kruskal_to_vec
 
-
+from . import backend
 # Add Backend functions, dynamically dispatched
-def full_dir():
+def __dir__():
     """Returns the module's __dir__, including the local variables
         and augmenting it with the dynamically dispatched variables from backend.
     """
     static_items = list(sys.modules[__name__].__dict__.keys())
-    return _get_backend_dir() + static_items
+    return backend.get_backend_dir() + static_items
+    # return _get_backend_dir() + static_items
 
-override_module_dispatch(__name__, _get_backend_method, full_dir)
-del override_module_dispatch, full_dir, _get_backend_method
+__getattr__ = backend.__getattribute__
+
+
+# override_module_dispatch(__name__, 
+#                          backend_manager.__getattribute__,
+#                          full_dir)
+# # override_module_dispatch(__name__, _get_backend_method, full_dir)
+# del override_module_dispatch, full_dir#, _get_backend_method

--- a/tensorly/backend/__init__.py
+++ b/tensorly/backend/__init__.py
@@ -1,242 +1,231 @@
 import warnings
+
 from .core import Backend
 import importlib
 import os
-import sys
 import threading
 from contextlib import contextmanager
 import inspect
+import types
+import sys
 
-_DEFAULT_BACKEND = 'numpy'
-_KNOWN_BACKENDS = {'numpy': 'NumpyBackend',
-                   'mxnet': 'MxnetBackend',
-                   'pytorch': 'PyTorchBackend',
-                   'tensorflow': 'TensorflowBackend',
-                   'cupy': 'CupyBackend',
-                   'jax': 'JaxBackend'}
 
-_LOADED_BACKENDS = {}
-_LOCAL_STATE = threading.local()
+class dynamically_dispatched_class_attribute(object):
+    __slots__ = ['name']
 
-def initialize_backend():
-    """Initialises the backend
+    def __init__(self, name):
+        self.name = name
 
-    1) retrieve the default backend name from the `TENSORLY_BACKEND` environment variable
-        if not found, use _DEFAULT_BACKEND
-    2) sets the backend to the retrieved backend name
-    """
-    backend_name = os.environ.get('TENSORLY_BACKEND', _DEFAULT_BACKEND)
-    if backend_name not in _KNOWN_BACKENDS:
-        msg = ("TENSORLY_BACKEND should be one of {}, got {}. Defaulting to {}'").format(
-            ', '.join(map(repr, _KNOWN_BACKENDS)),
-            backend_name, _DEFAULT_BACKEND)
-        warnings.warn(msg, UserWarning)
-        backend_name = _DEFAULT_BACKEND
+    def __get__(self, instance, cls=None):
+        if isinstance is None:
+            return getattr(cls.current_backend(), self.name)
+        else:
+            return getattr(instance.current_backend(), self.name)
 
-    set_backend(backend_name, local_threadsafe=False)
+class BackendManager(types.ModuleType):
+    _functions = ['reshape', 'moveaxis', 'any', 'trace', 'shape', 'ndim',
+                  'where', 'copy', 'transpose', 'arange', 'ones', 'zeros',
+                  'zeros_like', 'eye', 'kron', 'concatenate', 'max', 'min', 'matmul',
+                  'all', 'mean', 'sum', 'cumsum', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
+                  'argmax', 'stack', 'conj', 'diag', 'einsum', 'log2', 'dot', 'tensordot', 
+                  'sin', 'cos', 'clip', 'kr', 'kron', 'partial_svd', 'lstsq', 'eps', 'finfo',
+                  'solve', 'qr', 'randn', 'check_random_state', 'sort', 'eigh',
+                  'index_update', 'context', 'tensor', 'norm', 'to_numpy', 'is_tensor',
+                  'randomized_range_finder', 'randomized_svd'
+                 ]
+    _attributes = ['int64', 'int32', 'float64', 'float32', 
+                   'complex128', 'complex64', 'SVD_FUNS', 'index', 'backend_name']
+    available_backend_names = ['numpy', 'mxnet', 'pytorch', 'tensorflow', 'cupy', 'jax']
+    _default_backend = 'numpy'
+    _loaded_backends = dict()
+    _backend = None
+    _THREAD_LOCAL_DATA = threading.local()
 
-def register_backend(backend_name):
-    """Registers a new backend by importing the corresponding module 
-        and adding the correspond `Backend` class in Backend._LOADED_BACKEND
-        under the key `backend_name`
+    @classmethod
+    def use_dynamic_dispatch(cls):
+        # Define class methods and attributes that dynamically dispatch to the backend
+        for name in cls._functions:
+            if hasattr(cls, name):
+                delattr(cls, name)
+            setattr(cls, name, staticmethod(cls.dispatch_backend_method(name, getattr(cls.current_backend(), name))))
+        for name in cls._attributes:
+            if hasattr(cls, name):
+                delattr(cls, name)
+            setattr(cls, name, dynamically_dispatched_class_attribute(name))
+
+    @classmethod
+    def use_static_dispatch(cls):
+        # Define class methods and attributes that dynamically dispatch to the backend
+        for name in cls._functions:
+            setattr(cls, name, staticmethod(getattr(cls.current_backend(), name)))
+        for name in cls._attributes:
+            setattr(cls, name, getattr(cls.current_backend(), name))
+
+    @classmethod
+    def current_backend(cls):
+        """Returns the currently used backend instance
+
+        Returns
+        -------
+        backend : tensorly.backend.Backend
+            Backend instance currently in use
+        """
+        return cls._THREAD_LOCAL_DATA.__dict__.get('backend', cls._backend)
+
+    @classmethod
+    def get_backend(cls):
+        """Returns the *name* (str) of the currently used backend
+        
+        Returns
+        -------
+        name : str
+        """
+        return cls._THREAD_LOCAL_DATA.__dict__.get('backend', cls._backend).backend_name
+
+    @classmethod
+    def get_backend_dir(cls):
+        return cls._attributes + cls._functions
+
+    @classmethod
+    def dispatch_backend_method(cls, name, method):
+        """Create a dispatched function from a generic backend method."""
+        
+        def wrapped_backend_method(*args, **kwargs):
+            return getattr(cls._THREAD_LOCAL_DATA.__dict__.get('backend', cls._backend), name)(*args, **kwargs)
+
+        # We don't use `functools.wraps` here because some of the dispatched
+        # methods include the backend (`cls`) as a parameter. Instead we manually
+        # copy over the needed information, and filter the signature for `cls`.
+        for attr in ['__module__', '__name__', '__qualname__', '__doc__',
+                     '__annotations__']:
+            try:
+                setattr(wrapped_backend_method, attr, getattr(method, attr))
+            except AttributeError:
+                pass
     
-    Parameters
-    ----------
-    backend_name : str, name of the backend to load
-    
-    Raises
-    ------
-    ValueError
-        If `backend_name` does not correspond to one listed
-            in `_KNOWN_BACKEND`
-    """
-    if backend_name in _KNOWN_BACKENDS:
-        module = importlib.import_module('tensorly.backend.{0}_backend'.format(backend_name))
-        backend = getattr(module, _KNOWN_BACKENDS[backend_name])()
-        _LOADED_BACKENDS[backend_name] = backend
-    else:
-        msg = "Unknown backend name {0!r}, known backends are [{1}]".format(
-            backend_name, ', '.join(map(repr, _KNOWN_BACKENDS)))
-        raise ValueError(msg)
-
-def set_backend(backend, local_threadsafe=False):
-    """Changes the backend to the specified one
-    
-    Parameters
-    ----------
-    backend : tensorly.Backend or str
-        name of the backend to load or Backend Class
-    local_threadsafe : bool, optional, default is False
-        If False, set the backend as default for all threads        
-    """
-    if not isinstance(backend, Backend):
-        # Backend is a string
-        if backend not in _LOADED_BACKENDS:
-            register_backend(backend)
-
-        backend = _LOADED_BACKENDS[backend]
-
-    # Set the backend
-    _LOCAL_STATE.backend = backend
-
-    if not local_threadsafe:
-        global _DEFAULT_BACKEND
-        _DEFAULT_BACKEND = backend.backend_name
-
-def get_backend():
-    """Returns the name of the current backend
-    """
-    return _get_backend_method('backend_name')
-
-def _get_backend_method(key):
-    try:
-        return getattr(_LOCAL_STATE.backend, key)
-    except AttributeError:
-        return getattr(_LOADED_BACKENDS[_DEFAULT_BACKEND], key)
-
-def _get_backend_dir():
-    return [k for k in dir(_LOCAL_STATE.backend) if not k.startswith('_')]
-
-@contextmanager
-def backend_context(backend, local_threadsafe=False):
-    """Context manager to set the backend for TensorLy.
-
-    Parameters
-    ----------
-    backend : {'numpy', 'mxnet', 'pytorch', 'tensorflow', 'cupy'}
-        The name of the backend to use. Default is 'numpy'.
-    local_threadsafe : bool, optional
-        If True, the backend will not become the default backend for all threads.
-        Note that this only affects threads where the backend hasn't already
-        been explicitly set. If False (default) the backend is set for the
-        entire session.
-
-    Examples
-    --------
-    Set the backend to numpy globally for this thread:
-
-    >>> import tensorly as tl
-    >>> tl.set_backend('numpy')
-    >>> with tl.backend_context('pytorch'):
-    ...     pass
-    """
-    _old_backend = get_backend()
-    set_backend(backend, local_threadsafe=local_threadsafe)
-    try:
-        yield
-    finally:
-        set_backend(_old_backend)
-
-def override_module_dispatch(module_name, getter_fun, dir_fun):
-    """Override the module's dispatch mechanism
-
-        In Python >= 3.7, we use module's __getattr__ and __dir__
-        On older versions, we override the sys.module[__name__].__class__
-    """
-    if sys.version_info >= (3, 7, 0):
-        sys.modules[module_name].__getattr__ = getter_fun
-        sys.modules[module_name].__dir__ = dir_fun
-
-    else:
-        import types
-
-        class BackendAttributeModuleType(types.ModuleType):
-            """A module type to dispatch backend generic attributes."""
-            def __getattr__(self, key):
-                return getter_fun(key)
-
-            def __dir__(self):
-                out = set(super().__dir__())
-                out.update({k for k in dir(_LOCAL_STATE.backend) if not k.startswith('_')})
-                return list(out)
-
-        sys.modules[module_name].__class__ = BackendAttributeModuleType
-
-
-def dispatch(method):
-    """Create a dispatched function from a generic backend method."""
-    name = method.__name__
-
-    def inner(*args, **kwargs):
-        return _get_backend_method(name)(*args, **kwargs)
-
-    # We don't use `functools.wraps` here because some of the dispatched
-    # methods include the backend (`self`) as a parameter. Instead we manually
-    # copy over the needed information, and filter the signature for `self`.
-    for attr in ['__module__', '__name__', '__qualname__', '__doc__',
-                 '__annotations__']:
+        getattr(wrapped_backend_method, '__dict__').update(getattr(method,  '__dict__', {}))
+        wrapped_backend_method.__wrapped__ = method
         try:
-            setattr(inner, attr, getattr(method, attr))
-        except AttributeError:
+            sig = inspect.signature(method)
+            if 'self' in sig.parameters:
+                parameters = [v for k, v in sig.parameters.items() if k != 'self']
+                sig = sig.replace(parameters=parameters)
+            wrapped_backend_method.__signature__ = sig
+        except ValueError:
+            # If it doesn't have a signature we don't need to remove self
+            # This happens for NumPy (e.g. np.where) where inspect.signature(np.where) errors:
+            # ValueError: no signature found for builtin <built-in function where>
             pass
 
-    sig = inspect.signature(method)
-    if 'self' in sig.parameters:
-        parameters = [v for k, v in sig.parameters.items() if k != 'self']
-        sig = sig.replace(parameters=parameters)
-    inner.__signature__ = sig
+        return wrapped_backend_method
 
-    return inner
+    @classmethod
+    @contextmanager
+    def backend_context(cls, backend, local_threadsafe=False):
+        """Context manager to set the backend for TensorLy.
+        Parameters
+        ----------
+        backend : {'numpy', 'mxnet', 'pytorch', 'tensorflow', 'cupy'}
+            The name of the backend to use. Default is 'numpy'.
+        local_threadsafe : bool, optional
+            If True, the backend will not become the default backend for all threads.
+            Note that this only affects threads where the backend hasn't already
+            been explicitly set. If False (default) the backend is set for the
+            entire session.
+        Examples
+        --------
+        Set the backend to numpy globally for this thread:
+        >>> import tensorly as tl
+        >>> tl.set_backend('numpy')
+        >>> with tl.backend_context('pytorch'):
+        ...     pass
+        """
+        _old_backend = cls.current_backend()
+        cls.set_backend(backend, local_threadsafe=local_threadsafe)
+        try:
+            yield
+        finally:
+            cls.set_backend(_old_backend)
 
+    @classmethod
+    def initialize_backend(cls):
+        """Initialises the backend
 
-# Generic methods, exposed as part of the public API
-check_random_state = dispatch(Backend.check_random_state)
-randn = dispatch(Backend.randn)
-context = dispatch(Backend.context)
-tensor = dispatch(Backend.tensor)
-is_tensor = dispatch(Backend.is_tensor)
-shape = dispatch(Backend.shape)
-ndim = dispatch(Backend.ndim)
-to_numpy = dispatch(Backend.to_numpy)
-copy = dispatch(Backend.copy)
-concatenate = dispatch(Backend.concatenate)
-stack = dispatch(Backend.stack)
-reshape = dispatch(Backend.reshape)
-transpose = dispatch(Backend.transpose)
-moveaxis = dispatch(Backend.moveaxis)
-arange = dispatch(Backend.arange)
-ones = dispatch(Backend.ones)
-zeros = dispatch(Backend.zeros)
-zeros_like = dispatch(Backend.zeros_like)
-eye = dispatch(Backend.eye)
-where = dispatch(Backend.where)
-clip = dispatch(Backend.clip)
-max = dispatch(Backend.max)
-min = dispatch(Backend.min)
-argmax = dispatch(Backend.argmax)
-argmin = dispatch(Backend.argmin)
-all = dispatch(Backend.all)
-mean = dispatch(Backend.mean)
-sum = dispatch(Backend.sum)
-prod = dispatch(Backend.prod)
-sign = dispatch(Backend.sign)
-abs = dispatch(Backend.abs)
-sqrt = dispatch(Backend.sqrt)
-norm = dispatch(Backend.norm)
-dot = dispatch(Backend.dot)
-matmul = dispatch(Backend.matmul)
-kron = dispatch(Backend.kron)
-solve = dispatch(Backend.solve)
-lstsq = dispatch(Backend.lstsq)
-qr = dispatch(Backend.qr)
-kr = dispatch(Backend.kr)
-partial_svd = dispatch(Backend.partial_svd)
-randomized_svd = dispatch(Backend.randomized_svd)
-randomized_range_finder = dispatch(Backend.randomized_range_finder)
-sort = dispatch(Backend.sort)
-conj = dispatch(Backend.conj)
-eps = dispatch(Backend.eps)
-finfo = dispatch(Backend.finfo)
-index = Backend.index
-index_update = dispatch(Backend.index_update)
-log2 = dispatch(Backend.log2)
-sin = dispatch(Backend.sin)
-cos = dispatch(Backend.cos)
+        1) retrieve the default backend name from the `TENSORLY_BACKEND` environment variable
+            if not found, use _DEFAULT_BACKEND
+        2) sets the backend to the retrieved backend name
+        """
+        backend_name = os.environ.get('TENSORLY_BACKEND', cls._default_backend)
+        if backend_name not in cls.available_backend_names:
+            msg = (f"TENSORLY_BACKEND should be one of {''.join(map(repr, cls.available_backend_names))}"
+                   f", got {backend_name}. Defaulting to {cls._default_backend}'")
+            warnings.warn(msg, UserWarning)
+            backend_name = cls._default_backend
+
+        cls._default_backend = backend_name
+        cls.set_backend(backend_name)
+
+    @classmethod
+    def load_backend(cls, backend_name):
+        """Registers a new backend by importing the corresponding module 
+            and adding the correspond `Backend` class in Backend._LOADED_BACKEND
+            under the key `backend_name`
+
+        Parameters
+        ----------
+        backend_name : str, name of the backend to load
+
+        Raises
+        ------
+        ValueError
+            If `backend_name` does not correspond to one listed
+                in `_KNOWN_BACKEND`
+        """
+        if backend_name not in cls.available_backend_names:
+            msg = f"Unknown backend name {backend_name!r}, known backends are {cls.available_backend_names}"
+            raise ValueError(msg)
+        if backend_name not in Backend._available_backends:
+            importlib.import_module('tensorly.backend.{0}_backend'.format(backend_name))
+        if backend_name in Backend._available_backends:
+            backend = Backend._available_backends[backend_name]()
+            # backend = getattr(module, )()
+            cls._loaded_backends[backend_name] = backend
+        
+        return backend
+
+    @classmethod
+    def set_backend(cls, backend, local_threadsafe=False):
+        """Changes the backend to the specified one
+
+        Parameters
+        ----------
+        backend : tensorly.Backend or str
+            name of the backend to load or Backend Class
+        local_threadsafe : bool, optional, default is False
+            If False, set the backend as default for all threads        
+        """
+        if not isinstance(backend, Backend):
+            # Backend is a string
+            if backend not in cls._loaded_backends:
+                backend = cls.load_backend(backend)
+            else:
+                backend = cls._loaded_backends[backend]
+
+        cls._THREAD_LOCAL_DATA.backend = backend
+        if not local_threadsafe:
+            cls._default_backend = backend.backend_name
+            cls._backend = backend
+
+    @classmethod
+    def register_backend_method(cls, name, fun_or_attr):
+        cls.current_backend().register_method(name, fun_or_attr)
+
+    def __dir__(cls):
+        additionals = ['dynamically_dispatched_class_attribute', 'backend_manager', 'BackendManager']
+        return cls.get_backend_dir() + additionals
 
 # Initialise the backend to the default one
-initialize_backend()
+BackendManager.initialize_backend()
+BackendManager.use_dynamic_dispatch()
 
-# dispatch non-callables (e.g. dtypes, index)
-override_module_dispatch(__name__, 
-                         _get_backend_method,
-                         _get_backend_dir)
+sys.modules[__name__].__class__ = BackendManager

--- a/tensorly/backend/__init__.py
+++ b/tensorly/backend/__init__.py
@@ -40,6 +40,7 @@ class BackendManager(types.ModuleType):
     _loaded_backends = dict()
     _backend = None
     _THREAD_LOCAL_DATA = threading.local()
+    _ENV_DEFAULT_VAR = 'TENSORLY_BACKEND'
 
     @classmethod
     def use_dynamic_dispatch(cls):
@@ -155,9 +156,9 @@ class BackendManager(types.ModuleType):
             if not found, use _DEFAULT_BACKEND
         2) sets the backend to the retrieved backend name
         """
-        backend_name = os.environ.get('TENSORLY_BACKEND', cls._default_backend)
+        backend_name = os.environ.get(cls._ENV_DEFAULT_VAR, cls._default_backend)
         if backend_name not in cls.available_backend_names:
-            msg = (f"TENSORLY_BACKEND should be one of {''.join(map(repr, cls.available_backend_names))}"
+            msg = (f"{cls._ENV_DEFAULT_VAR} should be one of {''.join(map(repr, cls.available_backend_names))}"
                    f", got {backend_name}. Defaulting to {cls._default_backend}'")
             warnings.warn(msg, UserWarning)
             backend_name = cls._default_backend

--- a/tensorly/backend/core.py
+++ b/tensorly/backend/core.py
@@ -32,12 +32,27 @@ class Index():
 
     def __getitem__(self, indices):
         return indices
+
     @property
     def __name__(self):
         return 'Index'
 
-
 class Backend(object):
+    _available_backends = dict()
+
+    def __init_subclass__(cls, backend_name, **kwargs):
+        """When a subclass is created, register it in _known_backends"""
+        super().__init_subclass__(**kwargs)
+
+        if backend_name != '':
+            cls._available_backends[backend_name.lower()] = cls
+            cls.backend_name = backend_name
+        else:
+            warnings.warn(f'Creating a subclass of BaseBackend ({cls.__name__}) with no name.')
+
+    def __repr__(self):
+        return f'TensorLy {self.backend_name}-backend'
+
     @classmethod
     def register_method(cls, name, func):
         """Register a method with the backend.
@@ -1013,6 +1028,12 @@ class Backend(object):
             U = U * signs[:self.shape(U)[1]]
 
         return U, V
+
+    def svd(self, matrix):
+        raise NotImplementedError
+    
+    def eigh(self, matrix):
+        raise NotImplementedError
 
     def partial_svd(self, matrix, n_eigenvecs=None, flip=False, random_state=None, **kwargs):
         """Computes a fast partial SVD on `matrix`

--- a/tensorly/backend/cupy_backend.py
+++ b/tensorly/backend/cupy_backend.py
@@ -12,8 +12,7 @@ import numpy as np
 from .core import Backend
 
 
-class CupyBackend(Backend):
-    backend_name = 'cupy'
+class CupyBackend(Backend, backend_name='cupy'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -19,8 +19,7 @@ from .core import Backend
 
 
 
-class JaxBackend(Backend):
-    backend_name = 'jax'
+class JaxBackend(Backend, backend_name='jax'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -14,8 +14,7 @@ from .core import Backend
 mx.npx.set_np()
 
 
-class MxnetBackend(Backend):
-    backend_name = 'mxnet'
+class MxnetBackend(Backend, backend_name='mxnet'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -2,8 +2,7 @@ import numpy as np
 from .core import Backend
 
 
-class NumpyBackend(Backend):
-    backend_name = 'numpy'
+class NumpyBackend(Backend, backend_name='numpy'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -16,8 +16,7 @@ from .core import Backend
 linalg_lstsq_avail = LooseVersion(torch.__version__) >= LooseVersion('1.9.0')
 
 
-class PyTorchBackend(Backend):
-    backend_name = 'pytorch'
+class PyTorchBackend(Backend, backend_name='pytorch'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -12,8 +12,7 @@ import numpy as np
 from . import Backend
 
 
-class TensorflowBackend(Backend):
-    backend_name = 'tensorflow'
+class TensorflowBackend(Backend, backend_name='tensorflow'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/contrib/sparse/__init__.py
+++ b/tensorly/contrib/sparse/__init__.py
@@ -1,4 +1,4 @@
-from ...backend import set_backend, get_backend, override_module_dispatch
+from ...backend import set_backend, get_backend
 from ... import backend, base, cp_tensor, tucker_tensor, tt_tensor
 
 from .backend import (tensor, is_tensor, context, shape, ndim, to_numpy, copy,
@@ -11,12 +11,18 @@ from .backend import (tensor, is_tensor, context, shape, ndim, to_numpy, copy,
 from .core import wrap
 
 import sys
-from ...backend import _get_backend_method, _get_backend_dir
+# from ...backend import _get_backend_method, _get_backend_dir
+# from ...backend import backend
+from ... import backend
 static_items = list(sys.modules[__name__].__dict__.keys())
-def sparse_dir():
-    return _get_backend_dir() + static_items
 
-override_module_dispatch(__name__, _get_backend_method, sparse_dir)
+def __dir__():
+    return backend.get_backend_dir() + static_items
+    # return _get_backend_dir() + static_items
+
+__getattr__ = backend.__getattribute__
+# override_module_dispatch(__name__, backend_manager.__getattribute__, sparse_dir)
+# override_module_dispatch(__name__, _get_backend_method, sparse_dir)
 
 unfold = wrap(base.unfold)
 fold = wrap(base.fold)

--- a/tensorly/contrib/sparse/backend/numpy_backend.py
+++ b/tensorly/contrib/sparse/backend/numpy_backend.py
@@ -21,8 +21,7 @@ def is_sparse(x):
     return isinstance(x, sparse.SparseArray)
 
 
-class NumpySparseBackend(Backend):
-    backend_name = 'numpy.sparse'
+class NumpySparseBackend(Backend, backend_name='numpy.sparse'):
 
     @staticmethod
     def context(tensor):

--- a/tensorly/tenalg/__init__.py
+++ b/tensorly/tenalg/__init__.py
@@ -2,138 +2,76 @@
 The :mod:`tensorly.tenalg` module contains utilities for Tensor Algebra 
 operations such as khatri-rao or kronecker product, n-mode product, etc.
 """ 
-from contextlib import contextmanager
-import os
-from functools import wraps
-import warnings
 
-from .core_tenalg import mode_dot, multi_mode_dot
-from .core_tenalg import kronecker
-from .core_tenalg import khatri_rao
-from .core_tenalg import inner
-from .core_tenalg import outer, batched_outer
-from .core_tenalg import higher_order_moment
-from .core_tenalg import _tt_matrix_to_tensor
-from .core_tenalg import tensordot
+import sys
+import importlib
+import threading
 
-from . import core_tenalg as core
-from . import einsum_tenalg
+from ..backend import BackendManager, dynamically_dispatched_class_attribute
+from .base_tenalg import TenalgBackend
 
-from .. import backend
-_LOCAL_STATE = backend._THREAD_LOCAL_DATA
-# from ..backend import backend_manager 
-# _LOCAL_STATE = backend_manager._THREAD_LOCAL_DATA
-# _THREAD_LOCAL_DATA as _LOCAL_STATE
+class TenalgBackendManager(BackendManager):
+    _functions = ['mode_dot', 'multi_mode_dot', 
+                  'kronecker', 'khatri_rao',
+                  'inner', 'outer', 'batched_outer',
+                  'higher_order_moment',
+                  '_tt_matrix_to_tensor',
+                  'tensordot'
+                 ]
+    _attributes = []
+    available_backend_names = ['core', 'einsum']
+    _default_backend = 'core'
+    _loaded_backends = dict()
+    _backend = None
+    _THREAD_LOCAL_DATA = threading.local()
 
-_DEFAULT_TENALG_BACKEND = 'core'
+    @classmethod
+    def use_dynamic_dispatch(cls):
+        # Define class methods and attributes that dynamically dispatch to the backend
+        for name in cls._functions:
+            try:
+                delattr(cls, name)
+            except AttributeError:
+                pass
+            setattr(cls, name, staticmethod(cls.dispatch_backend_method(name, getattr(cls.current_backend(), name))))
+        for name in cls._attributes:
+            try:
+                delattr(cls, name)
+            except AttributeError:
+                pass
+            setattr(cls, name, dynamically_dispatched_class_attribute(name))
 
-_TENALG_BACKENDS = {'core':core,
-                    'einsum':einsum_tenalg}
+    @classmethod
+    def load_backend(cls, backend_name):
+        """Registers a new backend by importing the corresponding module 
+            and adding the correspond `Backend` class in Backend._LOADED_BACKEND
+            under the key `backend_name`
 
-def initialize_tenalg_backend():
-    """Initialises the backend
+        Parameters
+        ----------
+        backend_name : str, name of the backend to load
 
-    1) retrieve the default backend name from the `TENSORLY_TENALG_BACKEND` environment variable
-        if not found, use _DEFAULT_TENALG_BACKEND
-    2) sets the backend to the retrieved backend name
-    """
-    tenalg_backend_name = os.environ.get('TENSORLY_TENALG_BACKEND', _DEFAULT_TENALG_BACKEND)
-    if tenalg_backend_name not in _TENALG_BACKENDS:
-        msg = ("TENSORLY_BACKEND should be one of {}, got {}. Defaulting to {}'").format(
-            ', '.join(map(repr, _TENALG_BACKENDS)),
-            tenalg_backend_name, _DEFAULT_TENALG_BACKEND)
-        warnings.warn(msg, UserWarning)
-        tenalg_backend_name = _DEFAULT_TENALG_BACKEND
-
-    set_tenalg_backend(tenalg_backend_name, local_threadsafe=False)
-
-def get_tenalg_backend():
-    """Returns the current backend
-    """
-    return _LOCAL_STATE.tenalg_backend
-
-def set_tenalg_backend(backend='core', local_threadsafe=False):
-    """Set the current tenalg backend
-
-    Parameters
-    ----------
-    backend : {'core', 'einsum'}
-        * if 'core', our manually optimized implementations are used 
-        * if 'einsum', all operations are dispatched to ``einsum``
-
-    If True, the backend will not become the default backend for all threads.
-        Note that this only affects threads where the backend hasn't already
-        been explicitly set. If False (default) the backend is set for the
-        entire session.
-    """
-    if backend in _TENALG_BACKENDS:
-        _LOCAL_STATE.tenalg_backend = backend
-        if local_threadsafe == False:
-            global _DEFAULT_TENALG_BACKEND
-            _DEFAULT_TENALG_BACKEND = backend
-    else:
-        raise ValueError(f'Unknown tenalg backend {backend}')
-
-@contextmanager
-def tenalg_backend_context(backend, local_threadsafe=False):
-    """Context manager to set the backend for TensorLy.
-
-    Parameters
-    ----------
-    backend : {'core', 'einsum'}
-        * if 'core', our manually optimized implementations are used 
-        * if 'einsum', all operations are dispatched to ``einsum``
-    local_threadsafe : bool, optional
-        If True, the backend will not become the default backend for all threads.
-        Note that this only affects threads where the backend hasn't already
-        been explicitly set. If False (default) the backend is set for the
-        entire session.
-
-    Examples
-    --------
-    Set the backend to numpy globally for this thread:
-
-    >>> import tensorly.tenalg as tlg
-    >>> tlg.set_tenalg_backend('core')
-    >>> with tlg.set_tenalg_backend('einsum'):
-    ...     pass
-    """
-    _old_backend = get_tenalg_backend()
-    set_tenalg_backend(backend, local_threadsafe=local_threadsafe)
-    try:
-        yield
-    finally:
-        set_tenalg_backend(_old_backend)
-
-def dynamically_dispatch_tenalg(function):
-    name = function.__name__
-
-    @wraps(function)
-    def dynamically_dispatched_fun(*args, **kwargs):
-        #print('hello')
-        try:
-            current_backend = _TENALG_BACKENDS[_LOCAL_STATE.tenalg_backend]
-        except AttributeError:
-            current_backend = _TENALG_BACKENDS[_DEFAULT_TENALG_BACKEND]
-            
-        if hasattr(current_backend, name):
-            fun = getattr(current_backend, name)(*args, **kwargs)
-        else:
-            warnings.warn(f'tenalg: defaulting to core tenalg backend, {name}'
-                          f'not yet implemented in {_LOCAL_STATE.tenalg_backend} backend.')
-            fun = getattr(core, name)(*args, **kwargs)
-        return fun
-    return dynamically_dispatched_fun
+        Raises
+        ------
+        ValueError
+            If `backend_name` does not correspond to one listed
+                in `_KNOWN_BACKEND`
+        """
+        if backend_name not in cls.available_backend_names:
+            msg = f"Unknown backend name {backend_name!r}, known backends are {cls.available_backend_names}"
+            raise ValueError(msg)
+        if backend_name not in TenalgBackend._available_tenalg_backends:
+            importlib.import_module('tensorly.tenalg.{0}_tenalg'.format(backend_name))
+        if backend_name in TenalgBackend._available_tenalg_backends:
+            backend = TenalgBackend._available_tenalg_backends[backend_name]()
+            # backend = getattr(module, )()
+            cls._loaded_backends[backend_name] = backend
+        
+        return backend
 
 
-mode_dot = dynamically_dispatch_tenalg(mode_dot)
-multi_mode_dot = dynamically_dispatch_tenalg(multi_mode_dot)
-kronecker = dynamically_dispatch_tenalg(kronecker)
-khatri_rao = dynamically_dispatch_tenalg(khatri_rao)
-inner = dynamically_dispatch_tenalg(inner)
-outer = dynamically_dispatch_tenalg(outer)
-batched_outer = dynamically_dispatch_tenalg(batched_outer)
-tensordot = dynamically_dispatch_tenalg(tensordot)
-higher_order_moment = dynamically_dispatch_tenalg(higher_order_moment)
+# Initialise the backend to the default one
+TenalgBackendManager.initialize_backend()
+TenalgBackendManager.use_dynamic_dispatch()
 
-initialize_tenalg_backend()
+sys.modules[__name__].__class__ = TenalgBackendManager

--- a/tensorly/tenalg/__init__.py
+++ b/tensorly/tenalg/__init__.py
@@ -6,6 +6,8 @@ operations such as khatri-rao or kronecker product, n-mode product, etc.
 import sys
 import importlib
 import threading
+import os
+import warnings
 
 from ..backend import BackendManager, dynamically_dispatched_class_attribute
 from .base_tenalg import TenalgBackend
@@ -24,6 +26,7 @@ class TenalgBackendManager(BackendManager):
     _loaded_backends = dict()
     _backend = None
     _THREAD_LOCAL_DATA = threading.local()
+    _ENV_DEFAULT_VAR = 'TENSORLY_TENALG_BACKEND'
 
     @classmethod
     def use_dynamic_dispatch(cls):
@@ -40,7 +43,7 @@ class TenalgBackendManager(BackendManager):
             except AttributeError:
                 pass
             setattr(cls, name, dynamically_dispatched_class_attribute(name))
-
+    
     @classmethod
     def load_backend(cls, backend_name):
         """Registers a new backend by importing the corresponding module 

--- a/tensorly/tenalg/__init__.py
+++ b/tensorly/tenalg/__init__.py
@@ -19,7 +19,11 @@ from .core_tenalg import tensordot
 from . import core_tenalg as core
 from . import einsum_tenalg
 
-from ..backend import _LOCAL_STATE
+from .. import backend
+_LOCAL_STATE = backend._THREAD_LOCAL_DATA
+# from ..backend import backend_manager 
+# _LOCAL_STATE = backend_manager._THREAD_LOCAL_DATA
+# _THREAD_LOCAL_DATA as _LOCAL_STATE
 
 _DEFAULT_TENALG_BACKEND = 'core'
 

--- a/tensorly/tenalg/base_tenalg.py
+++ b/tensorly/tenalg/base_tenalg.py
@@ -1,0 +1,31 @@
+import warnings
+
+class TenalgBackend():
+    _available_tenalg_backends = dict()
+
+    def __init_subclass__(cls, backend_name, **kwargs):
+        """When a subclass is created, register it in _known_backends"""
+        super().__init_subclass__(**kwargs)
+
+        if backend_name != '':
+            cls._available_tenalg_backends[backend_name.lower()] = cls
+            cls.backend_name = backend_name
+        else:
+            warnings.warn(f'Creating a subclass of BaseBackend ({cls.__name__}) with no name.')
+
+    def __repr__(self):
+        return f'TensorLy {self.backend_name}-tenalg backend'
+
+    @classmethod
+    def register_method(cls, name, func):
+        """Register a method with the backend.
+
+        Parameters
+        ----------
+        name : str
+            The method name.
+        func : callable
+            The method
+        """
+        setattr(cls, name, staticmethod(func))
+

--- a/tensorly/tenalg/core_tenalg/__init__.py
+++ b/tensorly/tenalg/core_tenalg/__init__.py
@@ -4,5 +4,21 @@ from ._khatri_rao import khatri_rao
 from .generalised_inner_product import inner
 from .outer_product import outer, batched_outer
 from .moments import higher_order_moment
-from ._tt_matrix import tt_matrix_to_tensor as _tt_matrix_to_tensor
+from ._tt_matrix import tt_matrix_to_tensor
 from ._batched_tensordot import tensordot
+
+from ..base_tenalg import TenalgBackend
+
+class CoreBackend(TenalgBackend, backend_name='core'):
+    pass
+
+CoreBackend.register_method('mode_dot', mode_dot)
+CoreBackend.register_method('multi_mode_dot', multi_mode_dot)
+CoreBackend.register_method('kronecker', kronecker)
+CoreBackend.register_method('khatri_rao', khatri_rao)
+CoreBackend.register_method('inner', inner)
+CoreBackend.register_method('outer', outer)
+CoreBackend.register_method('batched_outer', batched_outer)
+CoreBackend.register_method('higher_order_moment', higher_order_moment)
+CoreBackend.register_method('_tt_matrix_to_tensor', tt_matrix_to_tensor)
+CoreBackend.register_method('tensordot', tensordot)

--- a/tensorly/tenalg/core_tenalg/__init__.py
+++ b/tensorly/tenalg/core_tenalg/__init__.py
@@ -9,16 +9,16 @@ from ._batched_tensordot import tensordot
 
 from ..base_tenalg import TenalgBackend
 
-class CoreBackend(TenalgBackend, backend_name='core'):
+class CoreTenalgBackend(TenalgBackend, backend_name='core'):
     pass
 
-CoreBackend.register_method('mode_dot', mode_dot)
-CoreBackend.register_method('multi_mode_dot', multi_mode_dot)
-CoreBackend.register_method('kronecker', kronecker)
-CoreBackend.register_method('khatri_rao', khatri_rao)
-CoreBackend.register_method('inner', inner)
-CoreBackend.register_method('outer', outer)
-CoreBackend.register_method('batched_outer', batched_outer)
-CoreBackend.register_method('higher_order_moment', higher_order_moment)
-CoreBackend.register_method('_tt_matrix_to_tensor', tt_matrix_to_tensor)
-CoreBackend.register_method('tensordot', tensordot)
+CoreTenalgBackend.register_method('mode_dot', mode_dot)
+CoreTenalgBackend.register_method('multi_mode_dot', multi_mode_dot)
+CoreTenalgBackend.register_method('kronecker', kronecker)
+CoreTenalgBackend.register_method('khatri_rao', khatri_rao)
+CoreTenalgBackend.register_method('inner', inner)
+CoreTenalgBackend.register_method('outer', outer)
+CoreTenalgBackend.register_method('batched_outer', batched_outer)
+CoreTenalgBackend.register_method('higher_order_moment', higher_order_moment)
+CoreTenalgBackend.register_method('_tt_matrix_to_tensor', tt_matrix_to_tensor)
+CoreTenalgBackend.register_method('tensordot', tensordot)

--- a/tensorly/tenalg/core_tenalg/_tt_matrix.py
+++ b/tensorly/tenalg/core_tenalg/_tt_matrix.py
@@ -1,6 +1,7 @@
 """Manipulation of matrices in the TT format"""
 
 import tensorly as tl
+from ._batched_tensordot import tensordot
 
 def tt_matrix_to_tensor(tt_matrix):
     """Returns the full tensor whose TT-Matrix decomposition is given by 'factors'
@@ -19,8 +20,7 @@ def tt_matrix_to_tensor(tt_matrix):
                    tensor whose TT-Matrix decomposition was given by 'factors'
     """
     # Each core is of shape (rank_left, size_in, size_out, rank_right)
-    rank, in_shape, out_shape, rank_right = zip(*(tl.shape(f) for f in tt_matrix))
-    rank += (rank_right[-1], )                           
+    _, in_shape, out_shape, _ = zip(*(tl.shape(f) for f in tt_matrix))
     ndim = len(in_shape)
     
     # Intertwine the dims 
@@ -30,10 +30,8 @@ def tt_matrix_to_tensor(tt_matrix):
 
     for i, factor in enumerate(tt_matrix):
         if not i:
-            # factor = factor.squeeze(0)
-            res = tl.reshape(factor, (factor.shape[1], -1))
+            res = factor
         else:
-            res = tl.dot(tl.reshape(res, (-1, rank[i])), tl.reshape(factor, (rank[i], -1)))
-    res = tl.reshape(res, full_shape)
-    
-    return tl.transpose(res, order)
+            res = tensordot(res, factor, ([-1], [0]))
+
+    return tl.transpose(tl.reshape(res, full_shape), order)

--- a/tensorly/tenalg/einsum_tenalg/__init__.py
+++ b/tensorly/tenalg/einsum_tenalg/__init__.py
@@ -3,5 +3,20 @@ from ._kronecker import kronecker
 from ._khatri_rao import khatri_rao
 from .generalised_inner_product import inner
 from .outer_product import outer, batched_outer
-from ._tt_matrix import tt_matrix_to_tensor as _tt_matrix_to_tensor
+from ._tt_matrix import tt_matrix_to_tensor
 from ._batched_tensordot import tensordot
+
+from ..base_tenalg import TenalgBackend
+
+class EinsumBackend(TenalgBackend, backend_name='einsum'):
+    pass
+
+EinsumBackend.register_method('mode_dot', mode_dot)
+EinsumBackend.register_method('multi_mode_dot', multi_mode_dot)
+EinsumBackend.register_method('kronecker', kronecker)
+EinsumBackend.register_method('khatri_rao', khatri_rao)
+EinsumBackend.register_method('inner', inner)
+EinsumBackend.register_method('outer', outer)
+EinsumBackend.register_method('batched_outer', batched_outer)
+EinsumBackend.register_method('_tt_matrix_to_tensor', tt_matrix_to_tensor)
+EinsumBackend.register_method('tensordot', tensordot)

--- a/tensorly/tenalg/einsum_tenalg/__init__.py
+++ b/tensorly/tenalg/einsum_tenalg/__init__.py
@@ -9,16 +9,16 @@ from ._batched_tensordot import tensordot
 
 from ..base_tenalg import TenalgBackend
 
-class EinsumBackend(TenalgBackend, backend_name='einsum'):
+class EinsumTenalgBackend(TenalgBackend, backend_name='einsum'):
     pass
 
-EinsumBackend.register_method('mode_dot', mode_dot)
-EinsumBackend.register_method('multi_mode_dot', multi_mode_dot)
-EinsumBackend.register_method('kronecker', kronecker)
-EinsumBackend.register_method('khatri_rao', khatri_rao)
-EinsumBackend.register_method('inner', inner)
-EinsumBackend.register_method('outer', outer)
-EinsumBackend.register_method('batched_outer', batched_outer)
-EinsumBackend.register_method('higher_order_moment', higher_order_moment)
-EinsumBackend.register_method('_tt_matrix_to_tensor', tt_matrix_to_tensor)
-EinsumBackend.register_method('tensordot', tensordot)
+EinsumTenalgBackend.register_method('mode_dot', mode_dot)
+EinsumTenalgBackend.register_method('multi_mode_dot', multi_mode_dot)
+EinsumTenalgBackend.register_method('kronecker', kronecker)
+EinsumTenalgBackend.register_method('khatri_rao', khatri_rao)
+EinsumTenalgBackend.register_method('inner', inner)
+EinsumTenalgBackend.register_method('outer', outer)
+EinsumTenalgBackend.register_method('batched_outer', batched_outer)
+EinsumTenalgBackend.register_method('higher_order_moment', higher_order_moment)
+EinsumTenalgBackend.register_method('_tt_matrix_to_tensor', tt_matrix_to_tensor)
+EinsumTenalgBackend.register_method('tensordot', tensordot)

--- a/tensorly/tenalg/einsum_tenalg/__init__.py
+++ b/tensorly/tenalg/einsum_tenalg/__init__.py
@@ -3,6 +3,7 @@ from ._kronecker import kronecker
 from ._khatri_rao import khatri_rao
 from .generalised_inner_product import inner
 from .outer_product import outer, batched_outer
+from .moments import higher_order_moment
 from ._tt_matrix import tt_matrix_to_tensor
 from ._batched_tensordot import tensordot
 
@@ -18,5 +19,6 @@ EinsumBackend.register_method('khatri_rao', khatri_rao)
 EinsumBackend.register_method('inner', inner)
 EinsumBackend.register_method('outer', outer)
 EinsumBackend.register_method('batched_outer', batched_outer)
+EinsumBackend.register_method('higher_order_moment', higher_order_moment)
 EinsumBackend.register_method('_tt_matrix_to_tensor', tt_matrix_to_tensor)
 EinsumBackend.register_method('tensordot', tensordot)

--- a/tensorly/tenalg/einsum_tenalg/moments.py
+++ b/tensorly/tenalg/einsum_tenalg/moments.py
@@ -1,0 +1,30 @@
+import tensorly as tl
+
+def higher_order_moment(tensor, order):
+    """Computes the Higher-Order Momemt
+    
+    Parameters
+    ----------
+    tensor : 2D-tensor -- or ND-tensor
+        matrix of size (n_samples, n_features)
+        or tensor of size(n_samples, D1, ..., DN)
+        
+    order : int
+        order of the higher-order moment to compute
+        
+    Returns
+    -------
+    tensor : moment
+        if tensor is a matrix of size (n_samples, n_features), 
+        tensor of size (n_features, )*order
+    """    
+    batch = ord('a')
+    start = batch+1
+    tensor_sym = [f'{chr(start+i)}' for i, _ in enumerate(tensor.shape)]
+    out_sym = tensor_sym[1:]*order
+    eq = ''.join(tensor_sym) + '->' + ''.join(out_sym)
+
+    return tl.einsum(eq, tensor)
+
+
+

--- a/tensorly/tenalg/einsum_tenalg/outer_product.py
+++ b/tensorly/tenalg/einsum_tenalg/outer_product.py
@@ -36,7 +36,7 @@ def batched_outer(tensors):
     """
     for i, tensor in enumerate(tensors):
         if i:
-            res = tensordot(res, tensor, modes=(), batched_modes=())
+            res = tensordot(res, tensor, modes=(), batched_modes=(0))
         else:
             res = tensor
     return res


### PR DESCRIPTION
This version builds on #329 but instead directly uses the BackendManager as Module class for `tensorly.backend`. 
This should be the fastest and most transparent version for users - it seems that module getattr add some overhead. 

Main changes are in the [__init__](https://github.com/tensorly/tensorly/blob/80e01e5f6d2327976a26e467707a5ebe4018e7b1/tensorly/backend/__init__.py) where the BackendManager is defined.