### PR TITLE
Fix namespace calling of SVD_FUNS to backend.SVD_FUNS

### DIFF
--- a/tensorly/decomposition/_constrained_cp.py
+++ b/tensorly/decomposition/_constrained_cp.py
@@ -2,6 +2,7 @@ import numpy as np
 import warnings
 
 import tensorly as tl
+from tensorly import backend as T
 from ..random import random_cp
 from ..base import unfold
 from ..cp_tensor import (CPTensor, unfolding_dot_khatri_rao, cp_norm,
@@ -41,7 +42,7 @@ def initialize_constrained_parafac(tensor, rank, init='svd', svd='numpy_svd',
     random_state : {None, int, np.random.RandomState}
     init : {'svd', 'random', cptensor}, optional
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     non_negative : bool or dictionary
         This constraint is clipping negative values to '0'.
         If it is True, non-negative constraint is applied to all modes.
@@ -85,10 +86,10 @@ def initialize_constrained_parafac(tensor, rank, init='svd', svd='numpy_svd',
 
     elif init == 'svd':
         try:
-            svd_fun = tl.SVD_FUNS[svd]
+            svd_fun = T.SVD_FUNS[svd]
         except KeyError:
             message = 'Got svd={}. However, for the current backend ({}), the possible choices are {}'.format(
-                svd, tl.get_backend(), tl.SVD_FUNS)
+                svd, tl.get_backend(), T.SVD_FUNS)
             raise ValueError(message)
 
         factors = []
@@ -170,7 +171,7 @@ def constrained_parafac(tensor, rank, n_iter_max=100, n_iter_max_inner=10,
     init : {'svd', 'random', cptensor}, optional
         Type of factor matrix initialization. See `initialize_factors`.
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     tol_outer : float, optional
         (Default: 1e-8) Relative reconstruction error tolerance for outer loop. The
         algorithm is considered to have found a local minimum when the

--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -2,6 +2,7 @@ import numpy as np
 import warnings
 
 import tensorly as tl
+from tensorly import backend as T
 from ._base_decomposition import DecompositionMixin
 from ..random import random_cp
 from ..base import unfold
@@ -31,7 +32,7 @@ def initialize_cp(tensor, rank, init='svd', svd='numpy_svd', random_state=None, 
     rank : int
     init : {'svd', 'random', cptensor}, optional
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     non_negative : bool, default is False
         if True, non-negative factors are returned
 
@@ -48,10 +49,10 @@ def initialize_cp(tensor, rank, init='svd', svd='numpy_svd', random_state=None, 
 
     elif init == 'svd':
         try:
-            svd_fun = tl.SVD_FUNS[svd]
+            svd_fun = T.SVD_FUNS[svd]
         except KeyError:
             message = 'Got svd={}. However, for the current backend ({}), the possible choices are {}'.format(
-                      svd, tl.get_backend(), tl.SVD_FUNS)
+                      svd, tl.get_backend(), T.SVD_FUNS)
             raise ValueError(message)
 
         factors = []
@@ -213,7 +214,7 @@ def parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_svd',
         If a CPTensor is passed, this is directly used for initalization.
         See `initialize_factors`.
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     normalize_factors : if True, aggregate the weights of each factor in a 1D-tensor
         of shape (rank, ), which will contain the norms of the factors
     tol : float, optional
@@ -513,7 +514,7 @@ def randomised_parafac(tensor, rank, n_samples, n_iter_max=100, init='random', s
                  maximum number of iteration
     init : {'svd', 'random'}, optional
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     tol : float, optional
           tolerance: the algorithm stops when the variation in
           the reconstruction error is less than the tolerance
@@ -608,7 +609,7 @@ class CP(DecompositionMixin):
     init : {'svd', 'random'}, optional
         Type of factor matrix initialization. See `initialize_factors`.
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     normalize_factors : if True, aggregate the weights of each factor in a 1D-tensor
         of shape (rank, ), which will contain the norms of the factors
     tol : float, optional
@@ -742,7 +743,7 @@ class RandomizedCP(DecompositionMixin):
                 maximum number of iteration
     init : {'svd', 'random'}, optional
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     tol : float, optional
         tolerance: the algorithm stops when the variation in
         the reconstruction error is less than the tolerance

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -1,6 +1,7 @@
 import numpy as np
 import warnings
 import tensorly as tl
+from tensorly import backend as T
 from ._base_decomposition import DecompositionMixin
 from ..random import random_cp
 from ..base import unfold
@@ -102,7 +103,7 @@ def initialize_nn_cp(tensor, rank, init='svd', svd='numpy_svd', random_state=Non
     rank : int
     init : {'svd', 'random'}, optional
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     nntype : {'nndsvd', 'nndsvda'}
         Whether to fill small values with 0.0 (nndsvd), or the tensor mean (nndsvda, default).
 
@@ -119,10 +120,10 @@ def initialize_nn_cp(tensor, rank, init='svd', svd='numpy_svd', random_state=Non
 
     elif init == 'svd':
         try:
-            svd_fun = tl.SVD_FUNS[svd]
+            svd_fun = T.SVD_FUNS[svd]
         except KeyError:
             message = 'Got svd={}. However, for the current backend ({}), the possible choices are {}'.format(
-                svd, tl.get_backend(), tl.SVD_FUNS)
+                svd, tl.get_backend(), T.SVD_FUNS)
             raise ValueError(message)
 
         factors = []
@@ -182,7 +183,7 @@ def non_negative_parafac(tensor, rank, n_iter_max=100, init='svd', svd='numpy_sv
                  maximum number of iteration
     init : {'svd', 'random'}, optional
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     tol : float, optional
           tolerance: the algorithm stops when the variation in
           the reconstruction error is less than the tolerance
@@ -316,7 +317,7 @@ def non_negative_parafac_hals(tensor, rank, n_iter_max=100, init="svd", svd='num
                  maximum number of iteration
     init : {'svd', 'random'}, optional
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     tol : float, optional
           tolerance: the algorithm stops when the variation in
           the reconstruction error is less than the tolerance
@@ -476,7 +477,7 @@ class CP_NN(DecompositionMixin):
         init : {'svd', 'random'}, optional
             Type of factor matrix initialization. See `initialize_factors`.
         svd : str, default is 'numpy_svd'
-            function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+            function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
         normalize_factors : if True, aggregate the weights of each factor in a 1D-tensor
             of shape (rank, ), which will contain the norms of the factors
         tol : float, optional
@@ -601,7 +602,7 @@ class CP_NN_HALS(DecompositionMixin):
     init : {'svd', 'random'}, optional
         Type of factor matrix initialization. See `initialize_factors`.
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     normalize_factors : if True, aggregate the weights of each factor in a 1D-tensor
         of shape (rank, ), which will contain the norms of the factors
     tol : float, optional

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -1,6 +1,7 @@
 from warnings import warn
 
 import tensorly as tl
+from tensorly import backend as T
 from ._base_decomposition import DecompositionMixin
 from tensorly.random import random_parafac2
 from tensorly import backend as T
@@ -38,10 +39,10 @@ def initialize_decomposition(tensor_slices, rank, init='random', svd='numpy_svd'
                                **context)
     elif init == 'svd':
         try:
-            svd_fun = tl.SVD_FUNS[svd]
+            svd_fun = T.SVD_FUNS[svd]
         except KeyError:
             message = 'Got svd={}. However, for the current backend ({}), the possible choices are {}'.format(
-                    svd, tl.get_backend(), tl.SVD_FUNS)
+                    svd, tl.get_backend(), T.SVD_FUNS)
             raise ValueError(message)
         padded_tensor = _pad_by_zeros(tensor_slices)
         A = T.ones((padded_tensor.shape[0], rank), **context)
@@ -117,11 +118,11 @@ def _project_tensor_slices(tensor_slices, projections, out=None):
 
 
 def _get_svd(svd):
-    if svd in tl.SVD_FUNS:
-        return tl.SVD_FUNS[svd]
+    if svd in T.SVD_FUNS:
+        return T.SVD_FUNS[svd]
     else:
         message = 'Got svd={}. However, for the current backend ({}), the possible choices are {}'.format(
-                svd, tl.get_backend(), tl.SVD_FUNS)
+                svd, tl.get_backend(), T.SVD_FUNS)
         raise ValueError(message)
 
 
@@ -188,7 +189,7 @@ def parafac2(tensor_slices, rank, n_iter_max=2000, init='random', svd='numpy_svd
     init : {'svd', 'random', CPTensor, Parafac2Tensor}
         Type of factor matrix initialization. See `initialize_factors`.
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     normalize_factors : bool (optional)
         If True, aggregate the weights of each factor in a 1D-tensor
         of shape (rank, ), which will contain the norms of the factors. Note that
@@ -382,7 +383,7 @@ class Parafac2(DecompositionMixin):
     init : {'svd', 'random', CPTensor, Parafac2Tensor}
         Type of factor matrix initialization. See `initialize_factors`.
     svd : str, default is 'numpy_svd'
-        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+        function to use to compute the SVD, acceptable values in tensorly.backend.SVD_FUNS
     normalize_factors : bool (optional)
         If True, aggregate the weights of each factor in a 1D-tensor
         of shape (rank, ), which will contain the norms of the factors. Note that


### PR DESCRIPTION
I run `python examples/decomposition/plot_image_compression.py`:
```
Traceback (most recent call last):
  File "decomposition/plot_image_compression.py", line 43, in <module>
    core, tucker_factors = tucker(image, rank=tucker_rank, init='random', tol=10e-5, random_state=random_state)
  File "~/.local/lib/python3.6/site-packages/tensorly/decomposition/_tucker.py", line 271, in tucker
    verbose=verbose)
  File "~/.local/lib/python3.6/site-packages/tensorly/decomposition/_tucker.py", line 137, in partial_tucker
    svd_fun = tl.SVD_FUNS[svd]
AttributeError: module 'tensorly' has no attribute 'SVD_FUNS'
```
SVD_FUNS were moved the backend, and they should change the way to be called in api functions.
(tensorly.SVD_FUNS to tensorly.backend.SVD_FUNS)