### PR TITLE
PARAFAC2: Move normalization within CP, avoid unnecessary sign normalization in OP

### DIFF
--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -77,7 +77,9 @@ def _compute_projections(tensor_slices, factors, svd):
     for A, tensor_slice in zip(factors[0], tensor_slices):
         lhs = T.dot(factors[1], T.transpose(A * factors[2]))
         rhs = T.transpose(tensor_slice)
-        U, _, Vh = svd_interface(T.dot(lhs, rhs), n_eigenvecs=n_eig, method=svd, flip_sign=False)
+        U, _, Vh = svd_interface(
+            T.dot(lhs, rhs), n_eigenvecs=n_eig, method=svd, flip_sign=False
+        )
 
         out.append(T.transpose(T.dot(U, Vh)))
 


### PR DESCRIPTION
1. The SVD interface flips the sign of the results by default, so that the results are more consistent. This is a useful and reasonable feature, but Orthogonal Procrustes only uses `U @ Vh`, so this has no effect. On indexing-expensive backends this is about 20% of the PARAFAC2 time, so it does provide an appreciable performance benefit.
2. The CP implementations used within PARAFAC2 already implement normalization, so it seems beneficial to use that implementation, rather than performing it within PARAFAC2.

These are some simpler adjustments before I open pull requests for a line search routine and faster reconstruction error calculation, with more substantial performance improvements.