### PR TITLE
Use a secure link to tensorly.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ TensorLy
 
 TensorLy is a Python library that aims at making tensor learning simple and accessible. It allows to easily perform tensor decomposition, tensor learning and tensor algebra. Its backend system allows to seamlessly perform computation with NumPy, PyTorch, JAX, MXNet, TensorFlow or CuPy, and run methods at scale on CPU or GPU.
 
-- **Website:** http://tensorly.org
+- **Website:** https://tensorly.org
 - **Source-code:**  https://github.com/tensorly/tensorly
 - **Jupyter Notebooks:** https://github.com/JeanKossaifi/tensorly-notebooks
 


### PR DESCRIPTION
The secure link works, so provide that to the user from the README to improve the security posture for users.

Note: Ideally the website link in the project description would also be updated to https://tensorly.org as it currently also points to the non-secure HTTP site.

<img width="292" alt="Screen Shot 2022-12-19 at 8 38 47 AM" src="https://user-images.githubusercontent.com/10340167/208438450-708a925c-3729-486d-b6c8-f12b5fa5be8c.png">