### PR TITLE
Permute cp factors

### DIFF
--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -7,7 +7,7 @@ from .base import fold, tensor_to_vec
 from ._factorized_tensor import FactorizedTensor
 from .tenalg import khatri_rao, multi_mode_dot
 from .utils import DefineDeprecated
-
+from .metrics.factors import congruence_coefficient
 import numpy as np
 
 # Author: Jean Kossaifi
@@ -695,6 +695,48 @@ def cp_norm(cp_tensor):
     # as e.g. MXNet would return a 1D tensor, not a 0D tensor
     return T.sqrt(T.sum(norm))
 
+
+def cp_permute_factors(ref_cp_tensor, tensors_to_permute):
+    """
+    Compares factors of a reference cp tensor with factors of other another tensor (or list of tensor) in order to match component order.
+    Permutation occurs on the columns of factors, minimizing the cosine distance to reference cp tensor with scipy
+    Linear Sum Assignment method. The permuted tensor (or list of tensors) and list of permutation for each permuted tensors are returned.
+    Parameters
+    ----------
+    ref_cp_tensor : cp tensor
+        The tensor that serves as a reference for permutation.
+    tensors_to_permute : cp tensor or list of cp tensors
+        The tensors to permute so that the order of components match the reference tensor. Number of components must match.
+    Returns
+    -------
+    permuted_tensors : permuted cp tensor or list of cp tensors
+    permutation : list
+        list of permuted indices. Lenght is equal to rank of cp_tensors.
+    """
+    if not isinstance(tensors_to_permute, list):
+        permuted_tensors = [tensors_to_permute.cp_copy()]
+        tensors_to_permute = [tensors_to_permute]
+    else:
+        permuted_tensors = []
+        for i in range(len(tensors_to_permute)):
+            permuted_tensors.append(tensors_to_permute[i].cp_copy())
+            tensors_to_permute[i] = cp_normalize(tensors_to_permute[i])
+    ref_cp_tensor = cp_normalize(ref_cp_tensor)
+
+    rank = T.shape(ref_cp_tensor.factors[0])[1]
+    n_tensors = len(tensors_to_permute)
+    n_factors = len(ref_cp_tensor.factors)
+    permutation = []
+    ref_factors = T.concatenate(ref_cp_tensor.factors)
+    for i in range(n_tensors):
+        _, col = congruence_coefficient(ref_factors, T.concatenate(tensors_to_permute[i].factors))
+        for f in range(n_factors):
+            permuted_tensors[i].factors[f] = permuted_tensors[i].factors[f][: ,col]
+        permuted_tensors[i].weights = permuted_tensors[i].weights[col]
+        permutation.append(col)
+    if len(permuted_tensors) == 1:
+        permuted_tensors = permuted_tensors[0]
+    return permuted_tensors, permutation
 
 # Deprecated classes and functions
 KruskalTensor = DefineDeprecated(deprecated_name='KruskalTensor', use_instead=CPTensor)

--- a/tensorly/metrics/entropy.py
+++ b/tensorly/metrics/entropy.py
@@ -1,7 +1,6 @@
 import math
 import tensorly as tl
 from .. import backend as T
-from ..cp_tensor import cp_normalize
 from ..tt_tensor import tt_to_tensor
 from ..utils import prod
 
@@ -68,7 +67,7 @@ def cp_vonneumann_entropy(tensor):
     -------
     cp_von_neumann_entropy : order-0 tensor
     """
-    eig_vals = cp_normalize(tensor).weights
+    eig_vals = tl.cp_normalize(tensor).weights
     eps = tl.eps(eig_vals.dtype)
     eig_vals = eig_vals[eig_vals > eps]
 


### PR DESCRIPTION
# Permute cp factors
This pull request adds `cp_permute_factors` function to `cp_tensor.py` and relevant test to `test_cp_tensor`.

This function has 2 inputs which are ref_cp_tensor (one cp tensor) and tensors_to_permute (one cp tensor or list of cp tensor). It returns permuted tensor or tensors and permutation list for each permuted tensor.

# tl.gather
Since permuting factors require an operator to swap columns, I added `tl.gather` function to Tensorly to make this function work for tensorflow backend. While using [:, indices] is enough for all the other backends, index operation is not possible with tensorflow unfortunately. I have used `take` function for numpy, jax, mxnet and `indice_select` for pytorch backend to have same behaviour for all backends.

# Note
I don't see any error with Jax backend in my computer but it fails in github test.