### PR TITLE
Drop nosetests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Running the tests
 
 Testing and documentation are an essential part of this package and all functions come with uni-tests and documentation.
 
-The tests are ran using the `pytest` package (though you can also use `nose`). 
+The tests are ran using the `pytest` package. 
 First install `pytest`::
 
     pip install pytest

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,8 +24,6 @@ requirements:
 test:
   requires:
     - pytest
-    # NumPy requires nosetests e.g. for assert_raises.....
-    - nose
 
   commands:
     - TENSORLY_BACKEND='numpy' pytest -v $SP_DIR/tensorly

--- a/doc/sphinx_ext/numpydoc/numpydoc.py
+++ b/doc/sphinx_ext/numpydoc/numpydoc.py
@@ -120,9 +120,6 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
 
 def setup(app, get_doc_object_=get_doc_object):
-    if not hasattr(app, 'add_config_value'):
-        return  # probably called by nose, better bail out
-
     global get_doc_object
     get_doc_object = get_doc_object_
 

--- a/doc/sphinx_ext/sphinx_gallery/gen_gallery.py
+++ b/doc/sphinx_ext/sphinx_gallery/gen_gallery.py
@@ -350,8 +350,3 @@ def setup(app):
     app.connect('build-finished', embed_code_links)
     metadata = {'parallel_read_safe': True}
     return metadata
-
-
-def setup_module():
-    # HACK: Stop nosetests running setup() above
-    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
 scipy
 pytest
-nose
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ config = {
     'version': VERSION,
     'url': 'https://github.com/tensorly/tensorly',
     'download_url': 'https://github.com/tensorly/tensorly/tarball/' + VERSION,
-    'install_requires': ['numpy', 'scipy', 'nose'],
+    'install_requires': ['numpy', 'scipy'],
     'license': 'Modified BSD',
     'scripts': [],
     'classifiers': [


### PR DESCRIPTION
It was added as numpy.testing required nose [1], which is no longer the
case for numpy >= 1.15 [2] from 2018 [3].

Testing:
* nosetests fails as some testing code uses pytest-specific features
  (ex: @pytest.mark.parametrize in several files)
* `cd doc && make html` still works fine

Motivation: nose is [broken for Python 3.10](https://github.com/nose-devs/nose/issues/1099). Although there is no real harm, I don't want to install a package known to be not useful.

[1] https://github.com/tensorly/tensorly/issues/48
[2] https://numpy.org/devdocs/release/1.15.0-notes.html
[3] https://pypi.org/project/numpy/#history