### PR TITLE
Generalized cp

### DIFF
--- a/tensorly/backend/__init__.py
+++ b/tensorly/backend/__init__.py
@@ -31,7 +31,7 @@ class BackendManager(types.ModuleType):
                   'sin', 'cos', 'clip', 'kr', 'kron', 'partial_svd', 'lstsq', 'eps', 'finfo',
                   'solve', 'qr', 'randn', 'check_random_state', 'sort', 'eigh',
                   'index_update', 'context', 'tensor', 'norm', 'to_numpy', 'is_tensor',
-                  'randomized_range_finder', 'randomized_svd', 'argsort', 'flip', 'count_nonzero'
+                  'randomized_range_finder', 'randomized_svd', 'argsort', 'log', 'exp', 'flip', 'count_nonzero'
                  ]
     _attributes = ['int64', 'int32', 'float64', 'float32', 
                    'complex128', 'complex64', 'SVD_FUNS', 'index', 'backend_name']

--- a/tensorly/backend/core.py
+++ b/tensorly/backend/core.py
@@ -1425,6 +1425,18 @@ class Backend(object):
         raise NotImplementedError
 
     @staticmethod
+    def log(x):
+        """Return the logarithm of x.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def exp(x):
+        """Return the exponential of x.
+        """
+        raise NotImplementedError
+
+    @staticmethod
     def sin(x):
         """Return the sin of x.
         """

--- a/tensorly/backend/cupy_backend.py
+++ b/tensorly/backend/cupy_backend.py
@@ -68,7 +68,7 @@ for name in ['float64', 'float32', 'int64', 'int32', 'complex128', 'complex64', 
              'transpose', 'copy', 'ones', 'zeros', 'zeros_like', 'eye', 'trace', 'any',
              'arange', 'where', 'dot', 'kron', 'concatenate', 'max', 'flip', 'matmul',
              'min', 'all', 'mean', 'sum', 'cumsum', 'count_nonzero', 'prod', 'sign', 'abs', 'sqrt', 'stack',
-             'conj', 'diag', 'einsum', 'log2', 'tensordot']:
+             'conj', 'diag', 'einsum', 'log2', 'log', 'exp', 'tensordot']:
     CupyBackend.register_method(name, getattr(cp, name))
 
 for name in ['svd', 'qr', 'eigh', 'solve']:

--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -92,7 +92,7 @@ for name in ['int64', 'int32', 'float64', 'float32', 'complex128', 'complex64', 
              'where', 'transpose', 'arange', 'ones', 'zeros', 'flip', 'trace', 'any',
              'zeros_like', 'eye', 'kron', 'concatenate', 'max', 'min', 'matmul',
              'all', 'mean', 'sum', 'cumsum', 'count_nonzero', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
-             'argmax', 'stack', 'conj', 'diag', 'clip', 'einsum', 'log2', 'tensordot', 'sin', 'cos']:
+             'argmax', 'stack', 'conj', 'diag', 'clip', 'einsum', 'log2', 'log', 'exp', 'tensordot', 'sin', 'cos']:
     JaxBackend.register_method(name, getattr(np, name))
 
 for name in ['solve', 'qr', 'svd', 'eigh']:

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -114,7 +114,7 @@ for name in ['int64', 'int32', 'float64', 'float32', 'reshape', 'moveaxis',
              'where', 'copy', 'transpose', 'arange', 'ones', 'zeros', 'trace', 'any',
              'zeros_like', 'eye', 'concatenate', 'max', 'min', 'flip', 'matmul',
              'all', 'mean', 'sum', 'cumsum', 'count_nonzero',  'prod', 'sign', 'abs', 'sqrt', 'argmin',
-             'argmax', 'stack', 'diag', 'einsum', 'log2', 'tensordot', 'sin', 'cos']:
+             'argmax', 'stack', 'diag', 'einsum', 'log2', 'log', 'exp', 'tensordot', 'sin', 'cos']:
     MxnetBackend.register_method(name, getattr(np, name))
 
 for name in ['solve', 'qr', 'eigh']:

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -76,7 +76,7 @@ for name in ['int64', 'int32', 'float64', 'float32', 'complex128', 'complex64',
              'where', 'copy', 'transpose', 'arange', 'ones', 'zeros', 'flip',
              'zeros_like', 'eye', 'kron', 'concatenate', 'max', 'min', 'matmul',
              'all', 'mean', 'sum', 'cumsum', 'count_nonzero', 'prod', 'sign', 'abs', 'sqrt', 'argmin',
-             'argmax', 'stack', 'conj', 'diag', 'einsum', 'log2', 'tensordot', 'sin', 'cos']:
+             'argmax', 'stack', 'conj', 'diag', 'einsum', 'log2', 'log', 'exp', 'tensordot', 'sin', 'cos']:
     NumpyBackend.register_method(name, getattr(np, name))
 
 for name in ['solve', 'qr', 'svd', 'eigh']:

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -221,7 +221,7 @@ class PyTorchBackend(Backend, backend_name='pytorch'):
 for name in ['float64', 'float32', 'int64', 'int32', 'complex128', 'complex64',
              'is_tensor', 'ones', 'zeros', 'any', 'trace', 'cumsum', 'count_nonzero', 'tensordot',
              'zeros_like', 'reshape', 'eye', 'min', 'prod', 'abs', 'matmul',
-             'sqrt', 'sign', 'where', 'conj', 'finfo', 'einsum', 'log2', 'sin', 'cos']:
+             'sqrt', 'sign', 'where', 'conj', 'finfo', 'einsum', 'log2', 'log', 'exp', 'sin', 'cos']:
     PyTorchBackend.register_method(name, getattr(torch, name))
 
 

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -233,6 +233,8 @@ _FUN_NAMES = [
     (tf.tensordot, 'tensordot'),
     (tfm.sin, 'sin'),
     (tfm.cos, 'cos'),
+    (tfm.log, 'log'),
+    (tfm.exp, 'exp'),
     (tfm.count_nonzero, 'count_nonzero'),
     (tfm.cumsum, 'cumsum'),
     (tfm.reduce_any, 'any')

--- a/tensorly/decomposition/__init__.py
+++ b/tensorly/decomposition/__init__.py
@@ -14,6 +14,7 @@ from ._symmetric_cp import symmetric_parafac_power_iteration, symmetric_power_it
 from ._cp_power import parafac_power_iteration, power_iteration, CPPower
 from ._cmtf_als import coupled_matrix_tensor_3d_factorization
 from ._constrained_cp import constrained_parafac
+from ._generalized_parafac import generalized_parafac, stochastic_generalized_parafac
 
 # Deprecated
 from ._tt import matrix_product_state

--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -426,7 +426,7 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',
         return cp_tensor
     
 
-def sample_khatri_rao(matrices, n_samples, skip_matrix=None,
+def sample_khatri_rao(matrices, n_samples, skip_matrix=None, indices_list=None,
                       return_sampled_rows=False, random_state=None):
     """Random subsample of the Khatri-Rao product of the given list of matrices
 
@@ -445,6 +445,9 @@ def sample_khatri_rao(matrices, n_samples, skip_matrix=None,
 
     skip_matrix : None or int, optional, default is None
         if not None, index of a matrix to skip
+
+    indices_list : list, default is None
+        if None, random indices will be created
 
     random_state : None, int or numpy.random.RandomState
         if int, used to set the seed of the random number generator
@@ -465,22 +468,23 @@ def sample_khatri_rao(matrices, n_samples, skip_matrix=None,
     indices_kr : int list
         list of length `n_samples` containing the sampled row indices
     """
-    if random_state is None or not isinstance(random_state, np.random.RandomState):
-        rng = tl.check_random_state(random_state)
-        warnings.warn('You are creating a new random number generator at each call.\n'
-                      'If you are calling sample_khatri_rao inside a loop this will be slow:'
-                      ' best to create a rng outside and pass it as argument (random_state=rng).')
-    else:
-        rng = random_state
-
     if skip_matrix is not None:
         matrices = [matrices[i] for i in range(len(matrices)) if i != skip_matrix]
+
+    # For each matrix, randomly choose n_samples indices for which to compute the khatri-rao product
+    if indices_list is None:
+        if random_state is None or not isinstance(random_state, np.random.RandomState):
+            rng = tl.check_random_state(random_state)
+            warnings.warn('You are creating a new random number generator at each call.\n'
+                          'If you are calling sample_khatri_rao inside a loop this will be slow:'
+                          ' best to create a rng outside and pass it as argument (random_state=rng).')
+        else:
+            rng = random_state
+        indices_list = [rng.randint(0, tl.shape(m)[0], size=n_samples, dtype=int) for m in matrices]
 
     rank = tl.shape(matrices[0])[1]
     sizes = [tl.shape(m)[0] for m in matrices]
 
-    # For each matrix, randomly choose n_samples indices for which to compute the khatri-rao product
-    indices_list = [rng.randint(0, tl.shape(m)[0], size=n_samples, dtype=int) for m in matrices]
     if return_sampled_rows:
         # Compute corresponding rows of the full khatri-rao product
         indices_kr = np.zeros((n_samples), dtype=int)

--- a/tensorly/decomposition/_generalized_parafac.py
+++ b/tensorly/decomposition/_generalized_parafac.py
@@ -1,0 +1,591 @@
+import numpy as np
+from ..random import random_cp
+from ._base_decomposition import DecompositionMixin
+import tensorly as tl
+from ..cp_tensor import CPTensor, validate_cp_rank, unfolding_dot_khatri_rao
+from ..metrics.losses import loss_operator, gradient_operator
+
+
+def initialize_generalized_parafac(tensor, rank, init='svd', svd='numpy_svd', loss=None, random_state=None):
+    r"""Initialize factors used in `generalized parafac`.
+
+    Parameters
+    ----------
+    The type of initialization is set using `init`. If `init == 'random'` then
+    initialize factor matrices with uniform distribution using `random_state`. If `init == 'svd'` then
+    initialize the `m`th factor matrix using the `rank` left singular vectors
+    of the `m`th unfolding of the input tensor. If init is a previously initialized `cp tensor`, all
+    the weights are pulled in the last factor and then the weights are set to "1" for the output tensor.
+
+    Parameters
+    ----------
+    tensor : ndarray
+    rank : int
+    init : {'svd', 'random', cptensor}, optional
+    svd : str, default is 'numpy_svd'
+        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+    loss : {'gaussian', 'gamma', 'rayleigh', 'poisson_count', 'poisson_log', 'bernoulli_odds', 'bernoulli_log'}
+    random_state : {None, int, np.random.RandomState}
+    Returns
+    -------
+    factors : CPTensor
+        An initial cp tensor.
+    """
+    rng = tl.check_random_state(random_state)
+    if init == 'random':
+        kt = random_cp(tl.shape(tensor), rank, random_state=rng, normalise_factors=False, **tl.context(tensor))
+
+    elif init == 'svd':
+        try:
+            svd_fun = tl.SVD_FUNS[svd]
+        except KeyError:
+            message = 'Got svd={}. However, for the current backend ({}), the possible choices are {}'.format(
+                      svd, tl.get_backend(), tl.SVD_FUNS)
+            raise ValueError(message)
+
+        factors = []
+        for mode in range(tl.ndim(tensor)):
+            U, S, _ = svd_fun(tl.unfold(tensor, mode), n_eigenvecs=rank)
+
+            # Put SVD initialization on the same scaling as the tensor in case normalize_factors=False
+            if mode == 0:
+                idx = min(rank, tl.shape(S)[0])
+                U = tl.index_update(U, tl.index[:, :idx], U[:, :idx] * S[:idx])
+
+            if tensor.shape[mode] < rank:
+                random_part = tl.tensor(rng.random_sample((U.shape[0], rank - tl.shape(tensor)[mode])), **tl.context(tensor))
+                U = tl.concatenate([U, random_part], axis=1)
+
+            factors.append(U[:, :rank])
+        kt = CPTensor((None, factors))
+    elif isinstance(init, (tuple, list, CPTensor)):
+        try:
+            weights, factors = CPTensor(init)
+
+            if tl.all(weights == 1):
+                weights, factors = CPTensor((None, factors))
+            else:
+                weights_avg = tl.prod(weights) ** (1.0 / tl.shape(weights)[0])
+                for i in range(len(factors)):
+                    factors[i] = factors[i] * weights_avg
+            kt = CPTensor((None, factors))
+            return kt
+        except ValueError:
+            raise ValueError(
+                'If initialization method is a mapping, then it must '
+                'be possible to convert it to a CPTensor instance'
+            )
+    else:
+        raise ValueError('Initialization method "{}" not recognized'.format(init))
+    if loss == 'gamma' or loss == 'rayleigh' or loss == 'poisson_count' or loss == 'bernoulli_odds':
+        kt.factors = [tl.abs(f) for f in kt[1]]
+    return kt
+
+
+def sampled_kr_product(matrices, indices_list, n_samples=None, skip_matrix=None):
+    '''
+    Khatri-Rao product of the given list of matrices and indices.
+
+    Parameters
+    ----------
+    matrices : ndarray list
+        list of matrices with the same number of columns, i.e.::
+            for i in len(matrices):
+                matrices[i].shape = (n_i, m)
+    indices_list : list
+    n_samples : int
+        number of samples to be taken from the Khatri-Rao product
+    skip_matrix : None or int, optional, default is None
+        if not None, index of a matrix to skip
+
+    Returns
+    -------
+    sampled_Khatri_Rao : ndarray
+        The sampled matricised tensor Khatri-Rao with `n_samples` rows
+    '''
+    if n_samples is None:
+        raise ValueError('n_samples')
+    if skip_matrix is not None:
+        matrices = [matrices[i] for i in range(len(matrices)) if i != skip_matrix]
+    rank = tl.shape(matrices[0])[1]
+    sampled_kr = tl.ones((n_samples, rank), **tl.context(matrices[0]))
+    for indices, matrix in zip(indices_list, matrices):
+        sampled_kr = sampled_kr * matrix[indices, :]
+    return sampled_kr
+
+
+def stochastic_gradient(tensor, factors, batch_size, loss='gaussian', random_state=None, mask=None):
+    '''
+    Computes stochastic gradient between given tensor and estimated factors according to the given loss and batch size.
+
+    Parameters
+    ----------
+    tensor : ndarray
+    factors :  list of matrices
+    batch_size : int
+    loss : {'gaussian', 'gamma', 'rayleigh', 'poisson_count', 'poisson_log', 'bernoulli_odds', 'bernoulli_log'}
+    random_state : {None, int, np.random.RandomState}
+    mask : ndarray
+        array of booleans with the same shape as ``tensor`` should be 0 where
+        the values are missing and 1 everywhere else.
+
+    Returns
+    -------
+    ndarray
+          Stochastic gradient between tensor and factors according to the given batch size and loss.
+    '''
+    if random_state is None or not isinstance(random_state, np.random.RandomState):
+        rng = tl.check_random_state(random_state)
+    else:
+        rng = random_state
+    if mask is None:
+        indices_tuple = tuple([rng.randint(0, tl.shape(f)[0], size=batch_size, dtype=int) for f in factors])
+    else:
+        indices = list(tl.where(mask == 1))
+        indices_to_select = tuple([rng.randint(0, tl.shape(indices[0]), size=batch_size, dtype=int)])
+        indices_tuple = tuple([indices[i][indices_to_select] for i in range(len(indices))])
+    modes = tl.ndim(tensor)
+    gradient = [tl.zeros(tl.shape(factors[i])) for i in range(modes)]
+
+    for mode in range(modes):
+        indices_list = list(indices_tuple)
+        indice_list_mode = indices_list.pop(mode)
+        indices_list_mode_rest = indices_list.copy()
+        indices_list.insert(mode, slice(None, None, None))
+        indices_list = tuple(indices_list)
+        sampled_kr = sampled_kr_product(factors, indices_list_mode_rest, n_samples=batch_size, skip_matrix=mode)
+        if mode:
+            gradient_tensor = gradient_operator(tensor[indices_list], tl.dot(sampled_kr, tl.transpose(factors[mode])),
+                                                loss=loss, mask=mask)
+        else:
+            gradient_tensor = gradient_operator(tl.transpose(tensor[indices_list]),
+                                                tl.dot(sampled_kr, tl.transpose(factors[mode])), loss=loss, mask=mask)
+
+        gradient[mode] = tl.index_update(gradient[mode], tl.index[indice_list_mode, :],
+                                         tl.transpose(tl.dot(tl.transpose(sampled_kr), gradient_tensor))[indice_list_mode, :])
+    return gradient
+
+
+def generalized_parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd', tol=1e-8, verbose=0,
+                        random_state=None, return_errors=False, loss='gaussian', lr=0.01, mask=None,
+                        cvg_criterion='abs_rec_error'):
+    """ Generalized PARAFAC decomposition by using FISTA optimization
+    Computes a rank-`rank` decomposition of `tensor` [1]_ such that::
+        tensor = [|weights; factors[0], ..., factors[-1] |].
+    Parameters
+    ----------
+    tensor : ndarray
+    rank  : int
+        Number of components.
+    n_iter_max : int
+        Maximum number of iteration
+    init : {'svd', 'random', CPTensor}, optional
+        Type of factor matrix initialization.
+        If a CPTensor is passed, this is directly used for initialization.
+        See `initialize_factors`.
+    svd : str, default is 'numpy_svd'
+        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+    tol : float, optional
+        (Default: 1e-6) Relative reconstruction error tolerance. The
+        algorithm is considered to have found the global minimum when the
+        reconstruction error is less than `tol`.
+    verbose : int, optional
+        Level of verbosity
+    random_state : {None, int, np.random.RandomState}
+    verbose : int, optional
+        Level of verbosity
+    lr : float
+        Default : 0.01
+    mask : ndarray
+        array of booleans with the same shape as ``tensor`` should be 0 where
+        the values are missing and 1 everywhere else.
+    return_errors : bool, optional
+        Activate return of iteration errors
+    loss : {'gaussian', 'bernoulli_odds', 'bernoulli_logit', 'rayleigh', 'poisson_count', 'poisson_log', 'gamma'}
+        Default : 'gaussian'
+    cvg_criterion : {'abs_rec_error', 'rec_error'}, optional
+       Stopping criterion for ALS, works if `tol` is not None.
+       If 'rec_error',  ALS stops at current iteration if ``(previous rec_error - current rec_error) < tol``.
+       If 'abs_rec_error', ALS terminates when `|previous rec_error - current rec_error| < tol`.
+    Returns
+    -------
+    CPTensor : (weight, factors)
+        * weights : 1D array of shape (rank, )
+          * all ones if normalize_factors is False (default)
+          * weights of the (normalized) factors otherwise
+        * factors : List of factors of the CP decomposition element `i` is of shape ``(tensor.shape[i], rank)``
+    errors : list
+        A list of reconstruction errors at each iteration of the algorithms.
+    References
+    ----------
+    .. [1] Hong, D., Kolda, T. G., & Duersch, J. A. (2020).
+           Generalized canonical polyadic tensor decomposition. SIAM Review, 62(1), 133-163.
+    .. [2] Kolda, T. G., & Hong, D. (2020). Stochastic gradients for large-scale tensor decomposition.
+           SIAM Journal on Mathematics of Data Science, 2(4), 1066-1095.
+    """
+    rank = validate_cp_rank(tl.shape(tensor), rank=rank)
+    rng = tl.check_random_state(random_state)
+    rec_errors = []
+    modes = [mode for mode in range(tl.ndim(tensor))]
+    # Initial tensor
+    weights, factors = initialize_generalized_parafac(tensor, rank, init=init, svd=svd, loss=loss,
+                                                      random_state=rng)
+    gradient = []
+    # Fista parameters
+    momentum_old = tl.tensor(1.0)
+    factors_update = []
+    factors_new = []
+    for i in modes:
+        gradient.append(tl.zeros(tl.shape(factors[i])))
+        factors_update.append((factors[i]))
+        factors_new.append(tl.zeros(tl.shape(factors[i])))
+    for iteration in range(n_iter_max):
+        gradient_tensor = gradient_operator(tensor, tl.cp_to_tensor((None, factors)), loss=loss, mask=mask)
+        for mode in modes:
+            gradient[mode] = unfolding_dot_khatri_rao(gradient_tensor, (None, factors), mode)
+            factors_new[mode] = factors_update[mode] - lr * gradient[mode]
+            momentum = (1 + tl.sqrt(1 + 4 * momentum_old ** 2)) / 2
+            factors_update[mode] = factors_new[mode] + ((momentum_old - 1) / momentum) * (factors_new[mode] - factors[mode])
+            momentum_old = momentum
+            factors[mode] = tl.copy(factors_new[mode])
+            if loss == 'gamma' or loss == 'rayleigh' or loss == 'poisson_count' or loss == 'bernoulli_odds':
+                factors[mode] = tl.clip(factors[mode], 0)
+        # Calculate the current error
+        current_loss = loss_operator(tensor, tl.cp_to_tensor((weights, factors)), loss=loss, mask=mask)
+        rec_error = tl.sum(current_loss) / tl.norm(tensor)
+        rec_errors.append(rec_error)
+
+        if tol:
+            if iteration >= 1:
+                rec_error_decrease = rec_errors[-2] - rec_errors[-1]
+                if verbose:
+                    print("iteration {}, reconstruction error: {}, decrease = {}".format(iteration,
+                                                                                         rec_error,
+                                                                                         rec_error_decrease))
+                if cvg_criterion == 'abs_rec_error':
+                    stop_flag = abs(rec_error_decrease) < tol
+                elif cvg_criterion == 'rec_error':
+                    stop_flag = rec_error_decrease < tol
+                else:
+                    raise TypeError("Unknown convergence criterion")
+                if stop_flag:
+                    if verbose:
+                        print("PARAFAC converged after {} iterations".format(iteration))
+            else:
+                if verbose:
+                    print('reconstruction error={}'.format(rec_errors[-1]))
+    cp_tensor = CPTensor((weights, factors))
+    if return_errors:
+        return cp_tensor, rec_errors
+    else:
+        return cp_tensor
+
+
+def stochastic_generalized_parafac(tensor, rank, n_iter_max=1000, init='random', return_errors=False,
+                                   loss='gaussian', epochs=20, batch_size=200, lr=0.01, beta_1=0.9, beta_2=0.999,
+                                   mask=None, random_state=None):
+    """ Generalized PARAFAC decomposition by using ADAM optimization
+    Computes a rank-`rank` decomposition of `tensor` [1]_ such that::
+        tensor = [|weights; factors[0], ..., factors[-1] |].
+    Parameters
+    ----------
+    tensor : ndarray
+    rank  : int
+        Number of components.
+    n_iter_max : int
+        Maximum number of iteration
+    init : {'random', CPTensor}, optional
+        Type of factor matrix initialization.
+        If a CPTensor is passed, this is directly used for initialization.
+        See `initialize_factors`.
+    return_errors : bool, optional
+        Activate return of iteration errors
+    loss : {'gaussian', 'bernoulli_odds', 'bernoulli_logit', 'rayleigh', 'poisson_count', 'poisson_log', 'gamma'}
+        Default : 'gaussian'
+    epochs : int
+        Default : 20
+    batch_size : int
+        Default : 200
+    lr : float
+        Default : 0.01
+    beta_1 : float
+        ADAM optimization parameter.
+        Default : 0.9
+    beta_2 : float
+        ADAM optimization parameter.
+        Default : 0.999
+    mask : ndarray
+        array of booleans with the same shape as ``tensor`` should be 0 where
+        the values are missing and 1 everywhere else.
+    random_state : {None, int, np.random.RandomState}
+
+    Returns
+    -------
+    CPTensor : (weight, factors)
+        * weights : 1D array of shape (rank, )
+          * all ones if normalize_factors is False (default)
+          * weights of the (normalized) factors otherwise
+        * factors : List of factors of the CP decomposition element `i` is of shape ``(tensor.shape[i], rank)``
+    errors : list
+        A list of reconstruction errors at each iteration of the algorithms.
+    References
+    ----------
+    .. [1] Hong, D., Kolda, T. G., & Duersch, J. A. (2020).
+           Generalized canonical polyadic tensor decomposition. SIAM Review, 62(1), 133-163.
+    .. [2] Kolda, T. G., & Hong, D. (2020). Stochastic gradients for large-scale tensor decomposition.
+           SIAM Journal on Mathematics of Data Science, 2(4), 1066-1095.
+    """
+    rank = validate_cp_rank(tl.shape(tensor), rank=rank)
+    rng = tl.check_random_state(random_state)
+    rec_errors = []
+    modes = [mode for mode in range(tl.ndim(tensor))]
+    # initial tensor
+    _, factors = initialize_generalized_parafac(tensor, rank, init=init, loss=loss, random_state=rng)
+    # parameters for ADAM optimization
+    momentum_first = []
+    momentum_second = []
+    t_iter = 1
+    indices_tuple = tuple([rng.randint(0, tl.shape(f)[0], size=batch_size, dtype=int) for f in factors])
+    current_loss = loss_operator(tensor[indices_tuple],
+                                 tl.sum(sampled_kr_product(factors, indices_tuple, n_samples=batch_size), axis=1),
+                                 loss=loss, mask=mask)
+    # global loss
+    current_loss = tl.sum(current_loss)
+    for i in modes:
+        momentum_first.append(tl.zeros(tl.shape(factors[i])))
+        momentum_second.append(tl.zeros(tl.shape(factors[i])))
+    epsilon = 1e-8
+    bad_epochs = 0
+    max_bad_epochs = 20
+    for epoch in range(epochs):
+        loss_old = tl.copy(current_loss)
+        factors_old = [tl.copy(f) for f in factors]
+        momentum_first_old = [tl.copy(f) for f in momentum_first]
+        momentum_second_old = [tl.copy(f) for f in momentum_second]
+        for iteration in range(n_iter_max):
+            gradient = stochastic_gradient(tensor, factors, batch_size, random_state=rng, loss=loss)
+            for mode in modes:
+                # adam optimization
+                momentum_first[mode] = (beta_1 * momentum_first[mode]) + (1 - beta_1) * gradient[mode]
+                momentum_second[mode] = beta_2 * momentum_second[mode] + (1 - beta_2) * (gradient[mode] ** 2)
+                momentum_first_hat = momentum_first[mode] / (1 - (beta_1 ** t_iter))
+                momentum_second_hat = momentum_second[mode] / (1 - (beta_2 ** t_iter))
+                factors[mode] = factors[mode] - lr * momentum_first_hat / (tl.sqrt(momentum_second_hat) + epsilon)
+
+                if loss == 'gamma' or loss == 'rayleigh' or loss == 'poisson_count' or loss == 'bernoulli_odds':
+                    factors[mode] = tl.clip(factors[mode], 0)
+
+            t_iter += 1
+        # Calculate the current error
+        current_loss = loss_operator(tensor[indices_tuple],
+                                     tl.sum(sampled_kr_product(factors, indices_tuple, n_samples=batch_size), axis=1),
+                                     loss=loss, mask=mask)
+        # global loss
+        current_loss = tl.sum(current_loss)
+        if current_loss >= loss_old:
+            lr = lr / 10
+            factors = [tl.copy(f) for f in factors_old]
+            current_loss = tl.copy(loss_old)
+            t_iter -= iteration
+            momentum_first = [tl.copy(f) for f in momentum_first_old]
+            momentum_second = [tl.copy(f) for f in momentum_second_old]
+            bad_epochs += 1
+        else:
+            bad_epochs = 0
+        rec_error = current_loss / tl.norm(tensor)
+        rec_errors.append(rec_error)
+        if bad_epochs >= max_bad_epochs:
+            print("Sufficient number of bad epochs")
+            break
+    cp_tensor = CPTensor((None, factors))
+    if return_errors:
+        return cp_tensor, rec_errors
+    else:
+        return cp_tensor
+
+
+class GCP(DecompositionMixin):
+    """ Generalized PARAFAC decomposition by using Fista optimization
+    Computes a rank-`rank` decomposition of `tensor` [1]_ such that::
+        tensor = [|weights; factors[0], ..., factors[-1] |].
+    Parameters
+    ----------
+    tensor : ndarray
+    rank  : int
+        Number of components.
+    n_iter_max : int
+        Maximum number of iteration
+    init : {'svd', 'random', CPTensor}, optional
+        Type of factor matrix initialization.
+        If a CPTensor is passed, this is directly used for initialization.
+        See `initialize_factors`.
+    svd : str, default is 'numpy_svd'
+        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+    tol : float, optional
+        (Default: 1e-6) Relative reconstruction error tolerance. The
+        algorithm is considered to have found the global minimum when the
+        reconstruction error is less than `tol`.
+    verbose : int, optional
+        Level of verbosity
+    lr : float
+    normalize_factors : if True, aggregate the weights of each factor in a 1D-tensor
+        of shape (rank, ), which will contain the norms of the factors
+    mask : ndarray
+        array of booleans with the same shape as ``tensor`` should be 0 where
+        the values are missing and 1 everywhere else.
+    return_errors : bool, optional
+        Activate return of iteration errors
+    loss : {'gaussian', 'bernoulli_odds', 'bernoulli_logit', 'rayleigh', 'poisson_count', 'poisson_log', 'gamma'}
+    cvg_criterion : {'abs_rec_error', 'rec_error'}, optional
+       Stopping criterion for ALS, works if `tol` is not None.
+       If 'rec_error',  ALS stops at current iteration if ``(previous rec_error - current rec_error) < tol``.
+       If 'abs_rec_error', ALS terminates when `|previous rec_error - current rec_error| < tol`.
+    Returns
+    -------
+    CPTensor : (weight, factors)
+        * weights : 1D array of shape (rank, )
+          * all ones if normalize_factors is False (default)
+          * weights of the (normalized) factors otherwise
+        * factors : List of factors of the CP decomposition element `i` is of shape ``(tensor.shape[i], rank)``
+        * sparse_component : nD array of shape tensor.shape. Returns only if `sparsity` is not None.
+    errors : list
+        A list of reconstruction errors at each iteration of the algorithms.
+    References
+    ----------
+    .. [1] Hong, D., Kolda, T. G., & Duersch, J. A. (2020).
+           Generalized canonical polyadic tensor decomposition. SIAM Review, 62(1), 133-163.
+    .. [2] Kolda, T. G., & Hong, D. (2020). Stochastic gradients for large-scale tensor decomposition.
+           SIAM Journal on Mathematics of Data Science, 2(4), 1066-1095.
+    """
+
+    def __init__(self, rank, n_iter_max=100, init='svd', svd='numpy_svd', tol=1e-8, verbose=0, loss='gaussian', lr=0.01,
+                 cvg_criterion='abs_rec_error', random_state=None, mask=None, return_errors=False):
+        self.rank = rank
+        self.n_iter_max = n_iter_max
+        self.init = init
+        self.svd = svd
+        self.tol = tol
+        self.verbose = verbose
+        self.return_errors = return_errors
+        self.loss = loss
+        self.lr = lr
+        self.random_state = random_state
+        self.mask = mask
+        self.cvg_criterion = cvg_criterion
+
+    def fit_transform(self, tensor):
+        """Decompose an input tensor
+        Parameters
+        ----------
+        tensor : tensorly tensor
+            input tensor to decompose
+        Returns
+        -------
+        CPTensor
+            decomposed tensor
+        """
+        cp_tensor, errors = generalized_parafac(
+            tensor,
+            rank=self.rank,
+            n_iter_max=self.n_iter_max,
+            init=self.init,
+            svd=self.svd,
+            tol=self.tol,
+            verbose=self.verbose,
+            loss=self.loss,
+            lr=self.lr,
+            random_state=self.random_state,
+            mask=self.mask,
+            return_errors=self.return_errors,
+            cvg_criterion=self.cvg_criterion
+        )
+        self.decomposition_ = cp_tensor
+        self.errors_ = errors
+        return self.decomposition_
+
+
+class Stochastic_GCP(DecompositionMixin):
+    """ Stochastic Generalized PARAFAC decomposition by using ADAM optimization
+    Computes a rank-`rank` decomposition of `tensor` [1]_ such that::
+        tensor = [|weights; factors[0], ..., factors[-1] |].
+    Parameters
+    ----------
+    tensor : ndarray
+    rank  : int
+        Number of components.
+    n_iter_max : int
+        Maximum number of iteration
+    init : {'random', CPTensor}, optional
+        Type of factor matrix initialization.
+        If a CPTensor is passed, this is directly used for initialization.
+        See `initialize_factors`.
+    lr : float
+    mask : ndarray
+        array of booleans with the same shape as ``tensor`` should be 0 where
+        the values are missing and 1 everywhere else.
+    return_errors : bool, optional
+        Activate return of iteration errors
+    loss : {'gaussian', 'bernoulli_odds', 'bernoulli_logit', 'rayleigh', 'poisson_count', 'poisson_log', 'gamma'}
+
+    Returns
+    -------
+    CPTensor : (weight, factors)
+        * weights : 1D array of shape (rank, )
+          * all ones if normalize_factors is False (default)
+          * weights of the (normalized) factors otherwise
+        * factors : List of factors of the CP decomposition element `i` is of shape ``(tensor.shape[i], rank)``
+        * sparse_component : nD array of shape tensor.shape. Returns only if `sparsity` is not None.
+    errors : list
+        A list of reconstruction errors at each iteration of the algorithms.
+    References
+    ----------
+    .. [1] Hong, D., Kolda, T. G., & Duersch, J. A. (2020).
+           Generalized canonical polyadic tensor decomposition. SIAM Review, 62(1), 133-163.
+    .. [2] Kolda, T. G., & Hong, D. (2020). Stochastic gradients for large-scale tensor decomposition.
+           SIAM Journal on Mathematics of Data Science, 2(4), 1066-1095.
+    """
+
+    def __init__(self, rank, n_iter_max=100, init='random', loss='gaussian', epochs=100, batch_size=100, lr=0.01,
+                 beta_1=0.9, beta_2=0.999, return_errors=False, random_state=None, mask=None):
+        self.rank = rank
+        self.n_iter_max = n_iter_max
+        self.init = init
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.beta_1 = beta_1
+        self.beta_2 = beta_2
+        self.return_errors = return_errors
+        self.loss = loss
+        self.random_state = random_state
+        self.lr = lr
+        self.mask = mask
+
+    def fit_transform(self, tensor):
+        """Decompose an input tensor
+        Parameters
+        ----------
+        tensor : tensorly tensor
+            input tensor to decompose
+        Returns
+        -------
+        CPTensor
+            decomposed tensor
+        """
+        cp_tensor, errors = stochastic_generalized_parafac(
+            tensor,
+            rank=self.rank,
+            n_iter_max=self.n_iter_max,
+            init=self.init,
+            epochs=self.epochs,
+            batch_size=self.batch_size,
+            beta_1=self.beta_1,
+            beta_2=self.beta_2,
+            loss=self.loss,
+            lr=self.lr,
+            random_state=self.random_state,
+            mask=self.mask,
+            return_errors=self.return_errors
+        )
+        self.decomposition_ = cp_tensor
+        self.errors_ = errors
+        return self.decomposition_

--- a/tensorly/decomposition/tests/test_generalized_parafac.py
+++ b/tensorly/decomposition/tests/test_generalized_parafac.py
@@ -31,7 +31,7 @@ def test_generalized_parafac(monkeypatch):
     loss = 'gamma'
     array = rng.gamma(1, initial_tensor, size=shape)
     tensor = T.tensor(array)
-    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-5)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-8)
     reconstructed_tensor = cp_to_tensor(gcp_result)
     error = loss_operator(initial_tensor, reconstructed_tensor, loss)
     error = T.sum(error) / T.norm(initial_tensor, 2)
@@ -42,7 +42,7 @@ def test_generalized_parafac(monkeypatch):
     loss = 'rayleigh'
     array = rng.rayleigh(initial_tensor, size=shape)
     tensor = T.tensor(array)
-    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-8)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-16)
     reconstructed_tensor = cp_to_tensor(gcp_result)
     error = loss_operator(initial_tensor, reconstructed_tensor, loss)
     error = T.sum(error) / T.norm(initial_tensor, 2)

--- a/tensorly/decomposition/tests/test_generalized_parafac.py
+++ b/tensorly/decomposition/tests/test_generalized_parafac.py
@@ -42,7 +42,7 @@ def test_generalized_parafac(monkeypatch):
     loss = 'rayleigh'
     array = rng.rayleigh(initial_tensor, size=shape)
     tensor = T.tensor(array)
-    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-16)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-16, lr=1e-5)
     reconstructed_tensor = cp_to_tensor(gcp_result)
     error = loss_operator(initial_tensor, reconstructed_tensor, loss)
     error = T.sum(error) / T.norm(initial_tensor, 2)

--- a/tensorly/decomposition/tests/test_generalized_parafac.py
+++ b/tensorly/decomposition/tests/test_generalized_parafac.py
@@ -1,0 +1,185 @@
+from .._generalized_parafac import generalized_parafac, stochastic_generalized_parafac, Stochastic_GCP, GCP
+from ...metrics.losses import loss_operator
+from ...testing import assert_, assert_class_wrapper_correctly_passes_arguments
+from ... import backend as T
+from ...cp_tensor import cp_to_tensor
+from ...random import random_cp
+import pytest
+import tensorly as tl
+
+
+def test_generalized_parafac(monkeypatch):
+    """Test for the Generalized Parafac decomposition
+    """
+    tol_norm_2 = 0.3
+    rank = 3
+    shape = [8, 10, 6]
+    init = 'random'
+    rng = T.check_random_state(1234)
+    initial_tensor = cp_to_tensor(random_cp(shape, rank=rank))
+
+    # Gaussian
+    loss = 'gaussian'
+    gcp_result = generalized_parafac(initial_tensor, loss=loss, rank=rank, init=init, tol=1e-5)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Gamma
+    loss = 'gamma'
+    array = rng.gamma(1, initial_tensor, size=shape)
+    tensor = T.tensor(array)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-5)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Rayleigh
+    loss = 'rayleigh'
+    array = rng.rayleigh(initial_tensor, size=shape)
+    tensor = T.tensor(array)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-8)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Poisson-count
+    loss = 'poisson_count'
+    array = 1.0 * rng.poisson(initial_tensor, size=shape)
+    tensor = T.tensor(array)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-8)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Poisson-log
+    loss = 'poisson_log'
+    array = 1.0 * rng.poisson(tl.exp(initial_tensor), size=shape)
+    tensor = T.tensor(array)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-5)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Bernoulli-odds
+    loss = 'bernoulli_odds'
+    array = 1.0 * rng.binomial(1, initial_tensor / (initial_tensor + 1), size=shape)
+    tensor = T.tensor(array)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-5)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Bernoulli-logit
+    loss = 'bernoulli_logit'
+    array = 1.0 * rng.binomial(1, tl.exp(initial_tensor) / (tl.exp(initial_tensor) + 1), size=shape)
+    tensor = T.tensor(array)
+    gcp_result = generalized_parafac(tensor, loss=loss, rank=rank, init=init, tol=1e-5)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, generalized_parafac, GCP, rank=3)
+
+
+@pytest.mark.xfail(tl.get_backend() == 'tensorflow', reason='Fails on tensorflow')
+def test_stochastic_generalized_parafac(monkeypatch):
+    """Test for the Stochastic Generalized Parafac decomposition
+    """
+    tol_norm_2 = 0.3
+    rank = 3
+    shape = [8, 10, 6]
+    init = 'random'
+    rng = T.check_random_state(1234)
+    initial_tensor = cp_to_tensor(random_cp(shape, rank=rank))
+    batch_size = 8
+
+    # Gaussian
+    loss = 'gaussian'
+    gcp_result = stochastic_generalized_parafac(initial_tensor, loss=loss, rank=rank, n_iter_max=100, init=init)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Gamma
+    loss = 'gamma'
+    array = rng.gamma(1, initial_tensor, size=shape)
+    tensor = T.tensor(array)
+    gcp_result = stochastic_generalized_parafac(tensor, loss=loss, rank=rank, init=init, n_iter_max=100, batch_size=batch_size)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Rayleigh
+    loss = 'rayleigh'
+    array = rng.rayleigh(initial_tensor, size=shape)
+    tensor = T.tensor(array)
+    gcp_result = stochastic_generalized_parafac(tensor, loss=loss, rank=rank, init=init, n_iter_max=100, batch_size=batch_size)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Poisson-count
+    loss = 'poisson_count'
+    array = 1.0 * rng.poisson(initial_tensor, size=shape)
+    tensor = T.tensor(array)
+    gcp_result = stochastic_generalized_parafac(tensor, loss=loss, rank=rank, init=init, n_iter_max=500, batch_size=batch_size)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Poisson-log
+    loss = 'poisson_log'
+    array = 1.0 * rng.poisson(tl.exp(initial_tensor), size=shape)
+    tensor = T.tensor(array)
+    gcp_result = stochastic_generalized_parafac(tensor, loss=loss, rank=rank, init=init, n_iter_max=500, batch_size=batch_size)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Bernoulli-odds
+    loss = 'bernoulli_odds'
+    array = 1.0 * rng.binomial(1, initial_tensor / (initial_tensor + 1), size=shape)
+    tensor = T.tensor(array)
+    gcp_result = stochastic_generalized_parafac(tensor, loss=loss, rank=rank, init=init, n_iter_max=100, batch_size=batch_size)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+
+    # Bernoulli-logit
+    loss = 'bernoulli_logit'
+    array = 1.0 * rng.binomial(1, tl.exp(initial_tensor) / (tl.exp(initial_tensor) + 1), size=shape)
+    tensor = T.tensor(array)
+    gcp_result = stochastic_generalized_parafac(tensor, loss=loss, rank=rank, init=init, batch_size=batch_size,
+                                                epochs=100, n_iter_max=100)
+    reconstructed_tensor = cp_to_tensor(gcp_result)
+    error = loss_operator(initial_tensor, reconstructed_tensor, loss)
+    error = T.sum(error) / T.norm(initial_tensor, 2)
+    assert_(error < tol_norm_2,
+            f'norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}')
+    assert_class_wrapper_correctly_passes_arguments(monkeypatch, stochastic_generalized_parafac, Stochastic_GCP, rank=3)

--- a/tensorly/metrics/__init__.py
+++ b/tensorly/metrics/__init__.py
@@ -6,3 +6,4 @@ The :mod:`tensorly.metrics` module includes utilities to measure performance
 from .regression import RMSE, MSE
 from .entropy import vonneumann_entropy, tt_vonneumann_entropy, cp_vonneumann_entropy
 from .factors import congruence_coefficient
+from .losses import loss_operator, gradient_operator

--- a/tensorly/metrics/losses.py
+++ b/tensorly/metrics/losses.py
@@ -1,0 +1,97 @@
+import tensorly as tl
+import math
+
+
+def loss_operator(tensor, estimated_tensor, loss, mask=None):
+    """
+    Operator to use loss functions from [1] in order to compute loss for
+    generalized parafac decomposition.
+
+    Parameters
+    ----------
+    tensor : ndarray
+    estimated_tensor : ndarray
+    loss : {'gaussian', 'gamma', 'rayleigh', 'poisson_count', 'poisson_log', 'bernoulli_odds', 'bernoulli_log'}
+    mask : ndarray
+        array of booleans with the same shape as ``tensor`` should be 0 where
+        the values are missing and 1 everywhere else.
+
+    Returns
+    -------
+    error : ndarray
+         Size based normalized loss for each entry
+    References
+    ----------
+    .. [1] Hong, D., Kolda, T. G., & Duersch, J. A. (2020).
+           Generalized canonical polyadic tensor decomposition. SIAM Review, 62(1), 133-163.
+    """
+    if mask is not None:
+        estimated_tensor = estimated_tensor * mask
+
+    epsilon = 1e-8
+    if loss == 'gaussian':
+        error = (tensor - estimated_tensor) ** 2
+    elif loss == 'bernoulli_odds':
+        error = tl.log(estimated_tensor + 1) - (tensor * tl.log(estimated_tensor + epsilon))
+    elif loss == 'bernoulli_logit':
+        error = tl.log(tl.exp(estimated_tensor) + 1) - (tensor * estimated_tensor)
+    elif loss == 'rayleigh':
+        error = 2 * tl.log(estimated_tensor + epsilon) + (math.pi / 4) * ((tensor / (estimated_tensor + epsilon)) ** 2)
+    elif loss == 'poisson_count':
+        error = estimated_tensor - tensor * tl.log(estimated_tensor + epsilon)
+    elif loss == 'poisson_log':
+        error = tl.exp(estimated_tensor) - (tensor * estimated_tensor)
+    elif loss == 'gamma':
+        error = tensor / (estimated_tensor + epsilon) + tl.log(estimated_tensor + epsilon)
+    else:
+        raise ValueError('Loss "{}" not recognized'.format(loss))
+    size = tl.tensor(tl.shape(tl.tensor_to_vec(tensor)), **tl.context(tensor))
+    return error / size
+
+
+def gradient_operator(tensor, estimated_tensor, loss, mask=None):
+    """
+    Operator to use loss functions from [1] in order to compute gradient for
+    generalized parafac decomposition.
+
+    Parameters
+    ----------
+    tensor : ndarray
+    estimated_tensor : ndarray
+    loss : {'gaussian', 'gamma', 'rayleigh', 'poisson_count', 'poisson_log', 'bernoulli_odds', 'bernoulli_log'}
+    mask : ndarray
+        array of booleans with the same shape as ``tensor`` should be 0 where
+        the values are missing and 1 everywhere else.
+
+    Returns
+    -------
+    gradient : ndarray
+        Size based normalized gradient for each entry
+    References
+    ----------
+    .. [1] Hong, D., Kolda, T. G., & Duersch, J. A. (2020).
+           Generalized canonical polyadic tensor decomposition. SIAM Review, 62(1), 133-163.
+    """
+    if mask is not None:
+        estimated_tensor = estimated_tensor * mask
+        tensor = tensor * mask
+
+    epsilon = 1e-8
+    if loss == 'gaussian':
+        gradient = 2 * (estimated_tensor - tensor)
+    elif loss == 'bernoulli_odds':
+        gradient = 1 / (estimated_tensor + 1) - (tensor / (estimated_tensor + epsilon))
+    elif loss == 'bernoulli_logit':
+        gradient = tl.exp(estimated_tensor) / (tl.exp(estimated_tensor) + 1) - tensor
+    elif loss == 'rayleigh':
+        gradient = 2 / (estimated_tensor + epsilon) - (math.pi / 2) * (tensor ** 2) / ((estimated_tensor + epsilon) ** 3)
+    elif loss == 'poisson_count':
+        gradient = 1 - tensor / (estimated_tensor + epsilon)
+    elif loss == 'poisson_log':
+        gradient = tl.exp(estimated_tensor) - tensor
+    elif loss == 'gamma':
+        gradient = -tensor / ((estimated_tensor + epsilon) ** 2) + (1 / (estimated_tensor + epsilon))
+    else:
+        raise ValueError('Loss "{}" not recognized'.format(loss))
+    size = tl.tensor(tl.shape(tl.tensor_to_vec(tensor)), **tl.context(tensor))
+    return gradient / size

--- a/tensorly/metrics/tests/test_losses.py
+++ b/tensorly/metrics/tests/test_losses.py
@@ -1,0 +1,72 @@
+import tensorly as tl
+from ...testing import assert_array_almost_equal
+from ..losses import loss_operator, gradient_operator
+
+
+def test_loss_operator():
+    """Test for loss operator"""
+
+    tensor_orig = tl.tensor([1, 0, 2, 2])
+    tensor_est = tl.tensor([1, 1, 1, 1])
+
+    # Gaussian loss
+    true_loss = [0, 0.25, 0.25, 0.25]
+    assert_array_almost_equal(loss_operator(tensor_orig, tensor_est, loss='gaussian'), true_loss)
+
+    # Gamma loss
+    true_loss = [0.25, 0, 0.5, 0.5]
+    assert_array_almost_equal(loss_operator(tensor_orig, tensor_est, loss='gamma'), true_loss)
+
+    # Rayleigh loss
+    true_loss = [0.19, 0, 0.78, 0.78]
+    assert_array_almost_equal(loss_operator(tensor_orig, tensor_est, loss='rayleigh'), true_loss, decimal=2)
+
+    # Poisson-log loss
+    true_loss = [0.42, 0.67, 0.17, 0.17]
+    assert_array_almost_equal(loss_operator(tensor_orig, tensor_est, loss='poisson_log'), true_loss, decimal=2)
+
+    # Poisson-count loss
+    true_loss = [0.25, 0.25, 0.25, 0.25]
+    assert_array_almost_equal(loss_operator(tensor_orig, tensor_est, loss='poisson_count'), true_loss)
+
+    # Bernoulli-odds loss
+    true_loss = [0.17, 0.17, 0.17, 0.17]
+    assert_array_almost_equal(loss_operator(tensor_orig, tensor_est, loss='bernoulli_odds'), true_loss, decimal=2)
+
+    # Bernoulli-logit loss
+    true_loss = [0.07, 0.32, -0.17, -0.17]
+    assert_array_almost_equal(loss_operator(tensor_orig, tensor_est, loss='bernoulli_logit'), true_loss, decimal=2)
+
+
+def test_gradient_operator():
+    """Test for gradient operator"""
+    tensor_orig = tl.tensor([1, 0, 2, 2])
+    tensor_est = tl.tensor([1, 1, 1, 1])
+
+    # Gaussian gradient
+    true_gradient = [0, 0.5, -0.5, -0.5]
+    assert_array_almost_equal(gradient_operator(tensor_orig, tensor_est, loss='gaussian'), true_gradient)
+
+    # Gamma gradient
+    true_gradient = [0, 0.25, -0.25, -0.25]
+    assert_array_almost_equal(gradient_operator(tensor_orig, tensor_est, loss='gamma'), true_gradient)
+
+    # Rayleigh gradient
+    true_gradient = [0.1, 0.5, -1.07, -1.07]
+    assert_array_almost_equal(gradient_operator(tensor_orig, tensor_est, loss='rayleigh'), true_gradient, decimal=2)
+
+    # Poisson-log gradient
+    true_gradient = [0.42, 0.67, 0.17, 0.17]
+    assert_array_almost_equal(gradient_operator(tensor_orig, tensor_est, loss='poisson_log'), true_gradient, decimal=2)
+
+    # Poisson-count gradient
+    true_gradient = [0, 0.25, -0.25, -0.25]
+    assert_array_almost_equal(gradient_operator(tensor_orig, tensor_est, loss='poisson_count'), true_gradient)
+
+    # Bernoulli-odds gradient
+    true_gradient = [-0.125,  0.125, -0.375, -0.375]
+    assert_array_almost_equal(gradient_operator(tensor_orig, tensor_est, loss='bernoulli_odds'), true_gradient, decimal=3)
+
+    # Bernoulli-logit gradient
+    true_gradient = [-0.06,  0.18, -0.31, -0.31]
+    assert_array_almost_equal(gradient_operator(tensor_orig, tensor_est, loss='bernoulli_logit'), true_gradient, decimal=2)


### PR DESCRIPTION
# Generalized CP Decomposition
This pull request adds a generalized and stochastic parafac decompositions [1,2] using Fista and ADAM optimizations respectively.

# Motivation
GCP allows different kind of losses such as:

1. Rayleigh
2. Bernoulli (odds and log)
3. Gamma
4. Poisson (count and log)
5. Gaussian

Depending on the data distribution, any loss can be selected by the user.

# Source Modification
* **./decomposition/_generalized_parafac.py:**

We added a new file which includes `initialize_generalized_parafac` ,  `stochastic_gradient`, `generalized_parafac`, `stochastic_generalized_parafac` functions and relevant classes.

* **./decomposition/tests/test_generalized_parafac:**
Test functions are added for each decomposition. 

* **./metrics/losses.py:**
This file includes `loss_operator` and `gradient_operator`. 

* **./metrics/test/test_losses.py:**
Tests for `loss_operator` and `gradient_operator`. 

* **./decomposition/_cp.py:**
We updated `sample_khatri_rao` function to have indices list as an input when it is necessary. 

In addition, `log` and  `exp` functions are added to all backends.

# References

[1]-  Hong, D., Kolda, T. G., & Duersch, J. A. (2020).
Generalized canonical polyadic tensor decomposition. SIAM Review, 62(1), 133-163. [Link](https://arxiv.org/abs/1808.07452)

[2]- Kolda, T. G., & Hong, D. (2020). Stochastic gradients for large-scale tensor decomposition. SIAM Journal on Mathematics of Data Science, 2(4), 1066-1095. [Link](https://arxiv.org/abs/1906.01687)
