### PR TITLE
Add ALS-based method for tensor ring decomposition

### DIFF
--- a/doc/development_guide/backend_system.rst
+++ b/doc/development_guide/backend_system.rst
@@ -3,7 +3,7 @@
 Backend System
 ==============
 The TensorLy backend system allows for switching between multiple backends in
-a thread-local way.  You can obtain the back that is currently being used with the
+a thread-local way.  You can obtain the backend that is currently being used with the
 ``get_backend()`` function::
 
     >>> import tensorly as tl
@@ -23,7 +23,7 @@ from the thread that spawned them (which is typically the main thread).
 Globally setting the backend supports interactive usage.
 
 Additionally,  we provide a context manager ``backend_context``  
-for convenience, whcih may be used to
+for convenience, which may be used to
 safely use a backend only for limited context::
 
     >>> with tl.backend_context('pytorch'):

--- a/doc/user_guide/backend.rst
+++ b/doc/user_guide/backend.rst
@@ -115,7 +115,7 @@ Now, let's create a random tensor using the :mod:`tensorly.random` module:
    # tensor is a PyTorch Tensor!
 
 We can decompose it easily, here using a Tucker decomposition: 
-First, we reate a decomposition instance, which keeps the number of parameters the same
+First, we create a decomposition instance, which keeps the number of parameters the same
 and with a random initialization. We then fit it to our tensor.
 
 .. code:: python
@@ -160,12 +160,12 @@ The rest is exactly the same, nothing more to do!
 Using static dispatching
 ------------------------
 
-We optimized the dynammical dispatch so the overhead is negligeable. 
+We optimized the dynamical dispatch so the overhead is negligeable. 
 However, if you only want to use one backend, you can first set it and then switch to static dispatching:
 
 >>> tl.use_static_dispatch()
 
-And you can switch back to dynammical dispatching just as easily:
+And you can switch back to dynamical dispatching just as easily:
 
 >>> tl.use_dynamic_dispatch()
 

--- a/doc/user_guide/quickstart.rst
+++ b/doc/user_guide/quickstart.rst
@@ -1,12 +1,12 @@
 Quick-Start
 ===========
 
-A short overview of TensorLy to get started quickly and get familiar with the organization of TensorLY. 
+A short overview of TensorLy to get started quickly and get familiar with the organization of TensorLy. 
 
 Organization of TensorLy
 -------------------------
 
-TensorLy is organized in several submodule:
+TensorLy is organized in several submodules:
 
 ================================= ================================
 Module                             Description
@@ -42,12 +42,12 @@ Why is that?
 
 
 This is why you should always manipulate tensors using tensorly backend functions only.
-For instance, `tensorly.max` calls either the MXNet, NumPy or PyTorch version depending on the backend you selected. There are other subtlties that are handled by the backend to allow a common API regardless of the backend use.
+For instance, `tensorly.max` calls either the MXNet, NumPy or PyTorch version depending on the backend you selected. There are other subtleties that are handled by the backend to allow a common API regardless of the backend use.
 
 .. note::
    
    By default, the backend is set to NumPy. You can change the backend using ``tensorly.set_backend``.
-   For instance, to switch to pytorch, simply type ``tensorly.set_backend('pytorch')``.
+   For instance, to switch to PyTorch, simply type ``tensorly.set_backend('pytorch')``.
    For more information on the backend, refer to :doc:`./backend`.
 
 
@@ -127,7 +127,7 @@ Tensor algebra
 --------------
 
 More '*advanced*' tensor algebra functions are located in the aptly named :py:mod:`tensorly.tenalg` module.
-This includes for instance, n-mode product, kronecker product, etc.
+This includes for instance, n-mode product, Kronecker product, etc.
 
 We now provide a backend system for tensor algebra, which allows to either use our "hand-crafter" implementations
 or to dispatch all the operations to einsum. By default, we use the hand-crafted implementations. To switch to einsum, or change the tenalg backend:

--- a/doc/user_guide/sparse_backend.rst
+++ b/doc/user_guide/sparse_backend.rst
@@ -123,7 +123,7 @@ much memory.
    <COO: shape=(1000, 1001, 1002), dtype=float64, nnz=5044, fill_value=0.0>
 
 This is how much memory the sparse array takes up, vs. how much it would take
-up if it were represented densly.
+up if it were represented densely.
 
    >>> tensor.nbytes / 1e9 # Actual memory usage in GB
    0.000161408

--- a/doc/user_guide/tensor_basics.rst
+++ b/doc/user_guide/tensor_basics.rst
@@ -57,7 +57,7 @@ Also called **matrization**, **unfolding** a tensor is done by reading the eleme
 For a tensor of size :math:`(I_0, I_1, \cdots, I_N)`, the n-mode unfolding of this tensor will be of size :math:`(I_n, I_0 \times I_1 \times \cdots \times I_{n-1} \times I_{n+1} \cdots \times I_N)`.
 
 .. important::
-   In tensorly we use an unfolding different from the classical one as defined in [1]_ for better performance.
+   In TensorLy we use an unfolding different from the classical one as defined in [1]_ for better performance.
 
    Given a tensor :math:`\tilde X \in \mathbb{R}^{I_0, I_1 \times I_2 \times \cdots \times I_N}`, the
    mode-n unfolding of :math:`\tilde X` is a matrix :math:`\mathbf{X}_{[n]} \in \mathbb{R}^{I_n, I_M}`,
@@ -72,7 +72,7 @@ For a tensor of size :math:`(I_0, I_1, \cdots, I_N)`, the n-mode unfolding of th
 
    Traditionally, mode-1 unfolding denotes the unfolding along the first dimension.
    However, to be consistent with the Python indexing that always starts at zero,
-   in tensorly, unfolding also starts at zero!
+   in TensorLy, unfolding also starts at zero!
 
    Therefore ``unfold(tensor, 0)`` will unfold said tensor along its first dimension!
 
@@ -112,7 +112,7 @@ Finally, the 2-mode unfolding is the unfolding along the last axis:
    \end{matrix} \right]
 
 
-In tensorly:
+In TensorLy:
 
 .. code-block:: python
 

--- a/doc/user_guide/tensor_decomposition.rst
+++ b/doc/user_guide/tensor_decomposition.rst
@@ -10,7 +10,7 @@ Refer to [1]_ for more information on tensor decomposition.
 CP form of a tensor
 ------------------------
 
-The idea is to express the tensor as a sum of rank one tensors. That is, a sum of outer product of vectors.
+The idea is to express the tensor as a sum of rank one tensors. That is, a sum of outer products of vectors.
 Such representation can be obtained by applying Canonical Polyadic Decomposition (also known as CANDECOMP-PARAFAC, CP, or PARAFAC decomposition). 
 
 CANDECOMP-PARAFAC decomposition
@@ -126,7 +126,7 @@ Note that some coefficients are almost zero (10e-16) but not exactly due to nume
 Matrix-Product-State / Tensor-Train Decomposition
 --------------------------------------------------
 
-The tensor-train decomposition, also known as matrix product state in physics community, is a way of decompositing high order tensors into third order ones. For a order d tensor A[i1,...,id], it splits each dimension into a order 3 sub-tensor, which we called factors or cores. One of the dimension of the sub-tensor is the real physical dimension, while the other two are edges connecting the cores before and after it.
+The tensor-train decomposition, also known as matrix product state in physics community, is a way of decompositing high order tensors into third order ones. For an order d tensor A[i1,...,id], it splits each dimension into an order 3 sub-tensor, which we called factors or cores. One of the dimension of the sub-tensor is the real physical dimension, while the other two are edges connecting the cores before and after it.
 
 .. math::
 

--- a/doc/user_guide/tensor_regression.rst
+++ b/doc/user_guide/tensor_regression.rst
@@ -19,7 +19,7 @@ For a detailed explanation on tensor regression, please refer to [1]_.
 
 TensorLy implements both types of tensor regression as scikit-learn-like estimators.
 
-For instance, Krusal regression is available through the :class:`tensorly.regression.CPRegression` object. This implements a fit method that takes as parameters `X`, the data tensor which first dimension is the number of samples, and `y`, the corresponding vector of labels.
+For instance, Krusal regression is available through the :class:`tensorly.regression.CPRegression` object. This implements a fit method that takes as parameters `X`, the data tensor whose first dimension is the number of samples, and `y`, the corresponding vector of labels.
 
 Given a set of testing samples, you can use the predict method to obtain the corresponding predictions from the model.
 

--- a/tensorly/decomposition/__init__.py
+++ b/tensorly/decomposition/__init__.py
@@ -15,7 +15,7 @@ from ._tucker import (
 from .robust_decomposition import robust_pca
 from ._tt import tensor_train, tensor_train_matrix
 from ._tt import TensorTrain, TensorTrainMatrix
-from ._tr import tensor_ring, TensorRing
+from ._tr import tensor_ring, tensor_ring_als, TensorRing, TensorRingALS
 from ._parafac2 import parafac2, Parafac2
 from ._symmetric_cp import (
     symmetric_parafac_power_iteration,

--- a/tensorly/decomposition/_tr.py
+++ b/tensorly/decomposition/_tr.py
@@ -116,6 +116,157 @@ def tensor_ring(input_tensor, rank, mode=0, svd="truncated_svd", verbose=False):
     return TRTensor(factors)
 
 
+def tensor_ring_als(
+    tensor,
+    rank,
+    ls_solve="lstsq",
+    n_iter_max=100,
+    tol=1e-6,
+    random_state=None,
+    verbose=False,
+    callback=None,
+):
+    """Tensor ring decomposition via alternating least squares (ALS)
+
+    Computes a rank-`rank` tensor ring decomposition of `tensor` using ALS. The
+    implementation roughly follows Algorithm 2 in [1]_.
+
+    Parameters
+    ----------
+    tensor : ndarray
+    rank : Union[int, List[int]]
+        The rank of the decomposition. If `rank` is an int, then all ranks will be the
+        same and equal to `rank`. If `rank` is a list, then the i-th core will be of
+        size rank[i]-by-shape[i]-by-rank[i+1], where shape[i] is the dimension of the
+        i-th mode of `tensor`.
+    ls_solve : {"lstsq", "normal_eq"}, default is "lstsq"
+        When equal to "lstsq", the least squares problems are solved as overdetermined
+        systems of equations using tl.lstsq. When equal to "normal_eq", a normal
+        equation formulation is used instead together with tl.solve. This latter
+        approach is expected to yield poorer accuracy due to numerical issuse with the
+        normal equations.
+    n_iter_max : int, default is 100
+        Maximum number of ALS iterations.
+    tol : float, default 1e-6
+        The algorithm is terminated when the change in the relative reconstruction error
+        is less than `tol`.
+    random_state : {None, int, np.random.RandomState}
+        Used to set the random seed in the algorithm.
+    verbose : bool, default False
+        If True, the algorithm will make some additional print outs.
+    callback : {None, Callable[[tl.tr_tensor.TRTensor, float], {None, bool}]}, default None
+        A callback function which can be used for, e.g., logging the per-iteration
+        error. Such a function takes two inputs: A tensor ring decomposition and a float
+        which indicates the relative reconstruction error between `tensor` and the
+        inputted TRTensor. It can return a bool which can be used to control when the
+        ALS algorithm terminates.
+
+    Returns
+    -------
+    tr_decomp : tl.tr_tensor.TRTensor
+        The tensor ring decomposition computed by the algorithm.
+
+    References
+    ----------
+    .. [1] Q. Zhao, G. Zhou, S. Xie, L. Zhang, A. Cichocki, "Tensor Ring Decomposition",
+           arXiv:1606.05535, 2016.
+    """
+
+    shape = tl.shape(tensor)
+    rank = validate_tr_rank(shape, rank=rank)
+    n_dim = len(shape)
+    rng = tl.check_random_state(random_state)
+    if tol > 0 or callback:
+        tensor_norm = tl.norm(tensor)
+    valid_ls_solve = {"lstsq", "normal_eq"}
+    if ls_solve not in valid_ls_solve:
+        raise ValueError(
+            f"Invalid value provided for ls_solve. It must be in {valid_ls_solve}."
+        )
+
+    # Randomly initialize decomposition cores
+    tr_decomp = tl.random.random_tr(shape, rank, random_state=rng, **tl.context(tensor))
+
+    # Run callback function if provided
+    if callback:
+        rel_error = tl.norm(tl.tr_to_tensor(tr_decomp) - tensor) / tensor_norm
+        callback(tr_decomp, rel_error)
+
+    # Main loop
+    rec_errors = []
+    for iter in range(n_iter_max):
+        for dim in range(n_dim):
+            # Compute appropriate transposed unfolding of tensor
+            tensor_unf = tl.reshape(tl.moveaxis(tensor, dim, -1), (-1, shape[dim]))
+
+            # Compute design matrix
+            subchain_tensor = tr_decomp[(dim + 1) % n_dim]
+            for j in range(2, n_dim):
+                subchain_tensor = tl.tensordot(
+                    subchain_tensor, tr_decomp[(dim + j) % n_dim], axes=1
+                )
+            tr_idx = (
+                [i + n_dim - dim for i in range(dim)]
+                + [i + 1 for i in range(n_dim - dim - 1)]
+                + [n_dim, 0]
+            )
+            subchain_tensor = tl.transpose(subchain_tensor, tr_idx)
+            design_mat = tl.reshape(subchain_tensor, (-1, rank[dim] * rank[dim + 1]))
+
+            if ls_solve == "lstsq":
+                # Solve least squares problem directly
+                sol, _ = tl.lstsq(design_mat, tensor_unf)
+
+            elif ls_solve == "normal_eq":
+                # Solve least squares problem via normal equations
+                design_mat_tr = tl.transpose(design_mat)
+                gram_mat = tl.matmul(design_mat_tr, design_mat)
+                rhs_mat = tl.matmul(design_mat_tr, tensor_unf)
+                sol = tl.solve(gram_mat, rhs_mat)
+
+            # Update core
+            tr_decomp[dim] = tl.transpose(
+                tl.reshape(sol, (rank[dim], rank[dim + 1], shape[dim])),
+                [0, 2, 1],
+            )
+
+        # Compute relative error if necessary
+        if tol > 0 or callback:
+            error = tl.norm(tl.matmul(design_mat, sol) - tensor_unf)
+            rel_error = error / tensor_norm
+            rec_errors.append(rel_error)
+            if iter >= 1:
+                rel_error_decrease = rec_errors[-2] - rec_errors[-1]
+            if verbose:
+                if iter >= 1:
+                    print(
+                        f"Iteration {iter+1} finished. Reconstruction error: {rel_error}, decrease = {rel_error_decrease}, unnormalized = {error}"
+                    )
+                else:
+                    print(
+                        f"Iteration {iter+1} finished. Reconstruction error: {rel_error}, unnormalized = {error}"
+                    )
+        elif verbose:
+            print(f"Iteration {iter+1} finished.")
+
+        # Run callback function if provided
+        if callback:
+            callback_retVal = callback(tr_decomp, rel_error)
+            if callback_retVal:
+                if verbose:
+                    print("Received True from callback function. Exiting.")
+                break
+
+        # Check convergence
+        if tol > 0 and iter >= 1:
+            if rel_error_decrease < tol:
+                if verbose:
+                    print(f"tensor_ring_als converged after {iter} iterations.")
+                break
+
+    return tr_decomp
+
+
 class TensorRing(DecompositionMixin):
     """Tensor Ring decomposition via recursive SVD
 
@@ -155,4 +306,118 @@ class TensorRing(DecompositionMixin):
         self.decomposition_ = tensor_ring(
             tensor, rank=self.rank, mode=self.mode, svd=self.svd, verbose=self.verbose
         )
+        return self.decomposition_
+
+
+class TensorRingALS(DecompositionMixin):
+    """A class wrapper for the tensor_ring_als function
+
+    Attributes
+    ----------
+    rank : Union[int, List[int]]
+        The rank of the decomposition. If `rank` is an int, then all ranks will be the
+        same and equal to `rank`. If `rank` is a list, then the i-th core will be of
+        size rank[i]-by-shape[i]-by-rank[i+1], where shape[i] is the dimension of the
+        i-th mode of `tensor`.
+    ls_solve : {"lstsq", "normal_eq"}
+        When equal to "lstsq", the least squares problems are solved as overdetermined
+        systems of equations using tl.lstsq. When equal to "normal_eq", a normal
+        equation formulation is used instead together with tl.solve. This latter
+        approach is expected to yield poorer accuracy due to numerical issuse with the
+        normal equations.
+    n_iter_max : int
+        Maximum number of ALS iterations.
+    tol : float
+        The algorithm is terminated when the change in the relative reconstruction error
+        is less than `tol`.
+    random_state : {None, int, np.random.RandomState}
+        Used to set the random seed in the algorithm.
+    verbose : bool
+        If True, the algorithm will make some additional print outs.
+    callback : {None, Callable[[tl.tr_tensor.TRTensor, float], {None, bool}]}
+        A callback function which can be used for, e.g., logging the per-iteration
+        error. Such a function takes two inputs: A tensor ring decomposition and a float
+        which indicates the relative reconstruction error between `tensor` and the
+        inputted TRTensor. It can return a bool which can be used to control when the
+        ALS algorithm terminates.
+
+    Methods
+    -------
+    fit_transformation(tensor)
+        Computes the decomposition of `tensor`.
+    """
+
+    def __init__(
+        self,
+        rank,
+        ls_solve="lstsq",
+        n_iter_max=100,
+        tol=1e-6,
+        random_state=None,
+        verbose=False,
+        callback=None,
+    ):
+        """
+        Parameters
+        ----------
+        rank : Union[int, List[int]]
+            The rank of the decomposition. If `rank` is an int, then all ranks will be the
+            same and equal to `rank`. If `rank` is a list, then the i-th core will be of
+            size rank[i]-by-shape[i]-by-rank[i+1], where shape[i] is the dimension of the
+            i-th mode of `tensor`.
+        ls_solve : {"lstsq", "normal_eq"}, default is "lstsq"
+            When equal to "lstsq", the least squares problems are solved as overdetermined
+            systems of equations using tl.lstsq. When equal to "normal_eq", a normal
+            equation formulation is used instead together with tl.solve. This latter
+            approach is expected to yield poorer accuracy due to numerical issuse with the
+            normal equations.
+        n_iter_max : int, default is 100
+            Maximum number of ALS iterations.
+        tol : float, default 1e-6
+            The algorithm is terminated when the change in the relative reconstruction error
+            is less than `tol`.
+        random_state : {None, int, np.random.RandomState}
+            Used to set the random seed in the algorithm.
+        verbose : bool, default False
+            If True, the algorithm will make some additional print outs.
+        callback : {None, Callable[[tl.tr_tensor.TRTensor, float], {None, bool}]}, default None
+            A callback function which can be used for, e.g., logging the per-iteration
+            error. Such a function takes two inputs: A tensor ring decomposition and a float
+            which indicates the relative reconstruction error between `tensor` and the
+            inputted TRTensor. It can return a bool which can be used to control when the
+            ALS algorithm terminates.
+        """
+
+        self.rank = rank
+        self.ls_solve = ls_solve
+        self.n_iter_max = n_iter_max
+        self.tol = tol
+        self.random_state = random_state
+        self.verbose = verbose
+        self.callback = callback
+
+    def fit_transform(self, tensor):
+        """Computes the decomposition of `tensor`.
+
+        Parameters
+        ----------
+        tensor : ndarray
+
+        Returns
+        -------
+        decomposition_ : tl.tr_tensor.TRTensor
+            The tensor ring decomposition computed by the algorithm.
+        """
+
+        tr_decomp = tensor_ring_als(
+            tensor,
+            rank=self.rank,
+            ls_solve=self.ls_solve,
+            n_iter_max=self.n_iter_max,
+            tol=self.tol,
+            random_state=self.random_state,
+            verbose=self.verbose,
+            callback=self.callback,
+        )
+        self.decomposition_ = tr_decomp
         return self.decomposition_

--- a/tensorly/decomposition/_tr.py
+++ b/tensorly/decomposition/_tr.py
@@ -1,5 +1,6 @@
 import tensorly as tl
 from ._base_decomposition import DecompositionMixin
+from ..base import matricize
 from ..tr_tensor import validate_tr_rank, TRTensor
 from ..tenalg.svd import svd_interface
 
@@ -197,7 +198,7 @@ def tensor_ring_als(
     for iter in range(n_iter_max):
         for dim in range(n_dim):
             # Compute appropriate transposed unfolding of tensor
-            tensor_unf = tl.reshape(tl.moveaxis(tensor, dim, -1), (-1, shape[dim]))
+            tensor_unf = matricize(tensor, [n for n in range(n_dim) if n != dim], [dim])
 
             # Compute design matrix
             subchain_tensor = tr_decomp[(dim + 1) % n_dim]

--- a/tensorly/decomposition/tests/test_tr_decomposition.py
+++ b/tensorly/decomposition/tests/test_tr_decomposition.py
@@ -1,6 +1,23 @@
-from .._tr import tensor_ring
+import pytest
+import tensorly as tl
+import numpy as np
+
+from .._tr import tensor_ring, tensor_ring_als, TensorRingALS
 from ...random import random_tr
-from ...testing import assert_, assert_array_almost_equal, assert_raises
+from ...testing import (
+    assert_,
+    assert_array_almost_equal,
+    assert_raises,
+    assert_class_wrapper_correctly_passes_arguments,
+)
+
+
+class ErrorTracker:
+    def __init__(self):
+        self.error = list()
+
+    def __call__(self, decomp, rec_error):
+        self.error.append(rec_error)
 
 
 def test_tensor_ring():
@@ -60,3 +77,74 @@ def test_tensor_ring_mode():
 
     with assert_raises(ValueError):
         tensor_ring(tensor, rank=(12, 2, 10, 3, 6, 12), mode=1)
+
+
+@pytest.mark.parametrize(
+    "tensor_shape, rank",
+    [((6, 2, 3, 2, 6), (3, 2, 4, 12, 18, 3)), ((20, 18, 19), (6, 7, 8, 6))],
+)
+@pytest.mark.parametrize(
+    "ls_solve, er_decrease_tol", [("lstsq", 1e-7), ("normal_eq", 1e-3)]
+)  # Lower tolerance for normal equation approach due to lower accuracy in solves
+@pytest.mark.parametrize("random_state", [1, 1234])
+def test_tensor_ring_als(
+    tensor_shape, rank, ls_solve, random_state, er_decrease_tol, monkeypatch
+):
+    rng = tl.check_random_state(random_state)
+
+    # Generate random tensor which has exact tensor ring decomposition
+    tensor = random_tr(
+        tensor_shape, rank, full=True, random_state=rng, dtype=tl.float64
+    )
+
+    # Ensure ValueError is raised for when invalid ls_solve is given
+    with np.testing.assert_raises(ValueError):
+        tr_decomp = tensor_ring_als(
+            tensor, rank, random_state=rng, ls_solve="invalid_ls_solve"
+        )
+
+    # Create callback function for error tracking and run decomposition
+    callback = ErrorTracker()
+    tr_decomp = tensor_ring_als(
+        tensor, rank, random_state=rng, callback=callback, ls_solve=ls_solve
+    )
+
+    # Ensure decomposition returns right number of factors
+    assert_(len(tr_decomp.factors) == len(tensor_shape))
+
+    # Ensure cores are sized correctly
+    for i in range(len(tensor_shape)):
+        core_shape = tr_decomp[i].shape
+        assert_(core_shape[0] == rank[i])
+        assert_(core_shape[1] == tensor_shape[i])
+        assert_(core_shape[2] == rank[i + 1])
+
+    # Compute decomposition relative error and ensure it's small enough
+    rel_error_tol = 1e-2
+    rel_error = tl.norm(tl.tr_to_tensor(tr_decomp) - tensor) / tl.norm(tensor)
+    assert_(rel_error < rel_error_tol)
+
+    # Ensure error decreases monotonically (up to numerical error)
+    for i in range(len(callback.error) - 1):
+        assert_(callback.error[i + 1] < callback.error[i] + er_decrease_tol)
+
+    # Ensure TensorRingALS class passes arguments correctly to decomposition function
+    assert_class_wrapper_correctly_passes_arguments(
+        monkeypatch, tensor_ring_als, TensorRingALS, rank=3
+    )
+
+    # Ensure that the computed decomposition is the same when the same random seed is
+    # used
+    rng1 = tl.check_random_state(random_state)
+    rng2 = tl.check_random_state(random_state)
+    callback1 = ErrorTracker()
+    callback2 = ErrorTracker()
+    tr_decomp1 = tensor_ring_als(
+        tensor, rank, random_state=rng1, callback=callback1, ls_solve=ls_solve
+    )
+    tr_decomp2 = tensor_ring_als(
+        tensor, rank, random_state=rng2, callback=callback2, ls_solve=ls_solve
+    )
+    assert_array_almost_equal(callback1.error, callback2.error)
+    for i in range(len(tr_decomp1.factors)):
+        assert_array_almost_equal(tr_decomp1[i], tr_decomp2[i])


### PR DESCRIPTION
This implements an alternating least squares method for tensor ring decomposition. It supports solving each least squares problem either directly as a least squares problem (using tl.lstsq) or via the normal equations (using tl.solve). In addition to the decomposition function, there is also a class wrapper for the function. I also implemented some tests.

Any feedback is welcome! In particular, feedback on lines 199-214 in `tensorly/decomposition/_tr.py` would be helpful. I originally wrote those lines using `order="F"` in the reshaping functions. However, due to issues with the PyTorch backend (and to improve efficiency), I rewrote these calculations to use standard C ordering instead.