### PR TITLE
More efficient error calculation in PARAFAC2

### DIFF
--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -6,12 +6,10 @@ from tensorly.random import random_parafac2
 from tensorly import backend as T
 from . import parafac, non_negative_parafac_hals
 from ..parafac2_tensor import (
-    parafac2_to_slice,
     Parafac2Tensor,
     _validate_parafac2_tensor,
 )
 from ..cp_tensor import CPTensor
-from ..base import unfold
 from ..tenalg.svd import svd_interface
 
 # Authors: Marie Roald
@@ -95,13 +93,34 @@ def _project_tensor_slices(tensor_slices, projections):
     return tl.stack(slices)
 
 
-def _parafac2_reconstruction_error(tensor_slices, decomposition):
+def _parafac2_reconstruction_error(tensor_slices, decomposition, norm_matrices=None):
     _validate_parafac2_tensor(decomposition)
-    squared_error = 0
-    for idx, tensor_slice in enumerate(tensor_slices):
-        reconstruction = parafac2_to_slice(decomposition, idx, validate=False)
-        squared_error += tl.sum((tensor_slice - reconstruction) ** 2)
-    return tl.sqrt(squared_error)
+
+    if norm_matrices is None:
+        norm_X_sq = sum(tl.norm(t_slice, 2) ** 2 for t_slice in tensor_slices)
+    else:
+        norm_X_sq = norm_matrices**2
+
+    weights, (A, B, C), projections = decomposition
+    if weights is not None:
+        A = A * weights
+
+    norm_cmf_sq = 0
+    inner_product = 0
+    CtC = tl.dot(tl.transpose(C), C)
+
+    for i, t_slice in enumerate(tensor_slices):
+        B_i = (projections[i] @ B) * A[i]
+        if tl.shape(B_i)[0] > tl.shape(C)[0]:
+            tmp = tl.dot(tl.transpose(B_i), t_slice)
+            inner_product += tl.trace(tl.dot(tmp, C))
+        else:
+            tmp = tl.dot(t_slice, C)
+            inner_product += tl.trace(tl.dot(tl.transpose(B_i), tmp))
+
+        norm_cmf_sq += tl.sum((B_i.T @ B_i) * CtC)
+
+    return tl.sqrt(norm_X_sq - 2 * inner_product + norm_cmf_sq)
 
 
 def parafac2(
@@ -318,7 +337,7 @@ def parafac2(
 
         if tol:
             rec_error = _parafac2_reconstruction_error(
-                tensor_slices, (weights, factors, projections)
+                tensor_slices, (weights, factors, projections), norm_tensor
             )
             rec_error /= norm_tensor
             rec_errors.append(rec_error)


### PR DESCRIPTION
I have been using this, borrowed from Marie Roald's matcouply package. We currently reconstruct the entire dataset before calculating the error; this frequently takes up the most time in my profiling. The approach here avoids doing so by looking at the inner product, which ends up being much more efficient.