### PR TITLE
Add `keepdims` to `tl.sum` with the PyTorch backend

### DIFF
--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -115,11 +115,10 @@ class PyTorchBackend(Backend, backend_name='pytorch'):
             return torch.mean(tensor, dim=axis)
 
     @staticmethod
-    def sum(tensor, axis=None):
+    def sum(tensor, axis=None, keepdims=False):
         if axis is None:
-            return torch.sum(tensor)
-        else:
-            return torch.sum(tensor, dim=axis)
+            axis = tuple(range(tensor.ndim))
+        return torch.sum(tensor, dim=axis, keepdim=keepdims)
 
     @staticmethod
     def max(tensor, axis=None):

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -405,3 +405,69 @@ def test_index_update():
     tensor = tl.index_update(tensor, tl.index[2, :], 2)
     assert_array_equal(np_tensor, tensor)
 
+
+def test_sum():
+    rng = tl.check_random_state(0)
+    tensor = tl.tensor(rng.random_sample((5, 6, 7)))
+    all_kwargs = [
+        {},
+        {'axis': 1},
+        {'axis': 1, 'keepdims': True},
+        {'axis': 1, 'keepdims': False},
+        {'keepdims': True},
+        {'keepdims': False},
+        {'axis': None, 'keepdims': True},
+        {'axis': (0, 2), 'keepdims': True},
+        {'axis': (0, 2), 'keepdims': False},
+        {'axis': (0, 2)}
+    ]
+    for kwargs in all_kwargs:
+        np.testing.assert_allclose(
+            tl.to_numpy(tl.sum(tensor, **kwargs)),
+            np.sum(tl.to_numpy(tensor), **kwargs),
+            rtol=1e-5,  # Single precision
+            err_msg=f"Sum not same as numpy with kwargs: {kwargs}"
+        )
+
+
+def test_sum_keepdims():
+    rng = tl.check_random_state(0)
+    random_matrix = tl.tensor(rng.random_sample((10, 20)))
+
+    summed_matrix1 = tl.sum(random_matrix, axis=0)
+    assert tl.shape(summed_matrix1) == (20,)
+    summed_matrix2 = tl.sum(random_matrix, axis=0, keepdims=False)
+    assert tl.shape(summed_matrix2) == (20,)
+    summed_matrix3 = tl.sum(random_matrix, axis=0, keepdims=True)
+    assert tl.shape(summed_matrix3) == (1, 20)
+
+    summed_matrix4 = tl.sum(random_matrix, axis=1)
+    assert tl.shape(summed_matrix4) == (10,)
+    summed_matrix5 = tl.sum(random_matrix, axis=1, keepdims=False)
+    assert tl.shape(summed_matrix5) == (10,)
+    summed_matrix6 = tl.sum(random_matrix, axis=1, keepdims=True)
+    assert tl.shape(summed_matrix6) == (10, 1)
+
+    # Third order tensor
+    random_tensor = tl.tensor(rng.random_sample((10, 20, 30)))
+
+    summed_tensor1 = tl.sum(random_tensor, axis=0)
+    assert tl.shape(summed_tensor1) == (20, 30)
+    summed_tensor2 = tl.sum(random_tensor, axis=0, keepdims=False)
+    assert tl.shape(summed_tensor2) == (20, 30)
+    summed_tensor3 = tl.sum(random_tensor, axis=0, keepdims=True)
+    assert tl.shape(summed_tensor3) == (1, 20, 30)
+
+    summed_tensor4 = tl.sum(random_tensor, axis=1)
+    assert tl.shape(summed_tensor4) == (10, 30)
+    summed_tensor5 = tl.sum(random_tensor, axis=1, keepdims=False)
+    assert tl.shape(summed_tensor5) == (10, 30)
+    summed_tensor6 = tl.sum(random_tensor, axis=1, keepdims=True)
+    assert tl.shape(summed_tensor6) == (10, 1, 30)
+
+    summed_tensor7 = tl.sum(random_tensor, axis=2)
+    assert tl.shape(summed_tensor7) == (10, 20)
+    summed_tensor8 = tl.sum(random_tensor, axis=2, keepdims=False)
+    assert tl.shape(summed_tensor8) == (10, 20)
+    summed_tensor9 = tl.sum(random_tensor, axis=2, keepdims=True)
+    assert tl.shape(summed_tensor9) == (10, 20, 1)


### PR DESCRIPTION
Currently, the PyTorch doesn't support a `keepdims` argument. This pull request adds this functionality.