### PR TITLE
non-negative hals examples

### DIFF
--- a/examples/decomposition/plot_nn_cp_hals.py
+++ b/examples/decomposition/plot_nn_cp_hals.py
@@ -1,0 +1,163 @@
+"""
+Non-negative CP decomposition in Tensorly >=0.6
+===============================================
+Example and comparison of Non-negative Parafac decompositions.
+"""
+
+##############################################################################
+# Introduction
+# -----------------------
+# Since version 0.6 in Tensorly, several options are available to compute
+# non-negative CP (NCP), in particular several
+# algorithms:
+#
+# 1. Multiplicative updates (MU) (already in Tensorly < 0.6)
+# 2. Non-negative Alternating Least Squares (ALS) using Hierarchical ALS (HALS)
+#
+# Non-negativity is an important constraint to handle for tensor decompositions.
+# One could expect that factors must have only non-negative values after it is
+# obtained from a non-negative tensor.
+
+import numpy as np
+import tensorly as tl
+from tensorly.decomposition import non_negative_parafac, non_negative_parafac_hals
+from tensorly.decomposition._nn_cp import initialize_nn_cp
+from tensorly.cp_tensor import CPTensor
+import time
+from copy import deepcopy
+
+##############################################################################
+# Create synthetic tensor
+# -----------------------
+# There are several ways to create a tensor with non-negative entries in Tensorly.
+# Here we chose to generate a random from the sequence of integers from 1 to 24000.
+
+# Tensor generation
+tensor = tl.tensor(np.arange(24000).reshape((30, 40, 20)), dtype=tl.float32)
+
+##############################################################################
+# Our goal here is to produce an approximation of the tensor generated above
+# which follows a low-rank CP model, with non-negative coefficients. Before
+# using these algorithms, we can use Tensorly to produce a good initial guess
+# for our NCP. In fact, in order to compare both algorithmic options in a
+# fair way, it is a good idea to use same initialized factors in decomposition
+# algorithms. We make use of the ``initialize_cp`` function to initialize the
+# factors of the NCP, and transform these factors (and factors weights) into
+# an instance of the CPTensor class:
+
+weights_init, factors_init = initialize_nn_cp(tensor, init='random', rank=10)
+
+cp_init = CPTensor((weights_init, factors_init))
+
+##############################################################################
+# Non-negative Parafac
+# -----------------------
+# From now on, we can use the same ``cp_init`` tensor as the initial tensor when
+# we use decomposition functions. Now let us first use the algorithm based on
+# Multiplicative Update, which can be called as follows:
+
+tic = time.time()
+tensor_mu, errors_mu = non_negative_parafac(tensor, rank=10, init=deepcopy(cp_init), return_errors=True)
+cp_reconstruction_mu = tl.cp_to_tensor(tensor_mu)
+time_mu = time.time()-tic
+
+##############################################################################
+# Here, we also compute the output tensor from the decomposed factors by using
+# the cp_to_tensor function. The tensor cp_reconstruction_mu is therefore a
+# low-rank non-negative approximation of the input tensor; looking at the
+# first few values of both tensors shows that this is indeed
+# the case but the approximation is quite coarse.
+
+print('reconstructed tensor\n', cp_reconstruction_mu[10:12, 10:12, 10:12], '\n')
+print('input data tensor\n', tensor[10:12, 10:12, 10:12])
+
+##############################################################################
+# Non-negative Parafac with HALS
+# ------------------------------
+# Our second (new) option to compute NCP is the HALS algorithm, which can be
+# used as follows:
+
+tic = time.time()
+tensor_hals, errors_hals = non_negative_parafac_hals(tensor, rank=10, init=deepcopy(cp_init), return_errors=True)
+cp_reconstruction_hals = tl.cp_to_tensor(tensor_hals)
+time_hals = time.time()-tic
+
+##############################################################################
+# Again, we can look at the reconstructed tensor entries.
+
+print('reconstructed tensor\n',cp_reconstruction_hals[10:12, 10:12, 10:12], '\n')
+print('input data tensor\n', tensor[10:12, 10:12, 10:12])
+
+##############################################################################
+# Non-negative Parafac with Exact HALS
+# ------------------------------------
+# From only looking at a few entries of the reconstructed tensors, we can
+# already see a huge gap between HALS and MU outputs.
+# Additionally, HALS algorithm has an option for exact solution to the non-negative
+# least squares subproblem rather than the faster, approximate solution.
+# Note that the overall HALS algorithm will still provide an approximation of
+# the input data, but will need longer to reach convergence.
+# Exact subroutine solution option can be used simply choosing exact as True
+# in the function:
+
+tic = time.time()
+tensorhals_exact, errors_exact = non_negative_parafac_hals(tensor, rank=10, init=deepcopy(cp_init), return_errors=True, exact=True)
+cp_reconstruction_exact_hals = tl.cp_to_tensor(tensorhals_exact)
+time_exact_hals = time.time()-tic
+
+##############################################################################
+# Comparison
+# -----------------------
+# First comparison option is processing time for each algorithm:
+
+print(str("{:.2f}".format(time_mu)) + ' ' + 'seconds')
+print(str("{:.2f}".format(time_hals)) + ' ' + 'seconds')
+print(str("{:.2f}".format(time_exact_hals)) + ' ' + 'seconds')
+
+##############################################################################
+# As it is expected, the exact solution takes much longer than the approximate
+# solution, while the gain in performance is often void. Therefore we recommend
+# to avoid this option unless it is specifically required by the application.
+# Also note that on appearance, both MU and HALS have similar runtimes.
+# However, a closer look suggest they are indeed behaving quite differently.
+# Computing the error between the output and the input tensor tells that story better.
+# In Tensorly, we provide a function to calculate Root Mean Square Error (RMSE):
+
+from tensorly.metrics.regression import RMSE
+print(RMSE(tensor, cp_reconstruction_mu))
+print(RMSE(tensor, cp_reconstruction_hals))
+print(RMSE(tensor, cp_reconstruction_exact_hals))
+
+##############################################################################
+# According to the RMSE results, HALS is better than the multiplicative update
+# with both exact and approximate solution. In particular, HALS converged to a
+# much lower reconstruction error than MU. We can better appreciate the difference
+# in convergence speed on the following error per iteration plot:
+
+import matplotlib.pyplot as plt
+def each_iteration(a,b,c,title):
+    fig=plt.figure()
+    fig.set_size_inches(10, fig.get_figheight(), forward=True)
+    plt.plot(a)
+    plt.plot(b)
+    plt.plot(c)
+    plt.title(str(title))
+    plt.legend(['MU', 'HALS', 'Exact HALS'], loc='upper left')
+
+
+each_iteration(errors_mu, errors_hals, errors_exact, 'Error for each iteration')
+
+##############################################################################
+# In conclusion, on this quick test, it appears that the HALS algorithm gives
+# much better results than the MU original Tensorly methods. Our recommendation
+# is to use HALS as a default, and only resort to MU in specific cases (only
+# encountered by expert users most likely).
+
+##############################################################################
+# References
+# ----------
+#
+# Gillis, N., & Glineur, F. (2012). Accelerated multiplicative updates and
+# hierarchical ALS algorithms for nonnegative matrix factorization.
+# Neural computation, 24(4), 1085-1105. (Link)
+# <https://direct.mit.edu/neco/article/24/4/1085/7755/Accelerated-Multiplicative-Updates-and>

--- a/examples/decomposition/plot_nn_tucker.py
+++ b/examples/decomposition/plot_nn_tucker.py
@@ -1,0 +1,155 @@
+"""
+Non-negative Tucker decomposition in Tensorly >=0.6
+===================================================
+Example and comparison of Non-negative Tucker decompositions.
+"""
+
+##############################################################################
+# Introduction
+# -----------------------
+# Since version 0.6 in Tensorly, two algorithms are available to compute non-negative
+# Tucker decomposition:
+#
+# 1. Multiplicative updates (MU) (already in Tensorly < 0.6)
+# 2. Non-negative Alternating Least Squares (ALS) using Hierarchical ALS (HALS)
+#
+# Non-negativity is an important constraint to handle for tensor decompositions.
+# One could expect that core and factors must have only non-negative values after
+# it is obtained from a non-negative tensor. Tucker decomposition includes core
+# (:math:`G`) and factors (:math:`A`, :math:`B`, :math:`C`).
+#
+# .. math::
+#     T = [| G; A, B , C |],
+#
+# We need to solve the following problem for each factor (e.g. factor :math:`A` here):
+#
+# .. math::
+#     \min_{A \geq 0} ||T_{[1]} - A\times G_{[1]}(B\times C)^T||_F^2,
+#
+# Here, :math:`G_{[i]}` represents ith mode unfolding of the core. To update
+# the core, we need the solve following problem:
+#
+# .. math::
+#    \min_{g \geq 0} ||t -   (A\times B \times C)\times g ||_F^2,
+#
+# where :math:`t` and :math:`g` are the vectorized data tensor :math:`T` and core :math:`G`.
+
+##############################################################################
+# To update the factors, we will use HALS and to update the core, we have two
+# different algorithms Active Set (AS) and Fast Iterative Shrinkage-Thresholding
+# Algorithm (FISTA) in Tensorly. While FISTA is an accelerated gradient method for
+# non-negative or unconstrained problems, AS is the widely used non-negative
+# least square solution proposed by Lawson and Hanson in 1974. Both algorithms
+# return non-negative core and FISTA is the default algorithm for HALS Tucker
+# decomposition in Tensorly.
+
+import numpy as np
+import tensorly as tl
+from tensorly.decomposition import non_negative_tucker, non_negative_tucker_hals
+import time
+from tensorly.metrics.regression import RMSE
+import matplotlib.pyplot as plt
+
+
+##############################################################################
+# Create synthetic tensor
+# -----------------------
+# There are several ways to create a tensor with non-negative entries in Tensorly.
+# Here we chose to generate a random tensor from the sequence of integers from
+# 1 to 1000.
+
+# tensor generation
+array = np.random.randint(1000, size=(10, 30, 40))
+tensor = tl.tensor(array, dtype='float')
+
+##############################################################################
+# Non-negative Tucker
+# -----------------------
+# First, multiplicative update can be implemented as:
+
+tic = time.time()
+tensor_mu, error_mu = non_negative_tucker(tensor, rank=[5, 5, 5], tol=1e-12, n_iter_max=100, return_errors=True)
+tucker_reconstruction_mu = tl.tucker_to_tensor(tensor_mu)
+time_mu = time.time()-tic
+
+##############################################################################
+# Here, we also compute the output tensor from the decomposed factors by using
+# the ``tucker_to_tensor`` function. The tensor ``tucker_reconstruction_mu`` is
+# therefore a low-rank non-negative approximation of the input tensor ``tensor``.
+
+##############################################################################
+# Non-negative Tucker with HALS and FISTA
+# ---------------------------------------
+# HALS algorithm with FISTA can be calculated as:
+
+ticnew = time.time()
+tensor_hals_fista, error_fista = non_negative_tucker_hals(tensor, rank=[5, 5, 5], algorithm='fista', return_errors=True)
+tucker_reconstruction_fista = tl.tucker_to_tensor(tensor_hals_fista)
+time_fista = time.time()-ticnew
+
+##############################################################################
+# Non-negative Tucker with HALS and Active Set
+# --------------------------------------------
+# As a second option, HALS algorithm with Active Set can be called as follows:
+
+ticnew = time.time()
+tensor_hals_as, error_as = non_negative_tucker_hals(tensor, rank=[5, 5, 5], algorithm='active_set', return_errors=True)
+tucker_reconstruction_as = tl.tucker_to_tensor(tensor_hals_as)
+time_as = time.time()-ticnew
+
+##############################################################################
+# Comparison
+# -----------------------
+# To compare the various methods, first we may look at each algorithm
+# processing time:
+
+print('time for tensorly nntucker:'+' ' + str("{:.2f}".format(time_mu)))
+print('time for HALS with fista:'+' ' + str("{:.2f}".format(time_fista)))
+print('time for HALS with as:'+' ' + str("{:.2f}".format(time_as)))
+
+##############################################################################
+# All algorithms should run with about the same number of iterations on our
+# example, so at first glance the MU algorithm is faster (i.e. has lower
+# per-iteration complexity). A second way to compare methods is to compute
+# the error between the output and input tensor. In Tensorly, there is a function
+# to compute Root Mean Square Error (RMSE):
+
+print('RMSE tensorly nntucker:'+' ' + str(RMSE(tensor, tucker_reconstruction_mu)))
+print('RMSE for hals with fista:'+' ' + str(RMSE(tensor, tucker_reconstruction_fista)))
+print('RMSE for hals with as:'+' ' + str(RMSE(tensor, tucker_reconstruction_as)))
+
+##############################################################################
+# According to the RMSE results, HALS is better than the multiplicative update
+# with both FISTA and active set core update options. We can better appreciate
+# the difference in convergence speed on the following error per iteration plot:
+
+
+def each_iteration(a,b,c,title):
+    fig=plt.figure()
+    fig.set_size_inches(10, fig.get_figheight(), forward=True)
+    plt.plot(a)
+    plt.plot(b)
+    plt.plot(c)
+    plt.title(str(title))
+    plt.legend(['MU', 'HALS + Fista', 'HALS + AS'], loc='upper right')
+
+
+each_iteration(error_mu, error_fista, error_as, 'Error for each iteration')
+
+##############################################################################
+# In conclusion, on this quick test, it appears that the HALS algorithm gives
+# much better results than the MU original Tensorly methods. Our recommendation
+# is to use HALS as a default, and only resort to MU in specific cases
+# (only encountered by expert users most likely). Besides, in this experiment
+# FISTA and active set give very similar results, however active set may last
+# longer when it is used with higher ranks according to our experience.
+# Therefore, we recommend to use FISTA with high rank decomposition.
+
+##############################################################################
+# References
+# ----------
+#
+# Gillis, N., & Glineur, F. (2012). Accelerated multiplicative updates and
+# hierarchical ALS algorithms for nonnegative matrix factorization.
+# Neural computation, 24(4), 1085-1105. (Link)
+# <https://direct.mit.edu/neco/article/24/4/1085/7755/Accelerated-Multiplicative-Updates-and>


### PR DESCRIPTION
This PR adds two examples to explain HALS method for non-negative cp and tucker decompositions. Besides, these examples compare this new HALS method with the multiplicative update method which was already in Tensorly for non-negative decompositions. 