### PR TITLE
Hotfix permute factors

### DIFF
--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -677,12 +677,13 @@ def cp_permute_factors(ref_cp_tensor, tensors_to_permute):
     n_tensors = len(tensors_to_permute)
     n_factors = len(ref_cp_tensor.factors)
     permutation = []
-    ref_factors = T.concatenate(ref_cp_tensor.factors)
+    #ref_factors = T.concatenate(ref_cp_tensor.factors) # using list input now
     for i in range(n_tensors):
         _, col = congruence_coefficient(
-            ref_factors, T.concatenate(tensors_to_permute[i].factors)
+            ref_cp_tensor.factors, tensors_to_permute[i].factors
         )
         col = T.tensor(col, dtype=T.int64)
+
         for f in range(n_factors):
             permuted_tensors[i].factors[f] = permuted_tensors[i].factors[f][:, col]
         permuted_tensors[i].weights = permuted_tensors[i].weights[col]

--- a/tensorly/cp_tensor.py
+++ b/tensorly/cp_tensor.py
@@ -677,13 +677,11 @@ def cp_permute_factors(ref_cp_tensor, tensors_to_permute):
     n_tensors = len(tensors_to_permute)
     n_factors = len(ref_cp_tensor.factors)
     permutation = []
-    #ref_factors = T.concatenate(ref_cp_tensor.factors) # using list input now
     for i in range(n_tensors):
         _, col = congruence_coefficient(
             ref_cp_tensor.factors, tensors_to_permute[i].factors
         )
         col = T.tensor(col, dtype=T.int64)
-
         for f in range(n_factors):
             permuted_tensors[i].factors[f] = permuted_tensors[i].factors[f][:, col]
         permuted_tensors[i].weights = permuted_tensors[i].weights[col]

--- a/tensorly/metrics/factors.py
+++ b/tensorly/metrics/factors.py
@@ -14,12 +14,17 @@ def congruence_coefficient(matrix1, matrix2, absolute_value=True):
         \\frac{\\mathbf{v}_1^T \\mathbf{v}_1^T}{\\|\\mathbf{v}_1^T\\| \\|\\mathbf{v}_1^T\\|}
 
     When we compute the congruence between two matrices, we find the optimal permutation of
-    the columns and return the mean congruence and the permutation.
+    the columns and return the mean congruence and the permutation. The output permutation is the one
+    that permutes the columns of matrix2 onto the closest columns in matrix1.
+
+    If a list of matrices is provided for each input, we define the congruence coefficient as the
+    product of the absolute values of pairs of matrices. The lists must therefore have the same size.
+    The output permutation also applies to each matrix of the lists.
 
     Parameters
     ----------
-    matrix1 : tensorly.Tensor
-    matrix2 : tensorly.Tensor
+    matrix1 : tensorly.Tensor or list of tensorly.Tensor
+    matrix2 : tensorly.Tensor of list of tensorly.Tensor to permute.
     absolute_value : bool
         Whether to take the absolute value of all vector products before finding the optimal permutation.
 
@@ -28,16 +33,33 @@ def congruence_coefficient(matrix1, matrix2, absolute_value=True):
     congruence : float
     permutation : list
     """
-    num_cols = T.shape(matrix1)[1]
-    if T.shape(matrix1) != T.shape(matrix2):
-        raise ValueError("Matrices must have same shape")
+    # Check if matrix1 and matrix2 are lists of the same length
+    if isinstance(matrix1,list):
+        if not isinstance(matrix2, list) or len(matrix1)!=len(matrix2):
+            raise ValueError("Input lists of matrices must have the same length")
+    else:
+        matrix1=[matrix1]
+        matrix2=[matrix2]
+    all_congruences_list=[]
+    # Store an arbitrary column dimension, they should all be the same
+    num_col_mat1 = T.shape(matrix1[0])[1]
+    for mat1, mat2 in zip(matrix1,matrix2):
+        num_cols = T.shape(mat1)[1]
+        if T.shape(mat1) != T.shape(mat2):
+            raise ValueError("Matrices must have same shape")
+        if T.shape(mat1)[1] != num_col_mat1 or T.shape(mat2)[1] != num_col_mat1:
+            # check that all matrices have the same number of columns
+            raise ValueError("Matrices must have the same number of columns")
 
-    matrix1 = matrix1 / T.norm(matrix1, axis=0)
-    matrix2 = matrix2 / T.norm(matrix2, axis=0)
-    all_congruences = T.dot(T.transpose(matrix1), matrix2)
-    if absolute_value:
-        all_congruences = T.abs(all_congruences)
-    all_congruences = T.to_numpy(all_congruences)
+        mat1 = mat1 / T.norm(mat1, axis=0)
+        mat2 = mat2 / T.norm(mat2, axis=0)
+        all_congruences_list.append(T.dot(T.transpose(mat1), mat2))
+        if absolute_value:
+            all_congruences_list[-1]=T.abs(all_congruences_list[-1])
+        all_congruences_list[-1] = T.to_numpy(all_congruences_list[-1])
+    all_congruences = 1
+    for congruence in all_congruences_list:
+        all_congruences *= congruence
     row_ind, col_ind = linear_sum_assignment(
         -all_congruences
     )  # Use -corr because scipy didn't doesn't support maximising prior to v1.4

--- a/tensorly/metrics/factors.py
+++ b/tensorly/metrics/factors.py
@@ -34,16 +34,16 @@ def congruence_coefficient(matrix1, matrix2, absolute_value=True):
     permutation : list
     """
     # Check if matrix1 and matrix2 are lists of the same length
-    if isinstance(matrix1,list):
-        if not isinstance(matrix2, list) or len(matrix1)!=len(matrix2):
+    if isinstance(matrix1, list):
+        if not isinstance(matrix2, list) or len(matrix1) != len(matrix2):
             raise ValueError("Input lists of matrices must have the same length")
     else:
-        matrix1=[matrix1]
-        matrix2=[matrix2]
-    all_congruences_list=[]
+        matrix1 = [matrix1]
+        matrix2 = [matrix2]
+    all_congruences_list = []
     # Store an arbitrary column dimension, they should all be the same
     num_col_mat1 = T.shape(matrix1[0])[1]
-    for mat1, mat2 in zip(matrix1,matrix2):
+    for mat1, mat2 in zip(matrix1, matrix2):
         num_cols = T.shape(mat1)[1]
         if T.shape(mat1) != T.shape(mat2):
             raise ValueError("Matrices must have same shape")
@@ -55,7 +55,7 @@ def congruence_coefficient(matrix1, matrix2, absolute_value=True):
         mat2 = mat2 / T.norm(mat2, axis=0)
         all_congruences_list.append(T.dot(T.transpose(mat1), mat2))
         if absolute_value:
-            all_congruences_list[-1]=T.abs(all_congruences_list[-1])
+            all_congruences_list[-1] = T.abs(all_congruences_list[-1])
         all_congruences_list[-1] = T.to_numpy(all_congruences_list[-1])
     all_congruences = 1
     for congruence in all_congruences_list:

--- a/tensorly/metrics/factors.py
+++ b/tensorly/metrics/factors.py
@@ -50,7 +50,7 @@ def congruence_coefficient(matrix1, matrix2, absolute_value=True):
         if T.shape(mat1)[0] != T.shape(mat2)[0]:
             raise ValueError("Pairs of matrices must have the same number of rows")
         # Check if any norm is exactly zero to avoid singularity
-        if T.prod(T.norm(mat1, axis=0)) * T.prod(T.norm(mat2, axis=0)) == 0:
+        if T.prod(T.norm(mat1, axis=0)) == 0 or T.prod(T.norm(mat2, axis=0)) == 0:
             raise ValueError("Columns of all matrices should have nonzero l2 norm")
         mat1 = mat1 / T.norm(mat1, axis=0)
         mat2 = mat2 / T.norm(mat2, axis=0)

--- a/tensorly/metrics/tests/test_factors.py
+++ b/tensorly/metrics/tests/test_factors.py
@@ -7,6 +7,11 @@ from ..factors import congruence_coefficient
 from tensorly.random import random_cp
 from tensorly.cp_tensor import cp_permute_factors
 
+skip_tensorflow = pytest.mark.skipif(
+    (tl.get_backend() == "tensorflow"),
+    reason=f"Indexing with list not supported in TensorFlow",
+)
+
 
 def _tucker_congruence(A, B):
     As = A / tl.norm(A, axis=0)
@@ -36,6 +41,7 @@ def _congruence_coefficient_slow(A, B, absolute_value):
     return best_corr, best_permutation
 
 
+@skip_tensorflow
 @pytest.mark.parametrize(
     ("I", "R", "absolute_value"),
     itertools.product(

--- a/tensorly/metrics/tests/test_factors.py
+++ b/tensorly/metrics/tests/test_factors.py
@@ -4,6 +4,8 @@ import pytest
 import tensorly as tl
 
 from ..factors import congruence_coefficient
+from tensorly.random import random_cp
+from tensorly.cp_tensor import cp_permute_factors
 
 
 def _tucker_congruence(A, B):
@@ -56,3 +58,16 @@ def test_congruence_coefficient(I, R, absolute_value):
     assert fast_congruence == pytest.approx(slow_congruence)
     if I != 1:
         assert fast_permutation == list(slow_permutation)
+
+    # Adding test from @maximeguillaud issue #487
+    shape = (3, 4, 5)
+    rank = 4
+    cp_tensor_1 = random_cp(shape, rank, random_state = 0)
+    cp_tensor_2 = cp_tensor_1.cp_copy()
+    col_order_2 = [3, 1, 2, 0]
+    for f in range(3):
+        cp_tensor_2.factors[f] = cp_tensor_1.factors[f][:, col_order_2]*(-1)**(f+1)
+    _, permutation = cp_permute_factors(cp_tensor_1, cp_tensor_2)
+
+    assert permutation[0].tolist() == col_order_2
+

--- a/tensorly/metrics/tests/test_factors.py
+++ b/tensorly/metrics/tests/test_factors.py
@@ -62,12 +62,13 @@ def test_congruence_coefficient(I, R, absolute_value):
     # Adding test from @maximeguillaud issue #487
     shape = (3, 4, 5)
     rank = 4
-    cp_tensor_1 = random_cp(shape, rank, random_state = 0)
+    cp_tensor_1 = random_cp(shape, rank, random_state=0)
     cp_tensor_2 = cp_tensor_1.cp_copy()
     col_order_2 = [3, 1, 2, 0]
     for f in range(3):
-        cp_tensor_2.factors[f] = cp_tensor_1.factors[f][:, col_order_2]*(-1)**(f+1)
+        cp_tensor_2.factors[f] = cp_tensor_1.factors[f][:, col_order_2] * (-1) ** (
+            f + 1
+        )
     _, permutation = cp_permute_factors(cp_tensor_1, cp_tensor_2)
 
     assert permutation[0].tolist() == col_order_2
-


### PR DESCRIPTION
This is a fix for the `cp_permute_factors` function. As pointed out by @maximeguillaud the usage of `congruence_coefficient` for CP was to input a concatenated list `[A,B,C]` of factor matrices and compute the congruence on that whole list. But this is not correct because of the sign ambiguity in CP decomposition.

A better way to compute the congruence coefficient is to compute the congruence for A, B, and C and then use the product of the absolute value of the outcomes to perform the linear assignment. 

I modified the `congruence_coefficient` function accordingly by allowing two list of matrices as inputs rather than only two matrices. The old code should run without issues since the previous inputs (matrix, matrix) is also supported. All tests are passing locally, and the bug raised in #487 is fixed:

```python 
import tensorly as tl
from tensorly.random import random_cp
from tensorly.cp_tensor import cp_permute_factors, cp_to_tensor
shape = (3, 4, 5)
rank = 4
cp_tensor_1 = random_cp(shape, rank, random_state = 0)
cp_tensor_1[1][0] *= 2
cp_tensor_2 = cp_tensor_1.cp_copy()
col_order_2 = [3, 1, 2, 0]
for f in range(3):
    cp_tensor_2.factors[f] = cp_tensor_1.factors[f][:, col_order_2]*(-1)**(f+1)
cp_tensors, permutation = cp_permute_factors(cp_tensor_1, cp_tensor_2)
```
produces the correct permutation [3, 1, 2, 0].

I also updated the doc of congruence coefficient to reflect that the returned permutation should be applied on the second input matrix/list of matrices.

(and sorry for the noisy commits, I can squash them if needed)
