### PR TITLE
Fix the documentation build

### DIFF
--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -3,5 +3,5 @@ slimit
 rcssmin
 numpydoc
 sphinx-gallery
-matplotlib
+matplotlib==3.5.2
 tensorly_sphinx_theme


### PR DESCRIPTION
The docs stopped building due to a change in the behavior of matplotlib ([issue #23973](https://github.com/matplotlib/matplotlib/issues/23973)).

I am proposing to pin the version of matplotlib so that we can ensure reproducible behavior. We can certainly update the plotting code in the documentation to work with the most recent version; this fix additionally prevents similar situations in the future.

@cyrillustan 