### PR TITLE
Add assert allclose and tests for test utils

### DIFF
--- a/tensorly/testing.py
+++ b/tensorly/testing.py
@@ -14,8 +14,19 @@ def assert_array_almost_equal(a, b, *args, **kwargs):
     np.testing.assert_array_almost_equal(T.to_numpy(a), T.to_numpy(b), *args, **kwargs)
 
 
-def assert_allclose(actual, desired, *args, **kwargs):
-    np.testing.assert_allclose(T.to_numpy(actual), T.to_numpy(desired), *args, **kwargs)
+def assert_allclose(actual, desired, rtol=1e-07, atol=0, equal_nan=True, err_msg='', verbose=True):
+    """Check if two arrays are equal up to a given relevant and absolute tolerance.
+
+    See the `NumPy documentation <https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_equal.html>`_ for more details."""
+    np.testing.assert_allclose(
+        T.to_numpy(actual),
+        T.to_numpy(desired),
+        rtol=rtol,
+        atol=atol,
+        equal_nan=equal_nan,
+        err_msg=err_msg,
+        verbose=verbose
+    )
 
 
 def assert_equal(actual, desired, *args, **kwargs):

--- a/tensorly/testing.py
+++ b/tensorly/testing.py
@@ -7,13 +7,15 @@ from tensorly import backend as T
 
 
 def assert_array_equal(a, b, *args, **kwargs):
-    np.testing.assert_array_equal(T.to_numpy(a), T.to_numpy(b),
-                                  *args, **kwargs)
+    np.testing.assert_array_equal(T.to_numpy(a), T.to_numpy(b), *args, **kwargs)
 
 
 def assert_array_almost_equal(a, b, *args, **kwargs):
-    np.testing.assert_array_almost_equal(T.to_numpy(a), T.to_numpy(b),
-                                         *args, **kwargs)
+    np.testing.assert_array_almost_equal(T.to_numpy(a), T.to_numpy(b), *args, **kwargs)
+
+
+def assert_allclose(actual, desired, *args, **kwargs):
+    np.testing.assert_allclose(T.to_numpy(actual), T.to_numpy(desired), *args, **kwargs)
 
 
 def assert_equal(actual, desired, *args, **kwargs):
@@ -60,7 +62,7 @@ def _get_decomposition_checker(supposed_kwargs, output_length):
         and their supposed value.
     output_length : int
         The number of outputs from the function
-    
+
     Returns
     -------
     function
@@ -117,6 +119,6 @@ def assert_class_wrapper_correctly_passes_arguments(
     monkeypatch.setattr(decomposition_module, decomposition_function.__name__, decomposition_checker)
     DecompositionClass(**extra_args, **test_kwargs).fit(None)
 
-    
+
 assert_ = np.testing.assert_
 assert_raises = np.testing.assert_raises

--- a/tensorly/tests/test_testing.py
+++ b/tensorly/tests/test_testing.py
@@ -1,0 +1,71 @@
+import pytest
+import tensorly as tl
+
+from ..testing import (
+    assert_allclose,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+)
+
+
+def test_assert_allclose():
+    tensor = tl.tensor([5, 5, 5])
+
+    assert_allclose(tensor, tensor)
+    assert_allclose(tensor, tensor + 1e-10)
+
+    with pytest.raises(AssertionError):
+        assert_allclose(tensor, tensor + 10)
+
+    assert_allclose(tensor, tensor + 1, atol=2)
+    with pytest.raises(AssertionError):
+        assert_allclose(tensor, tensor + 1, atol=0.5)
+
+    assert_allclose(tensor, tensor + 0.1 * tensor, rtol=0.2)
+    with pytest.raises(AssertionError):
+        assert_allclose(tensor, tensor + 0.1 * tensor, rtol=0.09)
+
+
+def test_assert_equal():
+    tensor = tl.tensor([5, 5, 5])
+
+    assert_equal(tensor, tensor)
+    assert_equal(tl.tensor([1, 2]), tl.tensor([1.0, 2.0]))
+
+    assert_equal(tl.tensor([1, 1, 1]), tl.tensor(1))
+
+    with pytest.raises(AssertionError):
+        assert_equal(tensor, tensor + 10)
+
+
+def test_assert_array_almost_equal():
+    tensor = tl.tensor([5, 5, 5])
+
+    assert_array_almost_equal(tensor, tensor)
+    assert_array_almost_equal(tensor, tensor + 1e-10)
+
+    with pytest.raises(AssertionError):
+        assert_array_almost_equal(tensor, tensor + 10)
+
+    decimal = 5
+    assert_array_almost_equal(
+        tensor, tensor + 1.5 * 10 ** (-decimal - 1), decimal=decimal
+    )
+    with pytest.raises(AssertionError):
+        assert_array_almost_equal(
+            tensor, tensor + 1.5 * 10 ** (-decimal), decimal=decimal
+        )
+
+
+def test_assert_array_equal():
+    tensor = tl.tensor([5, 5, 5])
+
+    assert_equal(tensor, tensor)
+    assert_equal(tl.tensor([1, 2]), tl.tensor([1.0, 2.0]))
+
+    with pytest.raises(AssertionError):
+        assert_equal(tensor, tensor + 10)
+
+    with pytest.raises(AssertionError):
+        assert_array_equal(tl.tensor([1, 1, 1]), tl.tensor([1]))

--- a/tensorly/tests/test_testing.py
+++ b/tensorly/tests/test_testing.py
@@ -48,7 +48,7 @@ def test_assert_array_almost_equal():
     with pytest.raises(AssertionError):
         assert_array_almost_equal(tensor, tensor + 10)
 
-    decimal = 5
+    decimal = 3
     assert_array_almost_equal(
         tensor, tensor + 1.5 * 10 ** (-decimal - 1), decimal=decimal
     )


### PR DESCRIPTION
This pull request adds assert_allclose to `tensorly.testing`. currently, TensorLy supports `assert_array_almost_equal`, which uses `numpy.testing.assert_almost_equal`. However, NumPy now recommends using `assert_allclose` (see [numpy.testing.assert_almost_equal — NumPy v1.22 Manual](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_almost_equal.html)) instead, so it would be nice if TensorLy had support for this too.

I also added some simple tests for the `tensorly.testing` module.