### PR TITLE
Fix bug with `tl.clip` for the PyTorch and TensorFlow backends

### DIFF
--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -61,14 +61,10 @@ class PyTorchBackend(Backend, backend_name='pytorch'):
 
     @staticmethod
     def clip(tensor, a_min=None, a_max=None, inplace=False):
-        if a_max is None:
-            a_max = torch.max(tensor)
-        if a_min is None:
-            a_min = torch.min(tensor)
         if inplace:
-            return torch.clamp(tensor, a_min, a_max, out=tensor)
+            return torch.clip(tensor, a_min, a_max, out=tensor)
         else:
-            return torch.clamp(tensor, a_min, a_max)
+            return torch.clip(tensor, a_min, a_max)
 
     @staticmethod
     def all(tensor):

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -60,12 +60,12 @@ class TensorflowBackend(Backend, backend_name='tensorflow'):
         if a_min is not None:
             a_min = self.tensor(a_min, **self.context(tensor_))
         else:
-            a_min = tf.reduce_min(input_tensor=tensor_)
+            a_min = self.tensor(-float('inf'))
 
         if a_max is not None:
             a_max = self.tensor(a_max, **self.context(tensor_))
         else:
-            a_max = tf.reduce_max(input_tensor=tensor_)
+            a_max = self.tensor(float('inf'))
 
         return tf.clip_by_value(tensor_, clip_value_min=a_min, clip_value_max=a_max)
 

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -269,10 +269,10 @@ def test_clip():
 
     # More extensive test with a larger random tensor
     rng = tl.check_random_state(0)
-    tensor = tl.tensor(rng.random_sample((10, 10, 10)))
+    tensor = tl.tensor(rng.random_sample((10, 10, 10)).astype('float32'))
 
-    val1 = rng.random_sample()
-    val2 = rng.random_sample()
+    val1 = np.float32(rng.random_sample())
+    val2 = np.float32(rng.random_sample())
     limits = [
         (min(val1, val2), max(val1, val2)),
         (-1, 2),

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -260,12 +260,38 @@ def test_norm():
 
 
 def test_clip():
-    """Test that clip can work with single arguments"""
+    # Test that clip can work with single arguments
     X = T.tensor([0.0, -1.0, 1.0])
     X_low = T.tensor([0.0, 0.0, 1.0])
     X_high = T.tensor([0.0, -1.0, 0.0])
     assert_array_equal(tl.clip(X, a_min=0.0), X_low)
     assert_array_equal(tl.clip(X, a_max=0.0), X_high)
+
+    # More extensive test with a larger random tensor
+    rng = tl.check_random_state(0)
+    tensor = tl.tensor(rng.random_sample((10, 10, 10)))
+
+    val1 = rng.random_sample()
+    val2 = rng.random_sample()
+    limits = [
+        (min(val1, val2), max(val1, val2)),
+        (-1, 2),
+        (tl.max(tensor) + 1, None),
+        (None, tl.min(tensor) - 1),
+        (tl.max(tensor), None),
+        (tl.min(tensor), None),
+        (None, tl.max(tensor)),
+        (None, tl.min(tensor))
+    ]
+
+    for min_val, max_val in limits:
+        message = f"Tensor clipped incorrectly with min_val={min_val} and max_val={max_val}. Tensor bounds are ({tl.to_numpy(tl.min(tensor))}, {tl.to_numpy(tl.max(tensor))}"
+        if min_val is not None:
+            assert tl.all(tl.clip(tensor, min_val, None) >= min_val), message
+            assert tl.all(tl.clip(tensor, min_val, max_val) >= min_val), message
+        if max_val is not None:
+            assert tl.all(tl.clip(tensor, None, max_val) <= max_val), message
+            assert tl.all(tl.clip(tensor, min_val, max_val) <= max_val), message
 
 
 def test_where():

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -294,6 +294,13 @@ def test_clip():
             assert tl.all(tl.clip(tensor, min_val, max_val) <= max_val), message
 
 
+def test_clips_all_negative_tensor_correctly():
+    # Regression test for bug found with the pytorch backend
+    negative_valued_tensor = tl.zeros((10, 10)) - 0.1
+    clipped_tensor = tl.clip(negative_valued_tensor, 0)
+    assert tl.all(clipped_tensor == 0)
+
+
 def test_where():
     # 1D
     shape = (2*3*4,); N = np.prod(shape)


### PR DESCRIPTION
For both PyTorch and TensorFlow, the values for a_max and a_min are computed by TensorLy whenever their values are None. However, the way these values are computed leads to erroneous behaviour. With PyTorch, this occurs when `a_min > max(tensor)` and `a_max=None`. I noticed this for PyTorch when I tried to clip a negative tensor to be non-negative. Here is an example:

```python
tl.set_backend("pytorch")
x = tl.tensor([-1, -1, -1])
tl.clip(x, 0, None)
```
```
tensor([-1., -1., -1.])
```

For TensorFlow, the error occurs when `a_min=None` and `a_max<min(tensor)`. Here is an example:

```python
tl.set_backend("tensorflow")
x = tl.tensor([1, 1, 1])
tl.clip(x, None, 0)
```
```
<tf.Tensor: shape=(3,), dtype=float32, numpy=array([1., 1., 1.], dtype=float32)>
```