### PR TITLE
Add logsumexp function

### DIFF
--- a/tensorly/backend/__init__.py
+++ b/tensorly/backend/__init__.py
@@ -114,6 +114,7 @@ class BackendManager(types.ModuleType):
         "acosh",
         "atanh",
         "partial_svd",
+        "logsumexp",
     ]
     _attributes = [
         "int64",

--- a/tensorly/backend/core.py
+++ b/tensorly/backend/core.py
@@ -1162,6 +1162,11 @@ class Backend(object):
         raise
 
     @staticmethod
+    def logsumexp(x):
+        """Calculate the log of the sum of exponentials of input elements in a numerically stable way."""
+        raise NotImplementedError
+
+    @staticmethod
     def exp(x):
         """Calculate the exponential of all elements in the input array."""
         raise NotImplementedError

--- a/tensorly/backend/core.py
+++ b/tensorly/backend/core.py
@@ -1162,8 +1162,22 @@ class Backend(object):
         raise
 
     @staticmethod
-    def logsumexp(x):
-        """Calculate the log of the sum of exponentials of input elements in a numerically stable way."""
+    def logsumexp(x, axis=None):
+        """
+        Calculate the log of the sum of exponentials of input elements in a numerically stable way.
+
+        Parameters
+        ----------
+        x: tensorly.tensor
+            Input tensor.
+        axis: int
+            Axis along which logsumexp should be applied.
+
+        Returns
+        -------
+        tensor
+            Output of ``log(sum(exp(x)))``.
+        """
         raise NotImplementedError
 
     @staticmethod

--- a/tensorly/backend/cupy_backend.py
+++ b/tensorly/backend/cupy_backend.py
@@ -52,6 +52,10 @@ class CupyBackend(Backend, backend_name="cupy"):
         x, residuals, _, _ = cp.linalg.lstsq(a, b, rcond=None)
         return x, residuals
 
+    @staticmethod
+    def logsumexp(tensor, axis=0):
+        max_tensor = cp.max(tensor, axis=axis, keepdims=True)
+        return cp.squeeze(cp.log(cp.sum(cp.exp(tensor - max_tensor), axis=axis, keepdims=True)) + max_tensor, axis=axis)
 
 for name in (
     backend_types

--- a/tensorly/backend/cupy_backend.py
+++ b/tensorly/backend/cupy_backend.py
@@ -55,7 +55,12 @@ class CupyBackend(Backend, backend_name="cupy"):
     @staticmethod
     def logsumexp(tensor, axis=0):
         max_tensor = cp.max(tensor, axis=axis, keepdims=True)
-        return cp.squeeze(cp.log(cp.sum(cp.exp(tensor - max_tensor), axis=axis, keepdims=True)) + max_tensor, axis=axis)
+        return cp.squeeze(
+            cp.log(cp.sum(cp.exp(tensor - max_tensor), axis=axis, keepdims=True))
+            + max_tensor,
+            axis=axis,
+        )
+
 
 for name in (
     backend_types

--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -77,6 +77,9 @@ class JaxBackend(Backend, backend_name="jax"):
         m = mask.reshape((-1, 1)) if mask is not None else 1
         return np.einsum(operation, *matrices).reshape((-1, n_columns)) * m
 
+    @staticmethod
+    def logsumexp(tensor, axis=0):
+        return jax.scipy.special.logsumexp(tensor, axis=axis)
 
 for name in (
     backend_types

--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -81,6 +81,7 @@ class JaxBackend(Backend, backend_name="jax"):
     def logsumexp(tensor, axis=0):
         return jax.scipy.special.logsumexp(tensor, axis=axis)
 
+
 for name in (
     backend_types
     + backend_basic_math

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -92,7 +92,10 @@ class MxnetBackend(Backend, backend_name="mxnet"):
     @staticmethod
     def logsumexp(x, axis=0):
         max_x = np.max(x, axis=axis, keepdims=True)
-        return np.squeeze(max_x + np.log(np.sum(np.exp(x - max_x), axis=axis, keepdims=True)), axis=axis)
+        return np.squeeze(
+            max_x + np.log(np.sum(np.exp(x - max_x), axis=axis, keepdims=True)),
+            axis=axis,
+        )
 
 
 for name in (

--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -89,6 +89,11 @@ class MxnetBackend(Backend, backend_name="mxnet"):
         x, residuals, _, _ = np.linalg.lstsq(a, b, rcond=None)
         return x, residuals
 
+    @staticmethod
+    def logsumexp(x, axis=0):
+        max_x = np.max(x, axis=axis, keepdims=True)
+        return np.squeeze(max_x + np.log(np.sum(np.exp(x - max_x), axis=axis, keepdims=True)), axis=axis)
+
 
 for name in (
     backend_basic_math

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -57,6 +57,10 @@ class NumpyBackend(Backend, backend_name="numpy"):
         m = mask.reshape((-1, 1)) if mask is not None else 1
         return np.einsum(operation, *matrices).reshape((-1, n_columns)) * m
 
+    @staticmethod
+    def logsumexp(tensor, axis=0):
+        return scipy.special.logsumexp(tensor, axis=axis)
+
 
 for name in (
     backend_types

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -239,6 +239,10 @@ class PyTorchBackend(Backend, backend_name="pytorch"):
         u, s, v = torch.svd(matrix, some=some, compute_uv=True)
         return u, s, v.transpose(-2, -1).conj()
 
+    @staticmethod
+    def logsumexp(tensor, axis=0):
+        return torch.logsumexp(tensor, dim=axis)
+
 
 # Register the other functions
 for name in (

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -106,6 +106,7 @@ class TensorflowBackend(Backend, backend_name="tensorflow"):
     def logsumexp(tensor, axis=0):
         return tfm.reduce_logsumexp(tensor, axis=axis)
 
+
 # Register numpy functions
 for name in ["nan"]:
     TensorflowBackend.register_method(name, getattr(np, name))

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -102,6 +102,9 @@ class TensorflowBackend(Backend, backend_name="tensorflow"):
         else:
             return tensor
 
+    @staticmethod
+    def logsumexp(tensor, axis=0):
+        return tfm.reduce_logsumexp(tensor, axis=axis)
 
 # Register numpy functions
 for name in ["nan"]:

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -4,10 +4,12 @@ import pytest
 from time import time
 import numpy as np
 from scipy.linalg import svd
+from scipy import special
 
 import tensorly as tl
 from .. import backend as T
 from ..testing import (
+    assert_allclose,
     assert_array_equal,
     assert_equal,
     assert_,
@@ -533,3 +535,20 @@ def test_sum_keepdims():
     assert tl.shape(summed_tensor8) == (10, 20)
     summed_tensor9 = tl.sum(random_tensor, axis=2, keepdims=True)
     assert tl.shape(summed_tensor9) == (10, 20, 1)
+
+
+def test_logsumexp():
+    """Test the logsumexp implementation against the scipy baseline result."""
+
+    # Example data
+    x = np.arange(24).reshape((3, 4, 2)).astype(np.float32)
+
+    # Tensorly tensor
+    tensor = tl.tensor(x)
+
+    # Compare against scipy baseline result
+    for axis in [0, 1, 2]:
+        # Run tensorly logsumexp
+        tensorly_result = tl.logsumexp(tensor, axis=axis)
+        scipy_result = special.logsumexp(x, axis=axis)
+        assert_allclose(tensorly_result, scipy_result)


### PR DESCRIPTION
This adds the `logsumexp` function using the logsumexp trick which is the numerical stable version of applying `log(sum(exp(x)))`. I chose to default to the backend implementation if available (pytorch, numpy/scipy, tensorflow, jax) and implemented the numerical stable computation of `log(sum(exp(x)))` when the backend did not provide a logsumexp function (mxnet, cupy).

Additionally, I've added a unit test that checks against the numpy/scipy baseline with some 3d data tensor over all axis.
