### PR TITLE
2 new dataset

### DIFF
--- a/examples/applications/plot_IL2.py
+++ b/examples/applications/plot_IL2.py
@@ -12,7 +12,7 @@ To do this, we will work with a tensor of experimentally measured cell signaling
 
 import numpy as np
 import matplotlib.pyplot as plt
-from tensorly.datasets import IL2data
+from tensorly.datasets import load_IL2data
 from tensorly.decomposition import non_negative_parafac
 from tensorly.cp_tensor import cp_normalize
 
@@ -48,7 +48,7 @@ from tensorly.cp_tensor import cp_normalize
 # measured quantity represents the amount of phosphorlyated STAT5 (pSTAT5) in a 
 # given cell population following stimulation with the specified IL-2 mutant.
 
-response_data = IL2data()
+response_data = load_IL2data()
 IL2mutants, cells = response_data.ticks[0], response_data.ticks[3]
 print(response_data.tensor.shape, response_data.dims)
 

--- a/tensorly/datasets/__init__.py
+++ b/tensorly/datasets/__init__.py
@@ -4,4 +4,4 @@ create synthetic data, e.g. for testing purposes.
 """
 
 from .synthetic import gen_image
-from .data_imports import load_IL2data, load_covid19_serology, load_indian_pines, load_kinetic
+from .data_imports import load_IL2data, load_covid19_serology, fetch_indian_pines, fetch_kinetic

--- a/tensorly/datasets/__init__.py
+++ b/tensorly/datasets/__init__.py
@@ -4,4 +4,4 @@ create synthetic data, e.g. for testing purposes.
 """
 
 from .synthetic import gen_image
-from .data_imports import IL2data
+from .data_imports import load_IL2data, load_covid19_serology, load_indian_pines, load_kinetic

--- a/tensorly/datasets/data_imports.py
+++ b/tensorly/datasets/data_imports.py
@@ -4,7 +4,7 @@ Load example datasets.
 
 from os.path import dirname
 import numpy as np
-import requests
+from urllib.request import urlopen
 import scipy.io
 from zipfile import ZipFile
 from io import BytesIO
@@ -225,8 +225,8 @@ def load_indian_pines():
     """
 
     url = 'http://www.ehu.eus/ccwintco/uploads/6/67/Indian_pines_corrected.mat'
-    r = requests.get(url, allow_redirects=True)
-    image = scipy.io.loadmat(BytesIO(r.content))['indian_pines_corrected']
+    r = urlopen(url)
+    image = scipy.io.loadmat(BytesIO(r.read()))['indian_pines_corrected']
     reference = "Baumgardner, M. F., Biehl, L. L., Landgrebe, D. A. (2015). 220 Band AVIRIS Hyperspectral " \
                 "Image Data Set: June 12, 1992 Indian Pine Test Site 3. Purdue University Research Repository. " \
                 "doi:10.4231/R7RX991C"
@@ -236,8 +236,8 @@ def load_indian_pines():
            "of West Lafayette and the surrounding area. This scene consists of 145 times 145 pixels and 220 spectral " \
            "reflectance bands in the wavelength range 0.4–2.5 10^(-6) meters."
     url_gt = 'http://www.ehu.eus/ccwintco/uploads/c/c4/Indian_pines_gt.mat'
-    r = requests.get(url_gt, allow_redirects=True)
-    labels = scipy.io.loadmat(BytesIO(r.content))['indian_pines_gt']
+    r = urlopen(url_gt)
+    labels = scipy.io.loadmat(BytesIO(r.read()))['indian_pines_gt']
     wavelengths = [400.02, 409.82, 419.62, 429.43, 439.25, 449.07, 458.9, 468.73, 478.57, 488.41, 498.26, 508.12,
                    517.98, 527.85, 537.72, 547.6, 557.49, 567.38, 577.28, 587.18, 597.09, 607.01, 616.93, 626.85,
                    636.78, 646.72, 656.67, 666.61, 676.57, 686.53, 696.5, 686.91, 696.55, 706.19, 715.83, 725.47,
@@ -272,8 +272,8 @@ def load_kinetic():
     in the hard drive.The data is well suited for Parafac and multi-way partial least squares regression (N-PLS).
     """
     url = 'http://models.life.ku.dk/sites/default/files/Kinetic_Fluor.zip'
-    r = requests.get(url, allow_redirects=True)
-    zip = ZipFile(BytesIO(r.content))
+    r = urlopen(url)
+    zip = ZipFile(BytesIO(r.read()))
     tensor = scipy.io.loadmat(zip.open('Xlarge.mat'))['Xlarge']
     tensor[np.isnan(tensor)] = 0
     reference = "Nikolajsen, R. P., Booksh, K. S., Hansen, Å. M., & Bro, R. (2003). \

--- a/tensorly/datasets/data_imports.py
+++ b/tensorly/datasets/data_imports.py
@@ -231,17 +231,35 @@ def load_indian_pines():
                 "Image Data Set: June 12, 1992 Indian Pine Test Site 3. Purdue University Research Repository. " \
                 "doi:10.4231/R7RX991C"
     licence = "Licensed under Attribution 3.0 Unported (https://creativecommons.org/licenses/by/3.0/legalcode)"
-    desc =  "Airborne Visible / Infrared Imaging Spectrometer (AVIRIS)  hyperspectral sensor data (aviris.jpl.nasa.gov/) " \
-            "were acquired on June 12, 1992 over the Purdue University Agronomy farm northwest " \
-            "of West Lafayette and the surrounding area. This scene consists of 145 times 145 pixels and 220 spectral " \
-            "reflectance bands in the wavelength range 0.4–2.5 10^(-6) meters."
+    desc = "Airborne Visible / Infrared Imaging Spectrometer (AVIRIS)  hyperspectral sensor data (aviris.jpl.nasa.gov/) " \
+           "were acquired on June 12, 1992 over the Purdue University Agronomy farm northwest " \
+           "of West Lafayette and the surrounding area. This scene consists of 145 times 145 pixels and 220 spectral " \
+           "reflectance bands in the wavelength range 0.4–2.5 10^(-6) meters."
     url_gt = 'http://www.ehu.eus/ccwintco/uploads/c/c4/Indian_pines_gt.mat'
     r = requests.get(url_gt, allow_redirects=True)
     labels = scipy.io.loadmat(BytesIO(r.content))['indian_pines_gt']
-    wavelenghts = []
+    wavelengths = [400.02, 409.82, 419.62, 429.43, 439.25, 449.07, 458.9, 468.73, 478.57, 488.41, 498.26, 508.12,
+                   517.98, 527.85, 537.72, 547.6, 557.49, 567.38, 577.28, 587.18, 597.09, 607.01, 616.93, 626.85,
+                   636.78, 646.72, 656.67, 666.61, 676.57, 686.53, 696.5, 686.91, 696.55, 706.19, 715.83, 725.47,
+                   735.11, 744.74, 754.38, 764.01, 773.64, 783.27, 792.91, 802.53, 812.21, 821.79, 831.41, 841.04,
+                   850.66, 860.28, 869.91, 879.53, 889.14, 898.76, 908.38, 917.99, 927.61, 937.22, 946.83, 956.45,
+                   966.06, 975.66, 985.27, 994.88, 1004.48, 1014.09, 1023.69, 1033.29, 1042.89, 1052.49, 1062.09,
+                   1071.69, 1081.29, 1090.88, 1100.48, 1110.07, 1119.66, 1129.25, 1138.84, 1148.43, 1158.02, 1167.61,
+                   1177.19, 1186.77, 1196.36, 1205.94, 1215.52, 1225.1, 1234.68, 1244.26, 1253.83, 1263.41, 1272.98,
+                   1282.55, 1273.0, 1282.96, 1292.93, 1302.89, 1312.85, 1322.81, 1332.77, 1342.73, 1352.68, 1422.34,
+                   1432.28, 1442.23, 1452.17, 1462.11, 1472.05, 1481.99, 1491.92, 1501.86, 1511.79, 1521.73, 1531.66,
+                   1541.59, 1551.52, 1561.44, 1571.37, 1581.3, 1591.22, 1601.14, 1611.06, 1620.98, 1630.9, 1640.81,
+                   1650.73, 1660.64, 1670.56, 1680.47, 1690.38, 1700.28, 1710.19, 1720.1, 1730.0, 1739.9, 1749.81,
+                   1759.71, 1769.6, 1779.5, 1789.4, 1799.29, 1809.19, 1819.08, 1953.26, 1963.25, 1973.24, 1983.23,
+                   1993.22, 2003.2, 2013.18, 2023.16, 2033.13, 2043.1, 2053.07, 2063.04, 2073.0, 2082.97, 2092.92,
+                   2102.88, 2112.83, 2122.78, 2132.73, 2142.68, 2152.62, 2162.56, 2172.5, 2182.43, 2192.37, 2202.3,
+                   2260.22, 2270.15, 2232.07, 2241.99, 2251.9, 2261.82, 2271.73, 2281.64, 2291.54, 2301.45, 2311.35,
+                   2321.25, 2331.14, 2341.03, 2350.92, 2360.81, 2370.7, 2380.58, 2390.46, 2400.33, 2410.21, 2420.08,
+                   2429.95, 2439.81, 2449.68, 2459.54, 2469.4, 2479.25, 2489.11, 2498.96]
+
     return Bunch(
         tensor=np.array(image, "float"),
-        ticks=[labels, wavelenghts],
+        ticks=[labels, wavelengths],
         dims=["Spatial dimension", "Spatial dimension", "Hyperspectral bands"],
         reference=reference,
         DESC=desc,
@@ -272,5 +290,5 @@ def load_kinetic():
         tensor=tensor,
         dims=["Measurements", "Emissions", "Excitations", "Time points"],
         reference=reference,
-        DESC = desc,
-        LICENCE = licence)
+        DESC=desc,
+        LICENCE=licence)

--- a/tensorly/datasets/data_imports.py
+++ b/tensorly/datasets/data_imports.py
@@ -33,7 +33,7 @@ class Bunch(dict):
         pass
 
 
-def IL2data():
+def load_IL2data():
     """
     Loads tensor of IL-2 mutein treatment responses.
     Tensor contains the signaling responses of eight different cell types to 13 IL-2 mutants.

--- a/tensorly/datasets/data_imports.py
+++ b/tensorly/datasets/data_imports.py
@@ -8,7 +8,7 @@ from urllib.request import urlopen
 import scipy.io
 from zipfile import ZipFile
 from io import BytesIO
-
+import tensorly as tl
 
 class Bunch(dict):
     """ A Bunch, exposing dict keys as a keys() method.
@@ -77,7 +77,7 @@ def load_IL2data():
         SOFTWARE."""
 
     return Bunch(
-        tensor=tensor,
+        tensor=tl.tensor(tensor),
         ticks=[ligands, times, doses, cells],
         dims=dims,
         reference=reference,
@@ -208,7 +208,7 @@ def load_covid19_serology():
             SOFTWARE."""
 
     return Bunch(
-        tensor=tensor,
+        tensor=tl.tensor(tensor),
         ticks=[sampleLabels, antigenLabels, receptorLabels],
         dims=dims,
         reference=reference,
@@ -216,7 +216,7 @@ def load_covid19_serology():
         LICENSE=LICENSE)
 
 
-def load_indian_pines():
+def fetch_indian_pines():
     """
     Loads indian pines hyperspectral data from th website and returns it as a tensorly tensor without storing the data
     in the hard drive. This dataset could be useful for non-negative constrained decomposition methods and
@@ -258,7 +258,7 @@ def load_indian_pines():
                    2429.95, 2439.81, 2449.68, 2459.54, 2469.4, 2479.25, 2489.11, 2498.96]
 
     return Bunch(
-        tensor=np.array(image, "float"),
+        tensor=tl.tensor(np.array(image, "float")),
         ticks=[labels, wavelengths],
         dims=["Spatial dimension", "Spatial dimension", "Hyperspectral bands"],
         reference=reference,
@@ -266,7 +266,7 @@ def load_indian_pines():
         LICENCE=licence)
 
 
-def load_kinetic():
+def fetch_kinetic():
     """
     Loads kinetic fluorescence dataset from website and returns it as tensorly tensor without storing the data
     in the hard drive.The data is well suited for Parafac and multi-way partial least squares regression (N-PLS).
@@ -287,7 +287,7 @@ def load_kinetic():
     desc = "A four-way data set with the modes: Concentration, excitation wavelength, emission wavelength and time"
 
     return Bunch(
-        tensor=tensor,
+        tensor=tl.tensor(tensor),
         dims=["Measurements", "Emissions", "Excitations", "Time points"],
         reference=reference,
         DESC=desc,

--- a/tensorly/datasets/data_imports.py
+++ b/tensorly/datasets/data_imports.py
@@ -235,8 +235,13 @@ def load_indian_pines():
             "were acquired on June 12, 1992 over the Purdue University Agronomy farm northwest " \
             "of West Lafayette and the surrounding area. This scene consists of 145 times 145 pixels and 220 spectral " \
             "reflectance bands in the wavelength range 0.4–2.5 10^(-6) meters."
+    url_gt = 'http://www.ehu.eus/ccwintco/uploads/c/c4/Indian_pines_gt.mat'
+    r = requests.get(url_gt, allow_redirects=True)
+    labels = scipy.io.loadmat(BytesIO(r.content))['indian_pines_gt']
+    wavelenghts = []
     return Bunch(
         tensor=np.array(image, "float"),
+        ticks=[labels, wavelenghts],
         dims=["Spatial dimension", "Spatial dimension", "Hyperspectral bands"],
         reference=reference,
         DESC=desc,

--- a/tensorly/datasets/tests/test_imports.py
+++ b/tensorly/datasets/tests/test_imports.py
@@ -1,4 +1,4 @@
-from ..data_imports import load_IL2data, load_covid19_serology, load_indian_pines, load_kinetic
+from ..data_imports import load_IL2data, load_covid19_serology, fetch_indian_pines, fetch_kinetic
 
 
 def test_IL2data():
@@ -24,7 +24,7 @@ def test_COVID19_data():
 
 def test_indian_pines():
     """ Test that data import dimensions match. """
-    data = load_indian_pines()
+    data = fetch_indian_pines()
 
     tensor = data["tensor"]
     assert tensor.shape[0] == len(data["ticks"][0])
@@ -34,7 +34,7 @@ def test_indian_pines():
 
 def test_kinetic():
     """ Test that data import dimensions match. """
-    data = load_kinetic()
+    data = fetch_kinetic()
 
     tensor = data["tensor"]
     assert tensor.shape[0] == 64

--- a/tensorly/datasets/tests/test_imports.py
+++ b/tensorly/datasets/tests/test_imports.py
@@ -27,7 +27,9 @@ def test_indian_pines():
     data = load_indian_pines()
 
     tensor = data["tensor"]
-    assert tensor.shape[0] == 145
+    assert tensor.shape[0] == len(data["ticks"][0])
+    assert tensor.shape[1] == len(data["ticks"][0])
+    assert tensor.shape[2] == len(data["ticks"][1])
 
 
 def test_kinetic():

--- a/tensorly/datasets/tests/test_imports.py
+++ b/tensorly/datasets/tests/test_imports.py
@@ -1,4 +1,4 @@
-from ..data_imports import IL2data, load_covid19_serology
+from ..data_imports import IL2data, load_covid19_serology, load_indian_pines, load_kinetic
 
 
 def test_IL2data():
@@ -21,3 +21,18 @@ def test_COVID19_data():
     assert tensor.shape[1] == len(data["ticks"][1])
     assert tensor.shape[2] == len(data["ticks"][2])
 
+
+def test_indian_pines():
+    """ Test that data import dimensions match. """
+    data = load_indian_pines()
+
+    tensor = data["tensor"]
+    assert tensor.shape[0] == 145
+
+
+def test_kinetic():
+    """ Test that data import dimensions match. """
+    data = load_kinetic()
+
+    tensor = data["tensor"]
+    assert tensor.shape[0] == 64

--- a/tensorly/datasets/tests/test_imports.py
+++ b/tensorly/datasets/tests/test_imports.py
@@ -1,9 +1,9 @@
-from ..data_imports import IL2data, load_covid19_serology, load_indian_pines, load_kinetic
+from ..data_imports import load_IL2data, load_covid19_serology, load_indian_pines, load_kinetic
 
 
 def test_IL2data():
     """ Test that data import dimensions match. """
-    data = IL2data()
+    data = load_IL2data()
 
     tensor = data["tensor"]
     assert tensor.shape[0] == len(data["ticks"][0])


### PR DESCRIPTION
This PR adds 2 functions to `data_imports` file in order to load indian pines and kinetic fluorescence dataset from their url. Both functions use `urllib` library which should not be a dependency for tensorly. 

I added necessary information according to Bunch dictionary and related tests to `test_imports` file. Also, I changed the `IL2data` name to `load_IL2data` to be consistent.

