### PR TITLE
Use f-strings instead of str.format()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scipy
 pytest
 pytest-cov
+python_version >= "3.6"

--- a/tensorly/backend/__init__.py
+++ b/tensorly/backend/__init__.py
@@ -290,7 +290,7 @@ class BackendManager(types.ModuleType):
             msg = f"Unknown backend name {backend_name!r}, known backends are {cls.available_backend_names}"
             raise ValueError(msg)
         if backend_name not in Backend._available_backends:
-            importlib.import_module("tensorly.backend.{0}_backend".format(backend_name))
+            importlib.import_module(f"tensorly.backend.{backend_name}_backend")
         if backend_name in Backend._available_backends:
             backend = Backend._available_backends[backend_name]()
             # backend = getattr(module, )()

--- a/tensorly/backend/core.py
+++ b/tensorly/backend/core.py
@@ -1073,8 +1073,7 @@ class Backend(object):
         """
         if len(matrices) < 2:
             raise ValueError(
-                "kr requires a list of at least 2 matrices, but {} "
-                "given.".format(len(matrices))
+                f"kr requires a list of at least 2 matrices, but {len(matrices)} given."
             )
 
         n_col = self.shape(matrices[0])[1]

--- a/tensorly/contrib/decomposition/_tt_cross.py
+++ b/tensorly/contrib/decomposition/_tt_cross.py
@@ -103,7 +103,8 @@ def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100, random_stat
     # Initialize rank
     if rank[0] != 1:
         print(
-            f"Provided {rank[0] = } but boundary conditions dictate rank[0] == rank[-1] == 1: setting rank[0] to 1."
+            f"Provided rank[0] = {rank[0]} but boundary conditions dictate "
+            + "rank[0] == rank[-1] == 1: setting rank[0] to 1."
         )
         rank[0] = 1
     if rank[-1] != 1:

--- a/tensorly/contrib/decomposition/_tt_cross.py
+++ b/tensorly/contrib/decomposition/_tt_cross.py
@@ -94,9 +94,7 @@ def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100, random_stat
     if isinstance(rank, int):
         rank = [rank] * (tensor_order + 1)
     elif tensor_order + 1 != len(rank):
-        message = "Provided incorrect number of ranks. Should verify len(rank) == tl.ndim(tensor)+1, but len(rank) = {} while tl.ndim(tensor) + 1  = {}".format(
-            len(rank), tensor_order
-        )
+        message = f"Provided incorrect number of ranks. Should verify len(rank) == tl.ndim(tensor)+1, but {len(rank) = } while tl.ndim(tensor) + 1  = {tensor_order}"
         raise (ValueError(message))
 
     # Make sure iter's not a tuple but a list
@@ -105,16 +103,12 @@ def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100, random_stat
     # Initialize rank
     if rank[0] != 1:
         print(
-            "Provided rank[0] == {} but boundary conditions dictate rank[0] == rank[-1] == 1: setting rank[0] to 1.".format(
-                rank[0]
-            )
+            f"Provided {rank[0] = } but boundary conditions dictate rank[0] == rank[-1] == 1: setting rank[0] to 1."
         )
         rank[0] = 1
     if rank[-1] != 1:
         print(
-            "Provided rank[-1] == {} but boundary conditions dictate rank[0] == rank[-1] == 1: setting rank[-1] to 1.".format(
-                rank[0]
-            )
+            f"Provided {rank[-11] = } but boundary conditions dictate rank[0] == rank[-1] == 1: setting rank[-1] to 1."
         )
 
     # list col_idx: column indices (right indices) for skeleton-decomposition: indicate which columns used in each core.

--- a/tensorly/contrib/decomposition/_tt_cross.py
+++ b/tensorly/contrib/decomposition/_tt_cross.py
@@ -94,7 +94,11 @@ def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100, random_stat
     if isinstance(rank, int):
         rank = [rank] * (tensor_order + 1)
     elif tensor_order + 1 != len(rank):
-        message = f"Provided incorrect number of ranks. Should verify len(rank) == tl.ndim(tensor)+1, but {len(rank) = } while tl.ndim(tensor) + 1  = {tensor_order}"
+        message = (
+            "Provided incorrect number of ranks. Should verify "
+            + f"len(rank) == tl.ndim(tensor)+1, but len(rank) = {len(rank)} "
+            + f"while tl.ndim(tensor) + 1  = {tensor_order}"
+        )
         raise (ValueError(message))
 
     # Make sure iter's not a tuple but a list

--- a/tensorly/contrib/decomposition/_tt_cross.py
+++ b/tensorly/contrib/decomposition/_tt_cross.py
@@ -109,7 +109,8 @@ def tensor_train_cross(input_tensor, rank, tol=1e-4, n_iter_max=100, random_stat
         rank[0] = 1
     if rank[-1] != 1:
         print(
-            f"Provided {rank[-11] = } but boundary conditions dictate rank[0] == rank[-1] == 1: setting rank[-1] to 1."
+            f"Provided rank[-1] = {rank[-1]} but boundary conditions dictate "
+            "rank[0] == rank[-1] == 1: setting rank[-1] to 1."
         )
 
     # list col_idx: column indices (right indices) for skeleton-decomposition: indicate which columns used in each core.

--- a/tensorly/contrib/sparse/backend/__init__.py
+++ b/tensorly/contrib/sparse/backend/__init__.py
@@ -38,14 +38,12 @@ def register_sparse_backend(backend_name):
 
     if backend_name in _KNOWN_BACKENDS:
         module = importlib.import_module(
-            "tensorly.contrib.sparse.backend.{0}_backend".format(backend_name)
+            f"tensorly.contrib.sparse.backend.{backend_name}_backend"
         )
         backend = getattr(module, _KNOWN_BACKENDS[backend_name])()
         _LOADED_BACKENDS[backend_name] = backend
     else:
-        msg = "Unknown backend name {0!r}, known backends are [{1}]".format(
-            backend_name, ", ".join(map(repr, _KNOWN_BACKENDS))
-        )
+        msg = f"Unknown backend name {backend_name!r}, known backends are [{", ".join(map(repr, _KNOWN_BACKENDS))}]"
         raise ValueError(msg)
 
 

--- a/tensorly/contrib/sparse/backend/numpy_backend.py
+++ b/tensorly/contrib/sparse/backend/numpy_backend.py
@@ -92,7 +92,7 @@ class NumpySparseBackend(Backend, backend_name="numpy.sparse"):
         # Check that matrix is... a matrix!
         if matrix.ndim != 2:
             raise ValueError(
-                "matrix be a matrix. matrix.ndim is {} != 2".format(matrix.ndim)
+                f"matrix be a matrix. {matrix.ndim = } != 2"
             )
 
         # Choose what to do depending on the params
@@ -121,10 +121,10 @@ class NumpySparseBackend(Backend, backend_name="numpy.sparse"):
         else:
             if n_eigenvecs > min_dim:
                 msg = (
-                    "n_eigenvecs={} if greater than the minimum matrix "
-                    "dimension ({})"
+                    f"{n_eigenvecs = } if greater than the minimum matrix "
+                    f"dimension ({min(matrix.shape)})"
                 )
-                raise ValueError(msg.format(n_eigenvecs, min(matrix.shape)))
+                raise ValueError(msg)
             if np.issubdtype(matrix.dtype, np.complexfloating):
                 raise NotImplementedError("Complex dtypes")
             # We can perform a partial SVD

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -63,7 +63,7 @@ class CPTensor(FactorizedTensor):
         return 2
 
     def __repr__(self):
-        message = f"(weights, factors) : rank-{self.rank} CPTensor of shape {self.shape} ")
+        message = f"(weights, factors) : rank-{self.rank} CPTensor of shape {self.shape}"
         return message
 
     def to_tensor(self):

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -38,9 +38,9 @@ class CPTensor(FactorizedTensor):
             return self.factors
         else:
             raise IndexError(
-                "You tried to access index {} of a CP tensor.\n"
+                f"You tried to access index {index} of a CP tensor.\n"
                 "You can only access index 0 and 1 of a CP tensor"
-                "(corresponding respectively to the weights and factors)".format(index)
+                "(corresponding respectively to the weights and factors)"
             )
 
     def __setitem__(self, index, value):
@@ -50,9 +50,9 @@ class CPTensor(FactorizedTensor):
             self.factors = value
         else:
             raise IndexError(
-                "You tried to set the value at index {} of a CP tensor.\n"
+                f"You tried to set the value at index {index} of a CP tensor.\n"
                 "You can only set index 0 and 1 of a CP tensor"
-                "(corresponding respectively to the weights and factors)".format(index)
+                "(corresponding respectively to the weights and factors)"
             )
 
     def __iter__(self):
@@ -63,9 +63,7 @@ class CPTensor(FactorizedTensor):
         return 2
 
     def __repr__(self):
-        message = "(weights, factors) : rank-{} CPTensor of shape {} ".format(
-            self.rank, self.shape
-        )
+        message = f"(weights, factors) : rank-{self.rank} CPTensor of shape {self.shape} ")
         return message
 
     def to_tensor(self):
@@ -203,16 +201,13 @@ def _validate_cp_tensor(cp_tensor):
         if current_rank != rank:
             raise ValueError(
                 "All the factors of a CP tensor should have the same number of column."
-                "However, factors[0].shape[1]={} but factors[{}].shape[1]={}.".format(
-                    rank, i, T.shape(factor)[1]
-                )
+                f"However, factors[0].shape[1]={rank} but factors[{i}].shape[1]={T.shape(factor)[1]}."
             )
         shape.append(current_mode_size)
 
     if weights is not None and T.shape(weights) != (rank,):
         raise ValueError(
-            "Given factors for a rank-{} CP tensor but len(weights)={}.".format(
-                rank, T.shape(weights)
+            f"Given factors for a rank-{rank} CP tensor but len(weights)={T.shape(weights)}."
             )
         )
 
@@ -582,25 +577,15 @@ def cp_mode_dot(cp_tensor, matrix_or_vector, mode, keep_dim=False, copy=False):
         # Test for the validity of the operation
         if matrix_or_vector.shape[1] != shape[mode]:
             raise ValueError(
-                "shapes {0} and {1} not aligned in mode-{2} multiplication: {3} (mode {2}) != {4} (dim 1 of matrix)".format(
-                    shape,
-                    matrix_or_vector.shape,
-                    mode,
-                    shape[mode],
-                    matrix_or_vector.shape[1],
-                )
+                f"shapes {shape} and {matrix_or_vector.shape} not aligned in mode-{mode} multiplication: "
+                f"{shape[mode]} (mode {mode}) != {matrix_or_vector.shape[1]} (dim 1 of matrix)"
             )
 
     elif T.ndim(matrix_or_vector) == 1:  # Tensor times vector
         if matrix_or_vector.shape[0] != shape[mode]:
             raise ValueError(
-                "shapes {0} and {1} not aligned for mode-{2} multiplication: {3} (mode {2}) != {4} (vector size)".format(
-                    shape,
-                    matrix_or_vector.shape,
-                    mode,
-                    shape[mode],
-                    matrix_or_vector.shape[0],
-                )
+                f"shapes {shape} and {matrix_or_vector.shape} not aligned for mode-{mode} multiplication: "
+                f"{shape[mode]} (mode {mode}) != {matrix_or_vector.shape[0]} (vector size)"
             )
         if not keep_dim:
             contract = True  # Contract over that mode

--- a/tensorly/decomposition/_constrained_cp.py
+++ b/tensorly/decomposition/_constrained_cp.py
@@ -136,7 +136,7 @@ def initialize_constrained_parafac(
                 "be possible to convert it to a CPTensor instance"
             )
     else:
-        raise ValueError('Initialization method "{}" not recognized'.format(init))
+        raise ValueError(f'Initialization method "{init}" not recognized')
 
     for i in range(n_modes):
         factors[i] = proximal_operator(
@@ -393,9 +393,7 @@ def constrained_parafac(
 
                 if verbose:
                     print(
-                        "iteration {}, reconstruction error: {}, decrease = {}".format(
-                            iteration, rec_error, rec_error_decrease
-                        )
+                        f"iteration {iteration}, reconstruction error: {rec_error}, decrease = {rec_error_decrease}"
                     )
 
                 if constraint_error < tol_outer:
@@ -409,12 +407,12 @@ def constrained_parafac(
 
                 if stop_flag:
                     if verbose:
-                        print("PARAFAC converged after {} iterations".format(iteration))
+                        print(f"PARAFAC converged after {iteration} iterations")
                     break
 
             else:
                 if verbose:
-                    print("reconstruction error={}".format(rec_errors[-1]))
+                    print(f"reconstruction error={rec_errors[-1]}")
 
     cp_tensor = CPTensor((weights, factors))
 

--- a/tensorly/decomposition/_cp.py
+++ b/tensorly/decomposition/_cp.py
@@ -125,7 +125,7 @@ def initialize_cp(
                 "be possible to convert it to a CPTensor instance"
             )
     else:
-        raise ValueError('Initialization method "{}" not recognized'.format(init))
+        raise ValueError(f'Initialization method "{init}" not recognized')
 
     if non_negative:
         # Make decomposition feasible by taking the absolute value of all factor matrices
@@ -445,7 +445,7 @@ def parafac(
                 acc_fail = 0
 
                 if verbose:
-                    print("Accepted line search jump of {}.".format(jump))
+                    print(f"Accepted line search jump of {jump}.")
             else:
                 unnorml_rec_error, tensor, norm_tensor = error_calc(
                     tensor, norm_tensor, weights, factors, sparsity, mask, mttkrp
@@ -453,7 +453,7 @@ def parafac(
                 acc_fail += 1
 
                 if verbose:
-                    print("Line search failed for jump of {}.".format(jump))
+                    print(f"Line search failed for jump of {jump}.")
 
                 if acc_fail == max_fail:
                     acc_pow += 1.0
@@ -472,9 +472,7 @@ def parafac(
 
                 if verbose:
                     print(
-                        "iteration {}, reconstruction error: {}, decrease = {}, unnormalized = {}".format(
-                            iteration, rec_error, rec_error_decrease, unnorml_rec_error
-                        )
+                        f"iteration {iteration}, reconstruction error: {rec_error}, decrease = {rec_error_decrease}, unnormalized = {unnorml_rec_error}"
                     )
 
                 if cvg_criterion == "abs_rec_error":
@@ -486,12 +484,12 @@ def parafac(
 
                 if stop_flag:
                     if verbose:
-                        print("PARAFAC converged after {} iterations".format(iteration))
+                        print(f"PARAFAC converged after {iteration} iterations")
                     break
 
             else:
                 if verbose:
-                    print("reconstruction error={}".format(rec_errors[-1]))
+                    print(f"reconstruction error={rec_errors[-1]}")
         if normalize_factors:
             weights, factors = cp_normalize((weights, factors))
     cp_tensor = CPTensor((weights, factors))
@@ -691,16 +689,14 @@ def randomised_parafac(
             if iteration > 1:
                 if verbose:
                     print(
-                        "reconstruction error={}, variation={}.".format(
-                            rec_errors[-1], rec_errors[-2] - rec_errors[-1]
-                        )
+                        f"reconstruction error={rec_errors[-1]}, variation={rec_errors[-2]-rec_errors[-1]}."
                     )
 
                 if (tol and abs(rec_errors[-2] - rec_errors[-1]) < tol) or (
                     stagnation and (stagnation > max_stagnation)
                 ):
                     if verbose:
-                        print("converged in {} iterations.".format(iteration))
+                        print(f"converged in {iteration} iterations.")
                     break
 
     if return_errors:

--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -155,9 +155,7 @@ def non_negative_parafac(
 
                 if verbose:
                     print(
-                        "iteration {}, reconstraction error: {}, decrease = {}".format(
-                            iteration, rec_error, rec_error_decrease
-                        )
+                        f"iteration {iteration}, reconstraction error: {rec_error}, decrease = {rec_error_decrease}"
                     )
 
                 if cvg_criterion == "abs_rec_error":
@@ -169,11 +167,11 @@ def non_negative_parafac(
 
                 if stop_flag:
                     if verbose:
-                        print("PARAFAC converged after {} iterations".format(iteration))
+                        print(f"PARAFAC converged after {iteration} iterations")
                     break
             else:
                 if verbose:
-                    print("reconstruction error={}".format(rec_errors[-1]))
+                    print(f"reconstruction error={rec_errors[-1]}")
         if normalize_factors:
             weights, factors = cp_normalize((weights, factors))
     cp_tensor = CPTensor((weights, factors))
@@ -353,9 +351,7 @@ def non_negative_parafac_hals(
 
                 if verbose:
                     print(
-                        "iteration {}, reconstruction error: {}, decrease = {}".format(
-                            iteration, rec_error, rec_error_decrease
-                        )
+                        f"iteration {iteration}, reconstruction error: {rec_error}, decrease = {rec_error_decrease}"
                     )
 
                 if cvg_criterion == "abs_rec_error":
@@ -367,11 +363,11 @@ def non_negative_parafac_hals(
 
                 if stop_flag:
                     if verbose:
-                        print("PARAFAC converged after {} iterations".format(iteration))
+                        print(f"PARAFAC converged after {iteration} iterations")
                     break
             else:
                 if verbose:
-                    print("reconstruction error={}".format(rec_errors[-1]))
+                    print(f"reconstruction error={rec_errors[-1]}")
         if normalize_factors:
             weights, factors = cp_normalize((weights, factors))
     cp_tensor = CPTensor((weights, factors))

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -51,9 +51,7 @@ def initialize_decomposition(
         unfolded_mode_2 = unfold(padded_tensor, 2)
         if T.shape(unfolded_mode_2)[0] < rank:
             raise ValueError(
-                "Cannot perform SVD init if rank ({}) is greater than the number of columns in each tensor slice ({})".format(
-                    rank, T.shape(unfolded_mode_2)[0]
-                )
+                f"Cannot perform SVD init if rank ({rank}) is greater than the number of columns in each tensor slice ({T.shape(unfolded_mode_2)[0]})"
             )
         C = svd_interface(unfolded_mode_2, n_eigenvecs=rank, method=svd)[0]
         B = T.eye(rank, **context)
@@ -71,7 +69,7 @@ def initialize_decomposition(
         if decomposition.rank != rank:
             raise ValueError("Cannot init with a decomposition of different rank")
         return decomposition
-    raise ValueError('Initialization method "{}" not recognized'.format(init))
+    raise ValueError(f'Initialization method "{init}" not recognized')
 
 
 def _pad_by_zeros(tensor_slices):
@@ -359,9 +357,7 @@ def parafac2(
             if iteration >= 1:
                 if verbose:
                     print(
-                        "PARAFAC2 reconstruction error={}, variation={}.".format(
-                            rec_errors[-1], rec_errors[-2] - rec_errors[-1]
-                        )
+                        f"PARAFAC2 reconstruction error={rec_errors[-1]}, variation={rec_errors[-2] - rec_errors[-1]}."
                     )
 
                 if (
@@ -370,11 +366,11 @@ def parafac2(
                     or rec_errors[-1] ** 2 < absolute_tol
                 ):
                     if verbose:
-                        print("converged in {} iterations.".format(iteration))
+                        print(f"converged in {iteration} iterations.")
                     break
             else:
                 if verbose:
-                    print("PARAFAC2 reconstruction error={}".format(rec_errors[-1]))
+                    print(f"PARAFAC2 reconstruction error={rec_errors[-1]}")
 
     parafac2_tensor = Parafac2Tensor((weights, factors, projections))
 

--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -156,9 +156,7 @@ def partial_tucker(
         warnings.warn(message, Warning)
         rank = [tl.shape(tensor)[mode] for mode in modes]
     elif isinstance(rank, int):
-        message = "Given only one int for 'rank' instead of a list of {} modes. Using this rank for all modes.".format(
-            len(modes)
-        )
+        message = f"Given only one int for 'rank' instead of a list of {len(modes)} modes. Using this rank for all modes."
         warnings.warn(message, Warning)
         rank = tuple(rank for _ in modes)
     else:
@@ -205,14 +203,12 @@ def partial_tucker(
         if iteration > 1:
             if verbose:
                 print(
-                    "reconstruction error={}, variation={}.".format(
-                        rec_errors[-1], rec_errors[-2] - rec_errors[-1]
-                    )
+                    f"reconstruction error={rec_errors[-1]}, variation={rec_errors[-2] - rec_errors[-1]}."
                 )
 
             if tol and abs(rec_errors[-2] - rec_errors[-1]) < tol:
                 if verbose:
-                    print("converged in {} iterations.".format(iteration))
+                    print(f"converged in {iteration} iterations.")
                 break
 
     return (core, factors), rec_errors
@@ -435,14 +431,12 @@ def non_negative_tucker(
         rec_errors.append(rec_error)
         if iteration > 1 and verbose:
             print(
-                "reconstruction error={}, variation={}.".format(
-                    rec_errors[-1], rec_errors[-2] - rec_errors[-1]
-                )
+                f"reconstruction error={rec_errors[-1]}, variation={rec_errors[-2] - rec_errors[-1]}."
             )
 
         if iteration > 1 and abs(rec_errors[-2] - rec_errors[-1]) < tol:
             if verbose:
-                print("converged in {} iterations.".format(iteration))
+                print(f"converged in {iteration} iterations.")
             break
         if normalize_factors:
             nn_core, nn_factors = tucker_normalize((nn_core, nn_factors))
@@ -671,14 +665,12 @@ def non_negative_tucker_hals(
         if iteration > 1:
             if verbose:
                 print(
-                    "reconstruction error={}, variation={}.".format(
-                        rec_errors[-1], rec_errors[-2] - rec_errors[-1]
-                    )
+                    f"reconstruction error={rec_errors[-1]}, variation={rec_errors[-2] - rec_errors[-1]}."
                 )
 
             if tol and abs(rec_errors[-2] - rec_errors[-1]) < tol:
                 if verbose:
-                    print("converged in {} iterations.".format(iteration))
+                    print(f"converged in {iteration} iterations.")
                 break
         if normalize_factors:
             nn_core, nn_factors = tucker_normalize((nn_core, nn_factors))

--- a/tensorly/decomposition/robust_decomposition.py
+++ b/tensorly/decomposition/robust_decomposition.py
@@ -133,7 +133,7 @@ def robust_pca(
         if iteration > 1:
             if rec_X[-1] <= tol and rec_D[-1] <= tol:
                 if verbose:
-                    print("\nConverged in {} iterations".format(iteration))
+                    print(f"\nConverged in {iteration} iterations")
                 break
 
     return D, E

--- a/tensorly/decomposition/tests/test_cp.py
+++ b/tensorly/decomposition/tests/test_cp.py
@@ -569,9 +569,7 @@ def test_randomised_parafac(monkeypatch):
     error = float(T.norm(reconstruction - tensor, 2) / T.norm(tensor, 2))
     assert_(
         error < tolerance,
-        msg="reconstruction of {} (higher than tolerance of {})".format(
-            error, tolerance
-        ),
+        msg=f"reconstruction of {error} (higher than tolerance of {tolerance})"
     )
 
     assert_class_wrapper_correctly_passes_arguments(

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -47,15 +47,12 @@ def test_partial_tucker():
         assert_equal(
             factors[i].shape,
             (tensor.shape[i + 1], ranks[i]),
-            err_msg="factors[{}].shape={}, expected {}".format(
-                i, factors[i].shape, (tensor.shape[i + 1], ranks[i])
-            ),
+            err_msg=f"{factors[i].shape = }, expected {(tensor.shape[i + 1], ranks[i])}"
         )
     assert_equal(
         core.shape,
         [tensor.shape[0]] + ranks,
-        err_msg="Core.shape={}, "
-        "expected {}".format(core.shape, [tensor.shape[0]] + ranks),
+        err_msg=f"{core.shape = }, expected {[tensor.shape[0]] + ranks)}"
     )
 
     # Test random_state fixes the core and the factor matrices
@@ -93,14 +90,12 @@ def test_tucker(monkeypatch):
         assert_equal(
             factors[i].shape,
             (tensor.shape[i], ranks[i]),
-            err_msg="factors[{}].shape={}, expected {}".format(
-                i, factors[i].shape, (tensor.shape[i], ranks[i])
-            ),
+            err_msg=f"{factors[i].shape = }, expected {(tensor.shape[i], ranks[i])}"
         )
         assert_equal(
             tl.shape(core)[i],
             rank,
-            err_msg="Core.shape[{}]={}, " "expected {}".format(i, core.shape[i], rank),
+            err_msg=f"{core.shape[i] = }, expected {rank}"
         )
 
     # try fixing the core
@@ -224,17 +219,13 @@ def test_non_negative_tucker(monkeypatch):
     core, factors = non_negative_tucker(tensor, rank=rank)
     assert_(
         tl.shape(core) == target_shape,
-        "core has the wrong shape, got {}, but expected {}.".format(
-            tl.shape(core), target_shape
-        ),
+        f"core has the wrong shape, got {tl.shape(core)}, but expected {target_shape}."
     )
     for i, f in enumerate(factors):
         expected_shape = (tl.shape(tensor)[i], rank)
         assert_(
             tl.shape(f) == expected_shape,
-            "{}-th factor has the wrong shape, got {}, but expected {}.".format(
-                i, tl.shape(f), expected_shape
-            ),
+            f"{i}-th factor has the wrong shape, got {tl.shape(f)}, but expected {expected_shape}."
         )
 
     assert_class_wrapper_correctly_passes_arguments(
@@ -300,17 +291,13 @@ def test_non_negative_tucker_hals(monkeypatch):
     core, factors = non_negative_tucker_hals(tensor, rank=rank)
     assert_(
         tl.shape(core) == target_shape,
-        "core has the wrong shape, got {}, but expected {}.".format(
-            tl.shape(core), target_shape
-        ),
+        f"core has the wrong shape, got {tl.shape(core)}, but expected {target_shape}."
     )
     for i, f in enumerate(factors):
         expected_shape = (tl.shape(tensor)[i], rank)
         assert_(
             tl.shape(f) == expected_shape,
-            "{}-th factor has the wrong shape, got {}, but expected {}.".format(
-                i, tl.shape(f), expected_shape
-            ),
+            f"{i}-th factor has the wrong shape, got {tl.shape(f)}, but expected {expected_shape}."
         )
     assert_class_wrapper_correctly_passes_arguments(
         monkeypatch,

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -95,7 +95,7 @@ def test_tucker(monkeypatch):
         assert_equal(
             tl.shape(core)[i],
             rank,
-            err_msg=f"{core.shape[i] = }, expected {rank}"
+            err_msg=f"core.shape[i] = {core.shape[i]}, expected {rank}"
         )
 
     # try fixing the core

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -90,7 +90,7 @@ def test_tucker(monkeypatch):
         assert_equal(
             factors[i].shape,
             (tensor.shape[i], ranks[i]),
-            err_msg=f"{factors[i].shape = }, expected {(tensor.shape[i], ranks[i])}"
+            err_msg=f"factors[i].shape = {factors[i].shape}, expected {(tensor.shape[i], ranks[i])}"
         )
         assert_equal(
             tl.shape(core)[i],

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -47,7 +47,7 @@ def test_partial_tucker():
         assert_equal(
             factors[i].shape,
             (tensor.shape[i + 1], ranks[i]),
-            err_msg=f"{factors[i].shape = }, expected {(tensor.shape[i + 1], ranks[i])}"
+            err_msg=f"factors[i].shape = {factors[i].shape}, expected {(tensor.shape[i + 1], ranks[i])}"
         )
     assert_equal(
         core.shape,

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -52,7 +52,7 @@ def test_partial_tucker():
     assert_equal(
         core.shape,
         [tensor.shape[0]] + ranks,
-        err_msg=f"{core.shape = }, expected {[tensor.shape[0]] + ranks)}"
+        err_msg=f"core.shape = {core.shape}, expected {[tensor.shape[0]] + ranks)}"
     )
 
     # Test random_state fixes the core and the factor matrices

--- a/tensorly/metrics/similarity.py
+++ b/tensorly/metrics/similarity.py
@@ -49,7 +49,7 @@ def correlation_index(
     # check method
     options = ["stacked", "max_score", "min_score", "avg_score"]
     if method not in options:
-        raise ValueError("The `method` must be either option among {}".format(options))
+        raise ValueError(f"The `method` must be either option among {options}")
 
     if method == "stacked":
         # vertically stack loading matrices -- shape sum(tensor.shape)xR)

--- a/tensorly/parafac2_tensor.py
+++ b/tensorly/parafac2_tensor.py
@@ -67,11 +67,9 @@ class Parafac2Tensor(FactorizedTensor):
             return self.projections
         else:
             raise IndexError(
-                "You tried to access index {} of a PARAFAC2 tensor.\n"
+                f"You tried to access index {index} of a PARAFAC2 tensor.\n"
                 "You can only access index 0, 1 and 2 of a PARAFAC2 tensor"
-                "(corresponding respectively to the weights, factors and projections)".format(
-                    index
-                )
+                "(corresponding respectively to the weights, factors and projections)"
             )
 
     def __iter__(self):
@@ -83,9 +81,7 @@ class Parafac2Tensor(FactorizedTensor):
         return 3
 
     def __repr__(self):
-        message = "(weights, factors, projections) : rank-{} Parafac2Tensor of shape {} ".format(
-            self.rank, self.shape
-        )
+        message = f"(weights, factors, projections) : rank-{self.rank} Parafac2Tensor of shape {self.shape} "
         return message
 
     def to_tensor(self):
@@ -121,14 +117,14 @@ def _validate_parafac2_tensor(parafac2_tensor):
     if len(factors) != 3:
         raise ValueError(
             "A PARAFAC2 tensor should be composed of exactly three factors."
-            "However, {} factors was given.".format(len(factors))
+            f"However, {len(factors)} factors was given."
         )
 
     if len(projections) != factors[0].shape[0]:
         raise ValueError(
             "A PARAFAC2 tensor should have one projection matrix for each horisontal"
-            " slice. However, {} projection matrices was given and the first mode has"
-            "length {}".format(len(projections), factors[0].shape[0])
+            f" slice. However, {len(projections)} projection matrices was given and the first mode has"
+            f"length {factors[0].shape[0]}"
         )
 
     rank = int(T.shape(factors[0])[1])
@@ -139,20 +135,15 @@ def _validate_parafac2_tensor(parafac2_tensor):
         if current_rank != rank:
             raise ValueError(
                 "All the projection matrices of a PARAFAC2 tensor should have the same number of "
-                "columns as the rank. However, rank={} but projections[{}].shape[1]={}".format(
-                    rank, i, T.shape(projection)[1]
-                )
+                f"columns as the rank. However, rank={rank} but projections[{i}].shape[1]={T.shape(projection)[1]}"
             )
 
         inner_product = T.dot(T.transpose(projection), projection)
         if T.max(T.abs(inner_product - T.eye(rank, **T.context(inner_product)))) > 1e-5:
             raise ValueError(
                 "All the projection matrices must be orthonormal, that is, P.T@P = I. "
-                "However, T.norm(projection[{}].T@projection[{}] - T.eye(rank)) = {}".format(
-                    i,
-                    i,
-                    T.norm(inner_product - T.eye(rank, **T.context(inner_product))),
-                )
+                f"However, T.norm(projection[{i}].T@projection[{i}] - T.eye(rank)) = "
+                f"{T.norm(inner_product - T.eye(rank, **T.context(inner_product)))}"
             )
 
         shape.append(
@@ -165,16 +156,12 @@ def _validate_parafac2_tensor(parafac2_tensor):
         if current_rank != rank:
             raise ValueError(
                 "All the factors of a PARAFAC2 tensor should have the same number of columns."
-                "However, factors[0].shape[1]={} but factors[{}].shape[1]={}.".format(
-                    rank, i, T.shape(factor)[1]
-                )
+                f"However, factors[0].shape[1]={rank} but factors[{i}].shape[1]={T.shape(factors)[1]}."
             )
 
     if weights is not None and T.shape(weights)[0] != rank:
         raise ValueError(
-            "Given factors for a rank-{} PARAFAC2 tensor but len(weights)={}.".format(
-                rank, T.shape(weights)[0]
-            )
+            f"Given factors for a rank-{rank} PARAFAC2 tensor but len(weights)={T.shape(weights)[0]}."
         )
 
     return tuple(shape), rank

--- a/tensorly/random/base.py
+++ b/tensorly/random/base.py
@@ -95,7 +95,7 @@ def random_cp(
     if (rank > min(shape)) and orthogonal:
         warnings.warn(
             "Can only construct orthogonal tensors when rank <= min(shape) but got "
-            "a tensor with min(shape)={} < rank={}".format(min(shape), rank)
+            f"a tensor with {min(shape)=} < {rank=}"
         )
 
     rns = T.check_random_state(random_state)
@@ -147,7 +147,7 @@ def random_tucker(
             if r > s:
                 warnings.warn(
                     "Selected orthogonal=True, but selected a rank larger than the tensor size for mode {0}: "
-                    "rank[{0}]={1} > shape[{0}]={2}.".format(i, r, s)
+                    f"rank[{i}]={r} > shape[{i}]={s}."
                 )
 
     factors = []
@@ -199,14 +199,10 @@ def random_tt(shape, rank, full=False, random_state=None, **context):
 
     # Initialization
     if rank[0] != 1:
-        message = "Provided rank[0] == {} but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1.".format(
-            rank[0]
-        )
+        message = "Provided {rank[0] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1."
         raise ValueError(message)
     if rank[-1] != 1:
-        message = "Provided rank[-1] == {} but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1.".format(
-            rank[0]
-        )
+        message = "Provided {rank[-1] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1."
         raise ValueError(message)
 
     rns = T.check_random_state(random_state)

--- a/tensorly/random/base.py
+++ b/tensorly/random/base.py
@@ -199,7 +199,7 @@ def random_tt(shape, rank, full=False, random_state=None, **context):
 
     # Initialization
     if rank[0] != 1:
-        message = f"Provided {rank[0] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1."
+        message = f"Provided rank[0] = {rank[0]} but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1."
         raise ValueError(message)
     if rank[-1] != 1:
         message = f"Provided {rank[-1] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1."

--- a/tensorly/random/base.py
+++ b/tensorly/random/base.py
@@ -199,10 +199,10 @@ def random_tt(shape, rank, full=False, random_state=None, **context):
 
     # Initialization
     if rank[0] != 1:
-        message = "Provided {rank[0] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1."
+        message = f"Provided {rank[0] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1."
         raise ValueError(message)
     if rank[-1] != 1:
-        message = "Provided {rank[-1] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1."
+        message = f"Provided {rank[-1] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1."
         raise ValueError(message)
 
     rns = T.check_random_state(random_state)

--- a/tensorly/random/base.py
+++ b/tensorly/random/base.py
@@ -95,7 +95,7 @@ def random_cp(
     if (rank > min(shape)) and orthogonal:
         warnings.warn(
             "Can only construct orthogonal tensors when rank <= min(shape) but got "
-            f"a tensor with {min(shape)=} < {rank=}"
+            f"a tensor with min(shape)={min(shape)} < rank={rank}"
         )
 
     rns = T.check_random_state(random_state)

--- a/tensorly/random/base.py
+++ b/tensorly/random/base.py
@@ -202,7 +202,7 @@ def random_tt(shape, rank, full=False, random_state=None, **context):
         message = f"Provided rank[0] = {rank[0]} but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1."
         raise ValueError(message)
     if rank[-1] != 1:
-        message = f"Provided {rank[-1] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1."
+        message = f"Provided rank[-1] = {rank[-1]} but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1."
         raise ValueError(message)
 
     rns = T.check_random_state(random_state)

--- a/tensorly/random/tests/test_base.py
+++ b/tensorly/random/tests/test_base.py
@@ -44,11 +44,7 @@ def test_random_cp():
         assert_equal(
             factor.shape,
             (shape[i], rank),
-            err_msg=(
-                "{}-th factor has shape {}, expected {}".format(
-                    i, factor.shape, (shape[i], rank)
-                )
-            ),
+            err_msg= f"{i}-th factor has shape {factor.shape}, expected {(shape[i], rank)}"
         )
 
     # tests that the columns of each factor matrix are indeed orthogonal
@@ -84,11 +80,7 @@ def test_random_tucker():
         assert_equal(
             factor.shape,
             (shape[i], rank),
-            err_msg=(
-                "{}-th factor has shape {}, expected {}".format(
-                    i, factor.shape, (shape[i], rank)
-                )
-            ),
+            err_msg= f"{i}-th factor has shape {factor.shape}, expected {(shape[i], rank)}"
         )
 
     shape = (10, 11, 12)
@@ -102,16 +94,12 @@ def test_random_tucker():
         assert_equal(
             factor.shape,
             (shape[i], rank[i]),
-            err_msg=(
-                "{}-th factor has shape {}, expected {}.".format(
-                    i, factor.shape, (shape[i], rank[i])
-                )
-            ),
+            err_msg= f"{i}-th factor has shape {factor.shape}, expected {(shape[i], rank[i])}."
         )
     assert_equal(
         core.shape,
         rank,
-        err_msg="core has shape {}, expected {}.".format(core.shape, rank),
+        err_msg=f"core has shape {core.shape}, expected {rank}."
     )
     for factor in factors:
         assert_array_almost_equal(
@@ -133,11 +121,7 @@ def test_random_tt():
         assert_equal(
             factor.shape,
             true_shape,
-            err_msg=(
-                "{}-th factor has shape {}, expected {}".format(
-                    i, factor.shape, true_shape
-                )
-            ),
+            err_msg= f"{i}-th factor has shape {factor.shape}, expected {true_shape}"
         )
 
     # Missing a rank
@@ -164,11 +148,7 @@ def test_random_tr():
         assert_equal(
             factor.shape,
             true_shape,
-            err_msg=(
-                "{}-th factor has shape {}, expected {}".format(
-                    i, factor.shape, true_shape
-                )
-            ),
+            err_msg= f"{i}-th factor has shape {factor.shape}, expected {true_shape}"
         )
 
     # Missing a rank

--- a/tensorly/regression/cp_regression.py
+++ b/tensorly/regression/cp_regression.py
@@ -118,7 +118,7 @@ class CPRegressor:
 
                 if weight_evolution <= self.tol:
                     if self.verbose:
-                        print("\nConverged in {} iterations".format(iteration))
+                        print(f"\nConverged in {iteration} iterations")
                     break
 
         self.weight_tensor_ = weight_tensor_

--- a/tensorly/regression/tests/test_cp_regression.py
+++ b/tensorly/regression/tests/test_cp_regression.py
@@ -40,7 +40,7 @@ def test_CPRegressor():
     y_pred = estimator.predict(X_test)
     error = RMSE(y_test, y_pred)
     assert_(
-        error <= tol, msg="CP Regressor : RMSE is too large, {} > {}".format(error, tol)
+        error <= tol, msg=f"CP Regressor : RMSE is too large, {error} > {tol}"
     )
 
     params = estimator.get_params()

--- a/tensorly/regression/tests/test_tucker_regression.py
+++ b/tensorly/regression/tests/test_tucker_regression.py
@@ -41,7 +41,7 @@ def test_TuckerRegressor():
     estimator.fit(X_train, y_train)
     y_pred = estimator.predict(X_test)
     error = RMSE(y_test, y_pred)
-    assert_(error <= tol, msg="Tucker Regression : RMSE={} > {}".format(error, tol))
+    assert_(error <= tol, msg=f"Tucker Regression : RMSE={error} > {tol}"
 
     params = estimator.get_params()
     assert_(

--- a/tensorly/regression/tucker_regression.py
+++ b/tensorly/regression/tucker_regression.py
@@ -128,7 +128,7 @@ class TuckerRegressor:
 
                 if weight_evolution <= self.tol:
                     if self.verbose:
-                        print("\nConverged in {} iterations".format(iteration))
+                        print(f"\nConverged in {iteration} iterations")
                     break
 
         self.weight_tensor_ = weight_tensor_

--- a/tensorly/tenalg/core_tenalg/_khatri_rao.py
+++ b/tensorly/tenalg/core_tenalg/_khatri_rao.py
@@ -86,12 +86,12 @@ def khatri_rao(matrices, weights=None, skip_matrix=None, reverse=False, mask=Non
         if T.ndim(matrix) != 2:
             raise ValueError(
                 "All the matrices must have exactly 2 dimensions!"
-                "Matrix {} has dimension {} != 2.".format(i, T.ndim(matrix))
+                f"Matrix {i} has dimension {T.ndim(matrix)} != 2."
             )
         if matrix.shape[1] != n_columns:
             raise ValueError(
                 "All matrices must have same number of columns!"
-                "Matrix {} has {} columns != {}.".format(i, matrix.shape[1], n_columns)
+                f"Matrix {i} has {matrix.shape[1]} columns != {n_columns}."
             )
 
     if reverse:

--- a/tensorly/tenalg/core_tenalg/generalised_inner_product.py
+++ b/tensorly/tenalg/core_tenalg/generalised_inner_product.py
@@ -31,9 +31,7 @@ def inner(tensor1, tensor2, n_modes=None):
                 "Taking a generalised product between two tensors without specifying common modes"
                 " is equivalent to taking inner product."
                 "This requires tensor1.shape == tensor2.shape."
-                "However, got tensor1.shape={} and tensor2.shape={}".format(
-                    tensor1.shape, tensor2.shape
-                )
+                f"However, got {tensor1.shape=} and {tensor2.shape=}"
             )
         return T.sum(tensor1 * tensor2)
 
@@ -46,8 +44,8 @@ def inner(tensor1, tensor2, n_modes=None):
 
     if common_modes != shape_t2[:n_modes]:
         raise ValueError(
-            "Incorrect shapes for inner product along {} common modes."
-            "tensor_1.shape={}, tensor_2.shape={}".format(n_modes, shape_t1, shape_t2)
+            f"Incorrect shapes for inner product along {n_modes} common modes."
+            f"{tensor_1.shape=}, {tensor_2.shape=}"
         )
     inner_product = T.dot(
         T.reshape(tensor1, (-1, common_size)), T.reshape(tensor2, (common_size, -1))

--- a/tensorly/tenalg/core_tenalg/n_mode_product.py
+++ b/tensorly/tenalg/core_tenalg/n_mode_product.py
@@ -40,13 +40,8 @@ def mode_dot(tensor, matrix_or_vector, mode, transpose=False):
         dim = 0 if transpose else 1
         if matrix_or_vector.shape[dim] != tensor.shape[mode]:
             raise ValueError(
-                "shapes {0} and {1} not aligned in mode-{2} multiplication: {3} (mode {2}) != {4} (dim 1 of matrix)".format(
-                    tensor.shape,
-                    matrix_or_vector.shape,
-                    mode,
-                    tensor.shape[mode],
-                    matrix_or_vector.shape[dim],
-                )
+                f"shapes {tensor.shape} and {matrix_or_vector.shape} not aligned in mode-{mode} multiplication: "
+                f"{tensor.shape[mode]} (mode {mode}) != {matrix_or_vector.shape[dim]} (dim 1 of matrix)"
             )
 
         if transpose:
@@ -58,13 +53,8 @@ def mode_dot(tensor, matrix_or_vector, mode, transpose=False):
     elif T.ndim(matrix_or_vector) == 1:  # Tensor times vector
         if matrix_or_vector.shape[0] != tensor.shape[mode]:
             raise ValueError(
-                "shapes {0} and {1} not aligned for mode-{2} multiplication: {3} (mode {2}) != {4} (vector size)".format(
-                    tensor.shape,
-                    matrix_or_vector.shape,
-                    mode,
-                    tensor.shape[mode],
-                    matrix_or_vector.shape[0],
-                )
+                f"shapes {tensor.shape} and {matrix_or_vector.shape} not aligned for mode-{mode} multiplication: "
+                f"{tensor.shape[mode]} (mode {mode}) != {matrix_or_vector.shape[0]} (vector size)"
             )
         if len(new_shape) > 1:
             new_shape.pop(mode)
@@ -77,9 +67,7 @@ def mode_dot(tensor, matrix_or_vector, mode, transpose=False):
     else:
         raise ValueError(
             "Can only take n_mode_product with a vector or a matrix."
-            "Provided array of dimension {} not in [1, 2].".format(
-                T.ndim(matrix_or_vector)
-            )
+            f"Provided array of dimension {T.ndim(matrix_or_vector)} not in [1, 2]."
         )
 
     res = T.dot(matrix_or_vector, unfold(tensor, mode))

--- a/tensorly/tenalg/einsum_tenalg/_khatri_rao.py
+++ b/tensorly/tenalg/einsum_tenalg/_khatri_rao.py
@@ -86,12 +86,12 @@ def khatri_rao(matrices, weights=None, skip_matrix=None, reverse=False, mask=Non
         if T.ndim(matrix) != 2:
             raise ValueError(
                 "All the matrices must have exactly 2 dimensions!"
-                "Matrix {} has dimension {} != 2.".format(i, T.ndim(matrix))
+                f"Matrix {i} has dimension {T.ndim(matrix)} != 2."
             )
         if matrix.shape[1] != n_columns:
             raise ValueError(
                 "All matrices must have same number of columns!"
-                "Matrix {} has {} columns != {}.".format(i, matrix.shape[1], n_columns)
+                f"Matrix {i} has {matrix.shape[1]} columns != {n_columns}."
             )
 
     if reverse:

--- a/tensorly/tenalg/einsum_tenalg/generalised_inner_product.py
+++ b/tensorly/tenalg/einsum_tenalg/generalised_inner_product.py
@@ -31,9 +31,7 @@ def inner(tensor1, tensor2, n_modes=None):
                 "Taking a generalised product between two tensors without specifying common modes"
                 " is equivalent to taking inner product."
                 "This requires tensor1.shape == tensor2.shape."
-                "However, got tensor1.shape={} and tensor2.shape={}".format(
-                    tensor1.shape, tensor2.shape
-                )
+                f"However, got {tensor1.shape=} and {tensor2.shape=}"
             )
         return T.sum(tensor1 * tensor2)
 
@@ -43,8 +41,8 @@ def inner(tensor1, tensor2, n_modes=None):
 
     if shape_t1[offset:] != shape_t2[:n_modes]:
         raise ValueError(
-            "Incorrect shapes for inner product along {} common modes."
-            "tensor_1.shape={}, tensor_2.shape={}".format(n_modes, shape_t1, shape_t2)
+            f"Incorrect shapes for inner product along {n_modes} common modes."
+            f"tensor_1.shape={shape_t1}, tensor_2.shape={shape_t2}"
         )
 
     # Inner product along `n_modes` common modes

--- a/tensorly/tenalg/einsum_tenalg/n_mode_product.py
+++ b/tensorly/tenalg/einsum_tenalg/n_mode_product.py
@@ -49,13 +49,8 @@ def mode_dot(tensor, matrix_or_vector, mode, transpose=False):
 
         if matrix_or_vector.shape[dim] != tensor.shape[mode]:
             raise ValueError(
-                "shapes {0} and {1} not aligned in mode-{2} multiplication: {3} (mode {2}) != {4} (dim 1 of matrix)".format(
-                    tensor.shape,
-                    matrix_or_vector.shape,
-                    mode,
-                    tensor.shape[mode],
-                    matrix_or_vector.shape[dim],
-                )
+                f"shapes {tensor.shape} and {matrix_or_vector.shape} not aligned in mode-{mode} multiplication: "
+                f"{tensor.shape[mode]} (mode {mode}) != {matrix_or_vector.shape[dim]} (dim 1 of matrix)"
             )
         if transpose:
             matrix_or_vector = tl.conj(tl.transpose(matrix_or_vector))
@@ -64,13 +59,8 @@ def mode_dot(tensor, matrix_or_vector, mode, transpose=False):
     elif tl.ndim(matrix_or_vector) == 1:  # Tensor times vector
         if matrix_or_vector.shape[0] != tensor.shape[mode]:
             raise ValueError(
-                "shapes {0} and {1} not aligned for mode-{2} multiplication: {3} (mode {2}) != {4} (vector size)".format(
-                    tensor.shape,
-                    matrix_or_vector.shape,
-                    mode,
-                    tensor.shape[mode],
-                    matrix_or_vector.shape[0],
-                )
+                f"shapes {tensor.shape} and {matrix_or_vector.shape} not aligned for mode-{mode} multiplication: "
+                f"{tensor.shape[mode]} (mode {mode}) != {matrix_or_vector.shape[0]} (vector size)"
             )
         matrix_or_vector_modes = [tensor_modes[mode]]
         result_modes.pop(mode)
@@ -78,9 +68,7 @@ def mode_dot(tensor, matrix_or_vector, mode, transpose=False):
     else:
         raise ValueError(
             "Can only take n_mode_product with a vector or a matrix."
-            "Provided array of dimension {} not in [1, 2].".format(
-                tl.ndim(matrix_or_vector)
-            )
+            "Provided array of dimension {tl.ndim(matrix_or_vector)} not in [1, 2]."
         )
 
     result_modes = "".join(result_modes)

--- a/tensorly/tenalg/einsum_tenalg/n_mode_product.py
+++ b/tensorly/tenalg/einsum_tenalg/n_mode_product.py
@@ -68,7 +68,7 @@ def mode_dot(tensor, matrix_or_vector, mode, transpose=False):
     else:
         raise ValueError(
             "Can only take n_mode_product with a vector or a matrix."
-            "Provided array of dimension {tl.ndim(matrix_or_vector)} not in [1, 2]."
+            f"Provided array of dimension {tl.ndim(matrix_or_vector)} not in [1, 2]."
         )
 
     result_modes = "".join(result_modes)

--- a/tensorly/tenalg/tests/test_n_mode_product.py
+++ b/tensorly/tenalg/tests/test_n_mode_product.py
@@ -122,7 +122,7 @@ def test_multi_mode_dot():
         assert_equal(
             true_res.shape,
             res.shape,
-            err_msg="shape should be {true_res.shape}, is {res.shape}"
+            err_msg=f"shape should be {true_res.shape}, is {res.shape}"
         )
         assert_array_almost_equal(true_res, res, decimal=5)
         assert_array_almost_equal(true_res, res2, decimal=5)

--- a/tensorly/tenalg/tests/test_n_mode_product.py
+++ b/tensorly/tenalg/tests/test_n_mode_product.py
@@ -122,7 +122,7 @@ def test_multi_mode_dot():
         assert_equal(
             true_res.shape,
             res.shape,
-            err_msg="shape should be {}, is {}".format(true_res.shape, res.shape),
+            err_msg="shape should be {true_res.shape}, is {res.shape}"
         )
         assert_array_almost_equal(true_res, res, decimal=5)
         assert_array_almost_equal(true_res, res2, decimal=5)

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -337,11 +337,11 @@ def test_where():
     for i in range(N):
         if i < 2 * 3:
             assert_equal(
-                out[i], 0, "Unexpected result on vector for element {}".format(i)
+                out[i], 0, f"Unexpected result on vector for element {i}"
             )
         else:
             assert_equal(
-                out[i], 1, "Unexpected result on vector for element {}".format(i)
+                out[i], 1, f"Unexpected result on vector for element {i}"
             )
 
     # 2D

--- a/tensorly/tests/test_cp_tensor.py
+++ b/tensorly/tests/test_cp_tensor.py
@@ -71,14 +71,12 @@ def test_validate_cp_tensor():
     assert_equal(
         shape,
         true_shape,
-        err_msg="Returned incorrect shape (got {}, expected {})".format(
-            shape, true_shape
-        ),
+        err_msg=f"Returned incorrect shape (got {shape}, expected {true_shape})"
     )
     assert_equal(
         rank,
         true_rank,
-        err_msg="Returned incorrect rank (got {}, expected {})".format(rank, true_rank),
+        err_msg=f"Returned incorrect rank (got {rank}, expected {true_rank})"
     )
 
     # One of the factors has the wrong rank
@@ -187,7 +185,7 @@ def test_cp_to_unfolded():
         assert_array_equal(
             true_res,
             res,
-            err_msg="khatri_rao product unfolded incorrectly for mode {}.".format(mode),
+            err_msg=f"khatri_rao product unfolded incorrectly for mode {mode}."
         )
 
 

--- a/tensorly/tests/test_parafac2_tensor.py
+++ b/tensorly/tests/test_parafac2_tensor.py
@@ -34,14 +34,12 @@ def test_validate_parafac2_tensor():
     assert_equal(
         shape,
         true_shape,
-        err_msg="Returned incorrect shape (got {}, expected {})".format(
-            shape, true_shape
-        ),
+        err_msg=f"Returned incorrect shape (got {shape}, expected {true_shape})"
     )
     assert_equal(
         rank,
         true_rank,
-        err_msg="Returned incorrect rank (got {}, expected {})".format(rank, true_rank),
+        err_msg=f"Returned incorrect rank (got {rank}, expected {true_rank})"
     )
 
     # One of the factors has the wrong rank

--- a/tensorly/tests/test_tr_tensor.py
+++ b/tensorly/tests/test_tr_tensor.py
@@ -17,14 +17,12 @@ def test_validate_tr_tensor():
     assert_equal(
         shape,
         true_shape,
-        err_msg="Returned incorrect shape (got {}, expected {})".format(
-            shape, true_shape
-        ),
+        err_msg=f"Returned incorrect shape (got {shape}, expected {true_shape})"
     )
     assert_equal(
         rank,
         true_rank,
-        err_msg="Returned incorrect rank (got {}, expected {})".format(rank, true_rank),
+        err_msg=f"Returned incorrect rank (got {rank}, expected {true_rank})"
     )
 
     # One of the factors has the wrong ndim

--- a/tensorly/tests/test_tt_tensor.py
+++ b/tensorly/tests/test_tt_tensor.py
@@ -26,14 +26,12 @@ def test_validate_tt_tensor():
     assert_equal(
         shape,
         true_shape,
-        err_msg="Returned incorrect shape (got {}, expected {})".format(
-            shape, true_shape
-        ),
+        err_msg=f"Returned incorrect shape (got {shape}, expected {true_shape})"
     )
     assert_equal(
         rank,
         true_rank,
-        err_msg="Returned incorrect rank (got {}, expected {})".format(rank, true_rank),
+        err_msg=f"Returned incorrect rank (got {rank}, expected {true_rank})"
     )
 
     # One of the factors has the wrong ndim

--- a/tensorly/tests/test_tucker_tensor.py
+++ b/tensorly/tests/test_tucker_tensor.py
@@ -34,14 +34,12 @@ def test_validate_tucker_tensor():
     assert_equal(
         shape,
         true_shape,
-        err_msg="Returned incorrect shape (got {}, expected {})".format(
-            shape, true_shape
-        ),
+        err_msg=f"Returned incorrect shape (got {shape}, expected {true_shape})"
     )
     assert_equal(
         rank,
         true_rank,
-        err_msg="Returned incorrect rank (got {}, expected {})".format(rank, true_rank),
+        err_msg=f"Returned incorrect rank (got {rank}, expected {true_rank})"
     )
 
     # One of the factors has the wrong rank

--- a/tensorly/tr_tensor.py
+++ b/tensorly/tr_tensor.py
@@ -92,7 +92,7 @@ def _validate_tr_tensor(tr_tensor):
     if n_factors < 2:
         raise ValueError(
             "A Tensor Ring tensor should be composed of at least two factors."
-            "However, {} factor was given.".format(n_factors)
+            f"However, {n_factors} factor was given."
         )
 
     rank = []
@@ -104,7 +104,7 @@ def _validate_tr_tensor(tr_tensor):
         if not tl.ndim(factor) == 3:
             raise ValueError(
                 "TR expresses a tensor as third order factors (tr-cores).\n"
-                "However, tl.ndim(factors[{}]) = {}".format(index, tl.ndim(factor))
+                f"However, tl.ndim(factors[{index}]) = {tl.ndim(factor)}"
             )
 
         # Consecutive factors should have matching ranks
@@ -112,10 +112,8 @@ def _validate_tr_tensor(tr_tensor):
             raise ValueError(
                 "Consecutive factors should have matching ranks\n"
                 " -- e.g. tl.shape(factors[0])[2]) == tl.shape(factors[1])[0])\n"
-                "However, tl.shape(factor[{}])[2] == {} but"
-                " tl.shape(factor[{}])[0] == {}".format(
-                    index - 1, tl.shape(factors[index - 1])[2], index, current_rank
-                )
+                f"However, tl.shape(factor[{index-1}])[2] == {tl.shape(factors[index-1])[2]} but"
+                f" tl.shape(factor[{index}])[0] == {current_rank}"
             )
 
         shape.append(current_shape)
@@ -244,9 +242,7 @@ class TRTensor(FactorizedTensor):
         return len(self.factors)
 
     def __repr__(self):
-        message = "factors list : rank-{} tensor ring tensor of shape {}".format(
-            self.rank, self.shape
-        )
+        message = f"factors list : rank-{self.rank} tensor ring tensor of shape {self.shape}"
         return message
 
     def to_tensor(self):

--- a/tensorly/tt_matrix.py
+++ b/tensorly/tt_matrix.py
@@ -158,7 +158,7 @@ def _validate_tt_matrix(tt_tensor):
     if n_factors < 1:
         raise ValueError(
             "A Tensor-Train (MPS) tensor should be composed of at least one factor."
-            "However, {} factor was given.".format(n_factors)
+            f"However, {n_factors} factor was given."
         )
 
     rank = []
@@ -173,28 +173,26 @@ def _validate_tt_matrix(tt_tensor):
         if not tl.ndim(factor) == 4:
             raise ValueError(
                 "A TTMatrix expresses a tensor as fourth order factors (tt-cores).\n"
-                "However, tl.ndim(factors[{}]) = {}".format(index, tl.ndim(factor))
+                f"However, tl.ndim(factors[{index}]) = {tl.ndim(factor)}"
             )
         # Consecutive factors should have matching ranks
         if index and tl.shape(factors[index - 1])[-1] != current_rank:
             raise ValueError(
                 "Consecutive factors should have matching ranks\n"
                 " -- e.g. tl.shape(factors[0])[-1]) == tl.shape(factors[1])[0])\n"
-                "However, tl.shape(factor[{}])[-1] == {} but"
-                " tl.shape(factor[{}])[0] == {} ".format(
-                    index - 1, tl.shape(factors[index - 1])[-1], index, current_rank
-                )
+                f"However, tl.shape(factor[{index-1}])[-1] == {tl.shape(factors[index - 1])[-1]} but"
+                f" tl.shape(factor[{index}])[0] == {current_rank} "
             )
         # Check for boundary conditions
         if (index == 0) and current_rank != 1:
             raise ValueError(
                 "Boundary conditions dictate factor[0].shape[0] == 1."
-                "However, got factor[0].shape[0] = {}.".format(current_rank)
+                f"However, got factor[0].shape[0] = {current_rank}."
             )
         if (index == n_factors - 1) and next_rank != 1:
             raise ValueError(
                 "Boundary conditions dictate factor[-1].shape[2] == 1."
-                "However, got factor[{}].shape[2] = {}.".format(n_factors, next_rank)
+                f"However, got factor[{n_factors}].shape[2] = {next_rank}."
             )
 
         left_shape.append(current_left_shape)

--- a/tensorly/tt_tensor.py
+++ b/tensorly/tt_tensor.py
@@ -29,28 +29,26 @@ def _validate_tt_tensor(tt_tensor):
         if not tl.ndim(factor) == 3:
             raise ValueError(
                 "TT expresses a tensor as third order factors (tt-cores).\n"
-                "However, tl.ndim(factors[{}]) = {}".format(index, tl.ndim(factor))
+                f"However, tl.ndim(factors[{index}]) = {tl.ndim(factor)}"
             )
         # Consecutive factors should have matching ranks
         if index and tl.shape(factors[index - 1])[2] != current_rank:
             raise ValueError(
                 "Consecutive factors should have matching ranks\n"
                 " -- e.g. tl.shape(factors[0])[2]) == tl.shape(factors[1])[0])\n"
-                "However, tl.shape(factor[{}])[2] == {} but"
-                " tl.shape(factor[{}])[0] == {} ".format(
-                    index - 1, tl.shape(factors[index - 1])[2], index, current_rank
-                )
+                f"However, tl.shape(factor[{index-1}])[2] == {tl.shape(factors[index - 1])[2]} but"
+                f" tl.shape(factor[{index}])[0] == {current_rank} "
             )
         # Check for boundary conditions
         if (index == 0) and current_rank != 1:
             raise ValueError(
                 "Boundary conditions dictate factor[0].shape[0] == 1."
-                "However, got factor[0].shape[0] = {}.".format(current_rank)
+                f"However, got factor[0].shape[0] = {current_rank}."
             )
         if (index == n_factors - 1) and next_rank != 1:
             raise ValueError(
                 "Boundary conditions dictate factor[-1].shape[2] == 1."
-                "However, got factor[{}].shape[2] = {}.".format(n_factors, next_rank)
+                f"However, got factor[{n_factors}].shape[2] = {next_rank}."
             )
 
         shape.append(current_shape)
@@ -259,21 +257,15 @@ def validate_tt_rank(
         if isinstance(rank, int):
             rank = [1] + [rank] * (n_dim - 1) + [1]
         elif n_dim + 1 != len(rank):
-            message = "Provided incorrect number of ranks. Should verify len(rank) == tl.ndim(tensor)+1, but len(rank) = {} while tl.ndim(tensor) + 1  = {}".format(
-                len(rank), n_dim + 1
-            )
+            message = f"Provided incorrect number of ranks. Should verify len(rank) == tl.ndim(tensor)+1, but {len(rank) = } while tl.ndim(tensor) + 1  = {n_dim+1}"
             raise (ValueError(message))
 
         # Initialization
         if rank[0] != 1:
-            message = "Provided rank[0] == {} but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1.".format(
-                rank[0]
-            )
+            message = f"Provided {rank[0] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[0] to 1."
             raise ValueError(message)
         if rank[-1] != 1:
-            message = "Provided rank[-1] == {} but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1.".format(
-                rank[0]
-            )
+            message = f"Provided {rank[-1] = } but boundaring conditions dictatate rank[0] == rank[-1] == 1: setting rank[-1] to 1."
             raise ValueError(message)
 
     if allow_overparametrization:
@@ -315,9 +307,7 @@ class TTTensor(FactorizedTensor):
 
     def __repr__(self):
         message = (
-            "factors list : rank-{} matrix-product-state tensor of shape {} ".format(
-                self.rank, self.shape
-            )
+            f"factors list : rank-{self.rank} matrix-product-state tensor of shape {self.shape} "
         )
         return message
 

--- a/tensorly/tucker_tensor.py
+++ b/tensorly/tucker_tensor.py
@@ -22,15 +22,13 @@ def _validate_tucker_tensor(tucker_tensor):
     if len(factors) < 2:
         raise ValueError(
             "A Tucker tensor should be composed of at least two factors and a core."
-            "However, {} factor was given.".format(len(factors))
+            f"However, {len(factors)} factor was given."
         )
 
     if len(factors) != tl.ndim(core):
         raise ValueError(
             "Tucker decompositions should have one factor per more of the core tensor."
-            "However, core has {} modes but {} factors have been provided".format(
-                tl.ndim(core), len(factors)
-            )
+            f"However, core has {tl.ndim(core)} modes but {len(factors)} factors have been provided"
         )
 
     shape = []
@@ -41,9 +39,7 @@ def _validate_tucker_tensor(tucker_tensor):
             raise ValueError(
                 "Factor `n` of Tucker decomposition should verify:\n"
                 "factors[n].shape[1] = core.shape[n]."
-                "However, factors[{0}].shape[1]={1} but core.shape[{0}]={2}.".format(
-                    i, tl.shape(factor)[1], tl.shape(core)[i]
-                )
+                f"However, factors[{i}].shape[1]={tl.shape(factor)[1]} but core.shape[{i}]={tl.shape(core)[i]}."
             )
         shape.append(current_shape)
         rank.append(current_rank)
@@ -193,25 +189,15 @@ def tucker_mode_dot(tucker_tensor, matrix_or_vector, mode, keep_dim=False, copy=
         # Test for the validity of the operation
         if matrix_or_vector.shape[1] != shape[mode]:
             raise ValueError(
-                "shapes {0} and {1} not aligned in mode-{2} multiplication: {3} (mode {2}) != {4} (dim 1 of matrix)".format(
-                    shape,
-                    matrix_or_vector.shape,
-                    mode,
-                    shape[mode],
-                    matrix_or_vector.shape[1],
-                )
+                f"shapes {shape} and {matrix_or_vector.shape} not aligned in mode-{mode} multiplication: "
+                f"{shape[mode]} ({mode = }) != {matrix_or_vector.shape[1]} (dim 1 of matrix)"
             )
 
     elif tl.ndim(matrix_or_vector) == 1:  # Tensor times vector
         if matrix_or_vector.shape[0] != shape[mode]:
             raise ValueError(
-                "shapes {0} and {1} not aligned for mode-{2} multiplication: {3} (mode {2}) != {4} (vector size)".format(
-                    shape,
-                    matrix_or_vector.shape,
-                    mode,
-                    shape[mode],
-                    matrix_or_vector.shape[0],
-                )
+                f"shapes {shape} and {matrix_or_vector.shape} not aligned for mode-{mode} multiplication: "
+                f"{shape[mode]} ({mode = }) != {matrix_or_vector.shape[0]} (vector size)"
             )
         if not keep_dim:
             contract = True  # Contract over that mode
@@ -250,9 +236,9 @@ class TuckerTensor(FactorizedTensor):
             return self.factors
         else:
             raise IndexError(
-                "You tried to access index {} of a Tucker tensor.\n"
+                f"You tried to access index {index} of a Tucker tensor.\n"
                 "You can only access index 0 and 1 of a Tucker tensor"
-                "(corresponding respectively to core and factors)".format(index)
+                "(corresponding respectively to core and factors)"
             )
 
     def __setitem__(self, index, value):
@@ -262,9 +248,9 @@ class TuckerTensor(FactorizedTensor):
             self.factors = value
         else:
             raise IndexError(
-                "You tried to set index {} of a Tucker tensor.\n"
+                f"You tried to set index {index} of a Tucker tensor.\n"
                 "You can only set index 0 and 1 of a Tucker tensor"
-                "(corresponding respectively to core and factors)".format(index)
+                "(corresponding respectively to core and factors)"
             )
 
     def __iter__(self):
@@ -275,9 +261,7 @@ class TuckerTensor(FactorizedTensor):
         return 2
 
     def __repr__(self):
-        message = "Decomposed rank-{} TuckerTensor of shape {} ".format(
-            self.rank, self.shape
-        )
+        message = f"Decomposed rank-{self.rank} TuckerTensor of shape {self.shape} "
         return message
 
     def to_tensor(self):
@@ -437,9 +421,7 @@ def validate_tucker_rank(tensor_shape, rank="same", rounding="round", fixed_mode
 
     elif isinstance(rank, int):
         n_modes = len(tensor_shape)
-        message = "Given only one int for 'rank' for decomposition a tensor of order {}. Using this rank for all modes.".format(
-            n_modes
-        )
+        message = f"Given only one int for 'rank' for decomposition a tensor of order {n_modes}. Using this rank for all modes."
         warnings.warn(message, RuntimeWarning)
         if fixed_modes is None:
             rank = [rank] * n_modes


### PR DESCRIPTION
Closes #427 
-All instances of using str.format() for printouts/error messages are changed to f-strings;
-Certain f-strings utilize the property that putting '=' sign after expression prints first the expression and then the result, to avoid duplicate typing of things like f"len(list) = {len(list)}", which is now simply f"{len(list) = }".
-requirements.txt now lists the  minimal version of Python (3.6) to support f-strings.