### PR TITLE
Add CP indexing function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 
 test-all:
 	TENSORLY_BACKEND='numpy' pytest -v tensorly
-	# TENSORLY_BACKEND='cupy' pytest -v tensorly
+	TENSORLY_BACKEND='cupy' pytest -v tensorly
 	TENSORLY_BACKEND='pytorch' pytest -v tensorly
 	TENSORLY_BACKEND='mxnet' pytest -v tensorly
 	TENSORLY_BACKEND='jax' pytest -v tensorly

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 
 test-all:
 	TENSORLY_BACKEND='numpy' pytest -v tensorly
-	TENSORLY_BACKEND='cupy' pytest -v tensorly
+	# TENSORLY_BACKEND='cupy' pytest -v tensorly
 	TENSORLY_BACKEND='pytorch' pytest -v tensorly
 	TENSORLY_BACKEND='mxnet' pytest -v tensorly
 	TENSORLY_BACKEND='jax' pytest -v tensorly

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -716,7 +716,7 @@ def cp_index(cp_tensor, index):
     """
     _ = _validate_cp_tensor(cp_tensor)
     weights, factors = cp_tensor
-    index = T.array(index)
+    index = T.tensor(index)
 
     factors = [f[:, index] for f in factors]
     

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -716,7 +716,7 @@ def cp_index(cp_tensor, index):
     """
     _ = _validate_cp_tensor(cp_tensor)
     weights, factors = cp_tensor
-    index = T.tensor(index, dtype=T.int32)
+    index = T.tensor(index, dtype=T.int64)
 
     factors = [f[:, index] for f in factors]
     

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -716,7 +716,7 @@ def cp_index(cp_tensor, index):
     """
     _ = _validate_cp_tensor(cp_tensor)
     weights, factors = cp_tensor
-    index = T.tensor(index)
+    index = T.tensor(index, dtype=int)
 
     factors = [f[:, index] for f in factors]
     

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -716,6 +716,7 @@ def cp_index(cp_tensor, index):
     """
     _ = _validate_cp_tensor(cp_tensor)
     weights, factors = cp_tensor
+    index = T.array(index)
 
     factors = [f[:, index] for f in factors]
     

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -696,6 +696,35 @@ def cp_norm(cp_tensor):
     return T.sqrt(T.sum(norm))
 
 
+def cp_index(cp_tensor, index):
+    """Re-index the components of a CP tensor.
+    This can be used to duplicate, remove, or permute the components.
+
+    Parameters
+    ----------
+    cp_tensor : tl.CPTensor or (core, factors)
+    index : index of the components
+
+    Returns
+    -------
+    cp_tensor : tl.CPTensor
+
+    Notes
+    -----
+    Ensure that index includes each component once if you only wish to
+    permute the components (and not change how the reconstructed tensor would look).
+    """
+    _ = _validate_cp_tensor(cp_tensor)
+    weights, factors = cp_tensor
+
+    factors = [f[:, index] for f in factors]
+    
+    if weights is not None:
+        weights = weights[index]
+
+    return CPTensor((weights, factors))
+
+
 # Deprecated classes and functions
 KruskalTensor = DefineDeprecated(deprecated_name='KruskalTensor', use_instead=CPTensor)
 kruskal_norm = DefineDeprecated(deprecated_name='kruskal_norm', use_instead=cp_norm)

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -716,7 +716,7 @@ def cp_index(cp_tensor, index):
     """
     _ = _validate_cp_tensor(cp_tensor)
     weights, factors = cp_tensor
-    index = T.tensor(index, dtype=int)
+    index = T.tensor(index, dtype=T.int32)
 
     factors = [f[:, index] for f in factors]
     

--- a/tensorly/tests/test_cp_tensor.py
+++ b/tensorly/tests/test_cp_tensor.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 
 import tensorly as tl
@@ -8,7 +9,7 @@ from ..cp_tensor import (cp_to_tensor, cp_to_unfolded,
                               cp_mode_dot, unfolding_dot_khatri_rao,
                               cp_norm, cp_flip_sign,
                               _cp_n_param, validate_cp_rank,
-                              cp_lstsq_grad
+                              cp_lstsq_grad, cp_index
                         )
 from ..base import unfold, tensor_to_vec
 from tensorly.random import random_cp
@@ -294,3 +295,17 @@ def test_cp_copy():
     weights_normalized, factors_normalized = cp_normalize(cp_tensor.cp_copy())
     # Check that modifying copy tensor doesn't change the original tensor
     assert_array_almost_equal(cp_to_tensor((weights, factors)), cp_to_tensor(cp_tensor))
+
+@pytest.mark.parametrize("norml", [True, False])
+def test_cp_index(norml):
+    shape = (3, 4, 5)
+    rank = 4
+    cp_tensor = random_cp(shape, rank, normalise_factors=norml)
+    reconstruction = cp_to_tensor(cp_tensor)
+    cp_tensor_index = cp_index(cp_tensor, [1, 0, 3, 2])
+    # Check that permuting the components doesn't change the result
+    assert_array_almost_equal(cp_to_tensor(cp_tensor_index), reconstruction)
+
+    # Check that removing a component does change the result
+    cp_tensor_index = cp_index(cp_tensor, [1, 3, 2])
+    assert cp_tensor_index.rank == 3


### PR DESCRIPTION
To help with #352, this adds a very simple function to allow indexing the components within a CP tensor. This makes it a little simpler to permute or remove a component.