### PR TITLE
default axis for tensorflow concatenate

### DIFF
--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -195,6 +195,10 @@ class TensorflowBackend(Backend, backend_name='tensorflow'):
     def log2(self,x):
         return tfm.log(x) / tfm.log(2.)
 
+    @staticmethod
+    def concatenate(tensors, axis=0):
+        return tf.concat(tensors, axis=axis)
+
 _FUN_NAMES = [
     # source_fun, target_fun
     (np.int32, 'int32'),
@@ -221,7 +225,6 @@ _FUN_NAMES = [
     (tf.argmax, 'argmax'),
     (tf.stack, 'stack'),
     (tf.identity, 'copy'),
-    (tf.concat, 'concatenate'),
     (tf.stack, 'stack'),
     (tf.reduce_min, 'min'),
     (tf.reduce_max, 'max'),


### PR DESCRIPTION
Tensorly concatenate function has a default axis in [description](http://tensorly.org/stable/modules/generated/tensorly.concatenate.html) but tensorflow [concat](https://www.tensorflow.org/api_docs/python/tf/concat) function doesn't have a default input. This PR fixes this issue.