### PR TITLE
Warning when fixing last mode

### DIFF
--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -580,7 +580,8 @@ def non_negative_tucker_hals(
 
     if tl.ndim(tensor) - 1 in fixed_modes:
         warnings.warn(
-            "You asked for fixing the last mode, which is not supported.\n The last mode will not be fixed. Consider using tl.moveaxis()"
+            "You asked for fixing the last mode, which is not supported. The last mode will not be fixed."
+            " Consider using tl.moveaxis() to permute it to another position and keep it fixed there."
         )
         fixed_modes.remove(tl.ndim(tensor) - 1)
 

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -578,6 +578,12 @@ def non_negative_tucker_hals(
     if fixed_modes is None:
         fixed_modes = []
 
+    if tl.ndim(tensor) - 1 in fixed_modes:
+        warnings.warn(
+            "You asked for fixing the last mode, which is not supported.\n The last mode will not be fixed. Consider using tl.moveaxis()"
+        )
+        fixed_modes.remove(tl.ndim(tensor) - 1)
+
     # Avoiding errors
     for fixed_value in fixed_modes:
         sparsity_coefficients[fixed_value] = None

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -293,6 +293,18 @@ def test_non_negative_tucker_hals(monkeypatch):
         "abs norm of difference between svd and random init too high",
     )
 
+    # try fixing the mode
+    factors_init = [tl.copy(f) for f in factors_random]
+    _, factors = non_negative_tucker_hals(
+        tensor,
+        rank=[3, 4, 3],
+        init=(core_random, factors_init),
+        fixed_modes=[1],
+        n_iter_max=100,
+        verbose=1,
+    )
+    assert_array_equal(factors_random[1], factors_init[1])
+
     # Test for a single rank passed
     # (should be used for all modes)
     rank = 3


### PR DESCRIPTION
This is a small PR for adding missing warning when fixing the last mode in non_negative_tucker_hals. I also extended the test of this function with a fixed_modes option.  

We can support fixing the last mode as it is discussed here #292 but it is better to have consistent warning until then.