### PR TITLE
change decimal for randomized_svd

### DIFF
--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -133,6 +133,10 @@ def test_svd():
     tol_orthogonality = 0.01
 
     for name, svd_fun in T.SVD_FUNS.items():
+        if name == "randomized_svd":
+            decimal = 2
+        else:
+            decimal = 3
         sizes = [(100, 100), (100, 5), (10, 10), (10, 4), (5, 100)]
         n_eigenvecs = [90, 4, 5, 4, 5]
 
@@ -143,7 +147,7 @@ def test_svd():
             U, S, V = svd(matrix)
             U, S, V = U[:, :n], S[:n], V[:n, :]
 
-            assert_array_almost_equal(np.abs(S), T.abs(fS), decimal=3,
+            assert_array_almost_equal(np.abs(S), T.abs(fS), decimal=decimal,
                 err_msg='eigenvals not correct for "{}" svd fun VS svd and backend="{}, for {} eigenenvecs, and size {}".'.format(
                         name, tl.get_backend(), n, s))
 


### PR DESCRIPTION
This PR is related to issues #308 and #287. Basically, svd test fails sometimes because of the randomized svd. As @JeanKossaifi suggested, I defined a lower precision specifically for it and ran the test 1000 times with Mxnet backend without failing.