### PR TITLE
Make `tl.shape` return tuple for PyTorch backend

### DIFF
--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -46,7 +46,7 @@ class PyTorchBackend(Backend, backend_name='pytorch'):
 
     @staticmethod
     def shape(tensor):
-        return tensor.shape
+        return tuple(tensor.shape)
 
     @staticmethod
     def ndim(tensor):

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -216,6 +216,8 @@ def test_shape():
     A2 = T.reshape(A, shape2)
     assert_equal(T.shape(A2), shape2)
 
+    assert type(T.shape(A2)) == tuple
+
 
 def test_ndim():
     A = T.arange(3*4*5)


### PR DESCRIPTION
Currently, `tl.shape` returns a tuple for most backends. However, with the PyTorch backend, it returns a `torch.Size` object, which can make it more difficult to make backend agnostic code. This pull request makes it return a tuple instead and adds a test that fails if the object returned from `tl.shape` is not a `tuple`.

Alternatively, if we don't want to cast the `torch.Size` to a tuple automatically, then we could add an optional `as_tuple` argument to all backends. However, I made it cast to a tuple since that is what's done in the TensorFlow backend.