### PR TITLE
fix tensorflow dtype issue

### DIFF
--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -20,8 +20,8 @@ class TensorflowBackend(Backend, backend_name='tensorflow'):
 
     @staticmethod
     def tensor(data, dtype=np.float32, device=None, device_id=None):
-        if isinstance(data, tf.Tensor):
-            return data
+        if isinstance(data, tf.Tensor) or isinstance(data, tf.Variable):
+            return tf.cast(data, dtype=dtype)
 
         out = tf.Variable(data, dtype=dtype)
         return out.gpu(device_id) if device == 'gpu' else out


### PR DESCRIPTION
This PR adds [tensorflow cast](https://www.tensorflow.org/api_docs/python/tf/cast) function to `tensorly.tensor` in `tensorflow_backend` to allow changing dtype when tensor is a tensorflow tensor. Otherwise, dtype remains same even if a user wants to change it.