### PR TITLE
Remove descending argument in sorting functions

### DIFF
--- a/tensorly/backend/core.py
+++ b/tensorly/backend/core.py
@@ -884,7 +884,7 @@ class Backend(object):
         raise NotImplementedError
 
     @staticmethod
-    def sort(tensor, axis, descending = False):
+    def sort(tensor, axis):
         """Return a sorted copy of an array
 
         Parameters
@@ -893,8 +893,6 @@ class Backend(object):
             An N-D tensor
         axis : int or None
             Axis along which to sort. If None, the array is flattened before sorting. The default is -1, which sorts along the last axis.
-        descending : bool
-            If True, values are sorted in descending order, otherwise in ascending.
 
         Returns
         -------
@@ -904,7 +902,7 @@ class Backend(object):
         raise NotImplementedError
 
     @staticmethod
-    def argsort(tensor, axis,  descending = False):
+    def argsort(tensor, axis):
         """Returns arguments of a sorted array
 
         Parameters
@@ -913,8 +911,6 @@ class Backend(object):
             An N-D tensor
         axis : int or None
             Axis along which to sort. If None, the array is flattened before sorting. The default is -1, which sorts along the last axis.
-        descending : bool
-            If True, values are sorted in descending order, otherwise in ascending.
 
         Returns
         -------

--- a/tensorly/backend/cupy_backend.py
+++ b/tensorly/backend/cupy_backend.py
@@ -35,10 +35,6 @@ class CupyBackend(Backend, backend_name='cupy'):
         return tensor
 
     @staticmethod
-    def shape(tensor):
-        return tensor.shape
-
-    @staticmethod
     def ndim(tensor):
         return tensor.ndim
 
@@ -51,20 +47,6 @@ class CupyBackend(Backend, backend_name='cupy'):
         x, residuals, _, _ = cp.linalg.lstsq(a, b, rcond=None)
         return x, residuals
 
-    @staticmethod
-    def sort(tensor, axis, descending = False):
-        if descending:
-            return cp.flip(cp.sort(tensor, axis=axis), axis = axis)
-        else:
-            return cp.sort(tensor, axis=axis)
-
-    @staticmethod
-    def argsort(tensor, axis, descending = False):
-        if descending:
-            return np.argsort(-1 * tensor, axis=axis)
-        else:
-            return np.argsort(tensor, axis=axis)
-
 
 for name in ['float64', 'float32', 'int64', 'int32', 'complex128', 'complex64', 'reshape', 'moveaxis',
              'pi', 'e', 'inf', 'nan',
@@ -75,7 +57,7 @@ for name in ['float64', 'float32', 'int64', 'int32', 'complex128', 'complex64', 
              'log', 'log2', 'exp',
              'sin', 'cos', 'tan', 
              'arcsin', 'arccos', 'arctan',
-             'sinh', 'cosh', 'tanh', 
+             'sinh', 'cosh', 'tanh', 'argsort', 'sort', 'shape',
              'arcsinh', 'arccosh', 'arctanh',
              ]:
     CupyBackend.register_method(name, getattr(cp, name))

--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -44,16 +44,8 @@ class JaxBackend(Backend, backend_name='jax'):
         #return copy.copy(tensor)
 
     @staticmethod
-    def shape(tensor):
-        return tensor.shape
-
-    @staticmethod
     def ndim(tensor):
         return tensor.ndim
-
-    @staticmethod
-    def dot(a, b):
-        return a.dot(b)
 
     @staticmethod
     def lstsq(a, b):
@@ -76,19 +68,6 @@ class JaxBackend(Backend, backend_name='jax'):
         m = mask.reshape((-1, 1)) if mask is not None else 1
         return np.einsum(operation, *matrices).reshape((-1, n_columns))*m
 
-    @staticmethod
-    def sort(tensor, axis, descending = False):
-        if descending:
-            return np.flip(np.sort(tensor, axis=axis), axis = axis)
-        else:
-            return np.sort(tensor, axis=axis)
-
-    @staticmethod
-    def argsort(tensor, axis, descending = False):
-        if descending:
-            return np.argsort(-1 * tensor, axis=axis)
-        else:
-            return np.argsort(tensor, axis=axis)
 
 for name in ['int64', 'int32', 'float64', 'float32', 'complex128', 'complex64', 
              'pi', 'e', 'inf', 'nan',
@@ -99,7 +78,7 @@ for name in ['int64', 'int32', 'float64', 'float32', 'complex128', 'complex64',
              'argmax', 'stack', 'conj', 'diag', 'clip', 'einsum', 'log', 'log2', 'tensordot', 'exp',
              'sin', 'cos', 'tan', 
              'arcsin', 'arccos', 'arctan',
-             'sinh', 'cosh', 'tanh', 
+             'sinh', 'cosh', 'tanh', 'argsort', 'sort', 'dot', 'shape',
              'arcsinh', 'arccosh', 'arctanh',
             ]:
     JaxBackend.register_method(name, getattr(np, name))

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -40,16 +40,8 @@ class MxnetBackend(Backend, backend_name='mxnet'):
             return numpy.array(tensor)
 
     @staticmethod
-    def shape(tensor):
-        return tensor.shape
-
-    @staticmethod
     def ndim(tensor):
         return tensor.ndim
-
-    @staticmethod
-    def dot(a, b):
-        return np.dot(a, b)
 
     @staticmethod
     def clip(tensor, a_min=None, a_max=None):
@@ -96,19 +88,6 @@ class MxnetBackend(Backend, backend_name='mxnet'):
         x, residuals, _, _ = np.linalg.lstsq(a, b, rcond=None)
         return x, residuals
 
-    @staticmethod
-    def sort(tensor, axis, descending = False):
-        if descending:
-            return np.flip(np.sort(tensor, axis=axis), axis = axis)
-        else:
-            return np.sort(tensor, axis=axis)
-
-    @staticmethod
-    def argsort(tensor, axis, descending = False):
-        if descending:
-            return np.argsort(-1 * tensor, axis=axis)
-        else:
-            return np.argsort(tensor, axis=axis)
 
 for name in ['int64', 'int32', 'float64', 'float32', 
              'pi', 'e', 'inf', 'nan',
@@ -119,7 +98,7 @@ for name in ['int64', 'int32', 'float64', 'float32',
              'argmax', 'stack', 'diag', 'einsum', 'log', 'log2', 'tensordot', 'exp',
              'sin', 'cos', 'tan', 
              'arcsin', 'arccos', 'arctan',
-             'sinh', 'cosh', 'tanh', 
+             'sinh', 'cosh', 'tanh', 'argsort', 'sort', 'dot', 'shape',
              'arcsinh', 'arccosh', 'arctanh',
             ]:
     MxnetBackend.register_method(name, getattr(np, name))

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -21,20 +21,12 @@ class NumpyBackend(Backend, backend_name='numpy'):
         return np.copy(tensor)
 
     @staticmethod
-    def shape(tensor):
-        return tensor.shape
-
-    @staticmethod
     def ndim(tensor):
         return tensor.ndim
 
     @staticmethod
     def clip(tensor, a_min=None, a_max=None):
         return np.clip(tensor, a_min, a_max)
-
-    @staticmethod
-    def dot(a, b):
-        return a.dot(b)
 
     @staticmethod
     def lstsq(a, b):
@@ -57,19 +49,6 @@ class NumpyBackend(Backend, backend_name='numpy'):
         m = mask.reshape((-1, 1)) if mask is not None else 1
         return np.einsum(operation, *matrices).reshape((-1, n_columns))*m
 
-    @staticmethod
-    def sort(tensor, axis, descending = False):
-        if descending:
-            return np.flip(np.sort(tensor, axis=axis), axis = axis)
-        else:
-            return np.sort(tensor, axis=axis)
-
-    @staticmethod
-    def argsort(tensor, axis, descending = False):
-        if descending:
-            return np.argsort(-1 * tensor, axis=axis)
-        else:
-            return np.argsort(tensor, axis=axis)
 
 for name in ['int64', 'int32', 'float64', 'float32', 'complex128', 'complex64', 
              'pi', 'e', 'inf', 'nan',
@@ -80,7 +59,7 @@ for name in ['int64', 'int32', 'float64', 'float32', 'complex128', 'complex64',
              'argmax', 'stack', 'conj', 'diag', 'einsum', 'log', 'log2', 'tensordot', 'exp',
              'sin', 'cos', 'tan', 
              'arcsin', 'arccos', 'arctan',
-             'sinh', 'cosh', 'tanh', 
+             'sinh', 'cosh', 'tanh', 'argsort', 'sort', 'dot', 'shape',
              'arcsinh', 'arccosh', 'arctanh',
             ]:
     NumpyBackend.register_method(name, getattr(np, name))

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -146,8 +146,8 @@ class PyTorchBackend(Backend, backend_name='pytorch'):
             return torch.argmin(input, dim=axis)
 
     @staticmethod
-    def argsort(input, axis=None, descending=False):
-            return torch.argsort(input, dim=axis, descending=descending)
+    def argsort(input, axis=None):
+            return torch.argsort(input, dim=axis)
 
     @staticmethod
     def argmax(input, axis=None):
@@ -162,12 +162,12 @@ class PyTorchBackend(Backend, backend_name='pytorch'):
         return torch.diag(tensor, diagonal=k)
 
     @staticmethod
-    def sort(tensor, axis, descending = False):
+    def sort(tensor, axis):
         if axis is None:
             tensor = tensor.flatten()
             axis = -1
 
-        return torch.sort(tensor, dim=axis, descending = descending).values
+        return torch.sort(tensor, dim=axis).values
 
     @staticmethod
     def update_index(tensor, index, values):

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -125,30 +125,20 @@ class TensorflowBackend(Backend, backend_name='tensorflow'):
         return res
 
     @staticmethod
-    def sort(tensor, axis, descending = False):
-        if descending:
-            direction = 'DESCENDING'
-        else:
-            direction = 'ASCENDING'
-            
+    def sort(tensor, axis):
         if axis is None:
             tensor = tf.reshape(tensor, [-1])
             axis = -1
 
-        return tf.sort(tensor, axis=axis, direction = direction)
+        return tf.sort(tensor, axis=axis, direction = 'ASCENDING')
 
     @staticmethod
-    def argsort(tensor, axis, descending=False):
-        if descending:
-            direction = 'DESCENDING'
-        else:
-            direction = 'ASCENDING'
-
+    def argsort(tensor, axis):
         if axis is None:
             tensor = tf.reshape(tensor, [-1])
             axis = -1
 
-        return tf.argsort(tensor, axis=axis, direction=direction)
+        return tf.argsort(tensor, axis=axis, direction='ASCENDING')
 
     def flip(self, tensor, axis=None):
         if isinstance(axis, int):

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -600,7 +600,7 @@ def simplex_prox(tensor, parameter):
         row = tl.shape(tensor)[0]
         col = 1
         tensor = tl.reshape(tensor, [row, col])
-    tensor_sort = tl.sort(tensor, axis=0, descending=True)
+    tensor_sort = tl.flip(tl.sort(tensor, axis=0), axis=0)
     # Broadcasting is used to divide rows by 1,2,3...
     cumsum_min_param_by_k = (tl.cumsum(tensor_sort, axis=0) - parameter) / tl.cumsum(tl.ones([row, 1]), axis=0)
     # Added -1 to correspond to a Python index
@@ -630,7 +630,7 @@ def hard_thresholding(tensor, number_of_non_zero):
           Thresholded tensor on which the operator has been applied
     """
     tensor_vec = tl.copy(tl.tensor_to_vec(tensor))
-    sorted_indices = tl.argsort(tl.argsort(tl.abs(tensor_vec), axis=0, descending=True), axis=0)
+    sorted_indices = tl.argsort(tl.flip(tl.argsort(tl.abs(tensor_vec), axis=0), axis=0), axis=0)
     return tl.reshape(tl.where(sorted_indices < number_of_non_zero, tensor_vec, tl.tensor(0, **tl.context(tensor_vec))), tensor.shape)
 
 


### PR DESCRIPTION
This removes the descending argument from the sorting functions so that they are consistent with the NumPy interface. Descending sorting was only used in two places, so these have been updated with an additional call to `np.flip`. I know this can easily turn into a game of code golf. However, I think users (1) will expect a NumPy-like interface as this has become standard and (2) simplifying the backend code will make it easier to navigate changes like a more consistent SVD backend. Once we can switch to the NumPy-like interface to PyTorch and tensorflow we should need only a minimal amount of code for the basic backend functions.