### PR TITLE
copy tucker tensor

### DIFF
--- a/tensorly/tests/test_tucker_tensor.py
+++ b/tensorly/tests/test_tucker_tensor.py
@@ -197,3 +197,11 @@ def test_tucker_normalize():
         assert_array_almost_equal(tl.norm(factors[i], axis=0), tl.ones(rank[i]))
     assert_array_almost_equal(tucker_to_tensor((core, factors)), tucker_to_tensor(tucker_ten))
 
+def test_tucker_copy():
+    shape = (3, 4, 5)
+    rank = 4
+    tucker_tensor = random_tucker(shape, rank)
+    core, factors = tucker_tensor
+    core_normalized, factors_normalized = tucker_normalize(tucker_tensor.tucker_copy())
+    # Check that modifying copy tensor doesn't change the original tensor
+    assert_array_almost_equal(tucker_to_tensor((core, factors)), tucker_to_tensor(tucker_tensor))

--- a/tensorly/tucker_tensor.py
+++ b/tensorly/tucker_tensor.py
@@ -244,6 +244,9 @@ class TuckerTensor(FactorizedTensor):
     
     def to_unfolded(self, mode):
         return tucker_to_unfolded(self, mode)
+
+    def tucker_copy(self):
+        return TuckerTensor((tl.copy(self.core), [tl.copy(self.factors[i]) for i in range(len(self.factors))]))
     
     def to_vec(self):
         return tucker_to_vec(self)


### PR DESCRIPTION
This PR adds `tucker_copy` function to TuckerTensor as `cp_copy` function merged in #324. 