### PR TITLE
reorder modes and ranks in partial_tucker

### DIFF
--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -76,7 +76,7 @@ def initialize_tucker(tensor, rank, modes, random_state, init='svd', svd='numpy_
     return core, factors
     
 
-def partial_tucker(tensor, modes, rank=None, n_iter_max=100, init='svd', tol=10e-5,
+def partial_tucker(tensor, rank, modes=None, n_iter_max=100, init='svd', tol=10e-5,
                    svd='numpy_svd', random_state=None, verbose=False, mask=None):
     """Partial tucker decomposition via Higher Order Orthogonal Iteration (HOI)
 
@@ -85,11 +85,11 @@ def partial_tucker(tensor, modes, rank=None, n_iter_max=100, init='svd', tol=10e
     Parameters
     ----------
     tensor : ndarray
-    modes : int list
-            list of the modes on which to perform the decomposition
     rank : None, int or int list
         size of the core tensor, ``(len(ranks) == tensor.ndim)``
         if int, the same rank is used for all modes
+    modes : None, int list
+            list of the modes on which to perform the decomposition
     n_iter_max : int
                  maximum number of iteration
     init : {'svd', 'random'}, or TuckerTensor optional
@@ -118,6 +118,9 @@ def partial_tucker(tensor, modes, rank=None, n_iter_max=100, init='svd', tol=10e
             with ``core.shape[i] == (tensor.shape[i], ranks[i]) for i in modes``
 
     """
+    if modes is None:
+        modes = list(range(tl.ndim(tensor)))
+
     if rank is None:
         message = "No value given for 'rank'. The decomposition will preserve the original size."
         warnings.warn(message, Warning)
@@ -254,7 +257,7 @@ def tucker(tensor, rank, fixed_factors=None, n_iter_max=100, init='svd', return_
         modes, factors = zip(*[(i, f) for (i, f) in enumerate(factors) if i not in fixed_factors])
         init = (core, list(factors))
 
-        (core, new_factors), rec_errors = partial_tucker(tensor, modes, rank=rank, n_iter_max=n_iter_max, init=init,
+        (core, new_factors), rec_errors = partial_tucker(tensor, rank=rank, modes=modes, n_iter_max=n_iter_max, init=init,
                                                          svd=svd, tol=tol, random_state=random_state, mask=mask,
                                                          verbose=verbose)
 
@@ -270,7 +273,7 @@ def tucker(tensor, rank, fixed_factors=None, n_iter_max=100, init='svd', return_
         # TO-DO validate rank for partial tucker as well
         rank = validate_tucker_rank(tl.shape(tensor), rank=rank)
 
-        (core, factors), rec_errors = partial_tucker(tensor, modes, rank=rank, n_iter_max=n_iter_max, init=init,
+        (core, factors), rec_errors = partial_tucker(tensor, rank=rank, modes=modes, n_iter_max=n_iter_max, init=init,
                                                      svd=svd, tol=tol, random_state=random_state, mask=mask,
                                                      verbose=verbose)
         tensor = TuckerTensor((core, factors))

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -14,7 +14,7 @@ def test_partial_tucker():
     tol_max_abs = 10e-1
     tensor = tl.tensor(rng.random_sample((3, 4, 3)))
     modes = [1, 2]
-    (core, factors), rec_errors = partial_tucker(tensor, modes, rank=None, n_iter_max=200, verbose=True)
+    (core, factors), rec_errors = partial_tucker(tensor, rank=None, modes=modes, n_iter_max=200, verbose=True)
     reconstructed_tensor = multi_mode_dot(core, factors, modes=modes)
     norm_rec = tl.norm(reconstructed_tensor, 2)
     norm_tensor = tl.norm(tensor, 2)
@@ -25,7 +25,7 @@ def test_partial_tucker():
 
     # Test the shape of the core and factors
     ranks = [3, 1]
-    (core, factors), rec_errors = partial_tucker(tensor, modes=modes, rank=ranks, n_iter_max=100, verbose=1)
+    (core, factors), rec_errors = partial_tucker(tensor, rank=ranks, modes=modes, n_iter_max=100, verbose=1)
     for i, rank in enumerate(ranks):
         assert_equal(factors[i].shape, (tensor.shape[i+1], ranks[i]),
                      err_msg="factors[{}].shape={}, expected {}".format(
@@ -34,8 +34,8 @@ def test_partial_tucker():
                      "expected {}".format(core.shape, [tensor.shape[0]]+ranks))
 
     # Test random_state fixes the core and the factor matrices
-    (core1, factors1), rec_errors = partial_tucker(tensor, modes=modes, rank=ranks, random_state=0)
-    (core2, factors2), rec_errors = partial_tucker(tensor, modes=modes, rank=ranks, random_state=0)
+    (core1, factors1), rec_errors = partial_tucker(tensor, rank=ranks, modes=modes, random_state=0)
+    (core2, factors2), rec_errors = partial_tucker(tensor, rank=ranks, modes=modes, random_state=0)
     assert_array_equal(core1, core2)
     for factor1, factor2 in zip(factors1, factors2):
         assert_array_equal(factor1, factor2)


### PR DESCRIPTION
This PR is related to consistency issue in partial_tucker raised in #237 . I reordered modes and rank arguments in signature, doc and tests. 