### PR TITLE
SVD compression of PARAFAC2

### DIFF
--- a/doc/modules/api.rst
+++ b/doc/modules/api.rst
@@ -376,6 +376,23 @@ Functions
     constrained_parafac
 
 
+Preprocessing (:mod:`tensorly.preprocessing`)
+=============================================
+
+.. automodule:: tensorly.preprocessing
+    :no-members:
+    :no-inherited-members:
+
+.. currentmodule:: tensorly.preprocessing
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    svd_compress_tensor_slices
+    svd_decompress_parafac2_tensor
+
+
 Tensor Regression (:mod:`tensorly.regression`)
 ==============================================
 
@@ -508,5 +525,3 @@ Currently, the following decomposition methods are supported (for the NumPy back
    sparse.decomposition.parafac
    sparse.decomposition.non_negative_parafac
    sparse.decomposition.symmetric_parafac_power_iteration
-
-

--- a/examples/decomposition/plot_parafac2.py
+++ b/examples/decomposition/plot_parafac2.py
@@ -19,7 +19,7 @@ from scipy.optimize import linear_sum_assignment
 # Create synthetic tensor
 # -----------------------
 # Here, we create a random tensor that follows the PARAFAC2 constraints found
-# inx `(Kiers et al 1999)`_.
+# in `(Kiers et al 1999)`_.
 # 
 # This particular tensor,
 # :math:`\mathcal{X} \in \mathbb{R}^{I\times J \times K}`, is a shifted

--- a/examples/decomposition/plot_parafac2_compression.py
+++ b/examples/decomposition/plot_parafac2_compression.py
@@ -1,0 +1,293 @@
+"""
+Speeding up PARAFAC2 with SVD compression
+=========================================
+
+PARAFAC2 can be very time-consuming to fit. However, if the number of rows greatly
+exceeds the number of columns or the data matrices are approximately low-rank, we can
+compress the data before fitting the PARAFAC2 model to considerably speed up the fitting
+procedure.
+
+The compression works by first computing the SVD of the tensor slices and fitting the
+PARAFAC2 model to the right singular vectors multiplied by the singular values. Then,
+after we fit the model, we left-multiply the :math:`B_i`-matrices with the left singular
+vectors to recover the decompressed model. Fitting to compressed data and then
+decompressing is mathematically equivalent to fitting to the original uncompressed data.
+
+For more information about why this works, see the documentation of
+:py:meth:`tensorly.decomposition.preprocessing.svd_compress_tensor_slices`.
+"""
+from time import monotonic
+import tensorly as tl
+from tensorly.decomposition import parafac2
+import tensorly.preprocessing as preprocessing
+
+
+##############################################################################
+# Function to create synthetic data
+# ---------------------------------
+#
+# Here, we create a function that constructs a random tensor from a PARAFAC2
+# decomposition with noise
+
+rng = tl.check_random_state(0)
+
+
+def create_random_data(shape, rank, noise_level):
+    I, J, K = shape  # noqa: E741
+    pf2 = tl.random.random_parafac2(
+        [(J, K) for i in range(I)], rank=rank, random_state=rng
+    )
+
+    X = pf2.to_tensor()
+    X_norm = [tl.norm(Xi) for Xi in X]
+
+    noise = [rng.standard_normal((J, K)) for i in range(I)]
+    noise = [noise_level * X_norm[i] / tl.norm(E_i) for i, E_i in enumerate(noise)]
+    return [X_i + E_i for X_i, E_i in zip(X, noise)]
+
+
+##############################################################################
+# Compressing data with many rows and few columns
+# -----------------------------------------------
+#
+# Here, we set up for a case where we have many rows compared to columns
+
+n_inits = 5
+rank = 3
+shape = (10, 10_000, 15)  # 10 matrices/tensor slices, each of size 10_000 x 15.
+noise_level = 0.33
+
+uncompressed_data = create_random_data(shape, rank=rank, noise_level=noise_level)
+
+##############################################################################
+# Fitting without compression
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# As a baseline, we see how long time it takes to fit models without compression.
+# Since PARAFAC2 is very prone to local minima, we fit five models and select the model
+# with the lowest reconstruction error.
+
+print("Fitting PARAFAC2 model without compression...")
+t1 = monotonic()
+lowest_error = float("inf")
+for i in range(n_inits):
+    pf2, errs = parafac2(
+        uncompressed_data,
+        rank,
+        n_iter_max=1000,
+        nn_modes=[0],
+        random_state=rng,
+        return_errors=True,
+    )
+    if errs[-1] < lowest_error:
+        pf2_full, errs_full = pf2, errs
+t2 = monotonic()
+print(
+    f"It took {t2 - t1:.1f}s to fit a PARAFAC2 model a tensor of shape {shape} "
+    + "without compression"
+)
+
+##############################################################################
+# Fitting with lossless compression
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Since the tensor slices have many rows compared to columns, we should be able to save
+# a lot of time by compressing the data. By compressing the matrices, we only need to
+# fit the PARAFAC2 model to a set of 10 matrices, each of size 15 x 15, not 10_000 x 15.
+#
+# The main bottleneck here is the SVD computation at the beginning of the fitting
+# procedure, but luckily, this is independent of the initialisations, so we only need
+# to compute this once. Also, if we are performing a grid search for the rank, then
+# we just need to perform the compression once for the whole grid search as well.
+
+print("Fitting PARAFAC2 model with SVD compression...")
+t1 = monotonic()
+lowest_error = float("inf")
+scores, loadings = preprocessing.svd_compress_tensor_slices(uncompressed_data)
+t2 = monotonic()
+for i in range(n_inits):
+    pf2, errs = parafac2(
+        scores,
+        rank,
+        n_iter_max=1000,
+        nn_modes=[0],
+        random_state=rng,
+        return_errors=True,
+    )
+    if errs[-1] < lowest_error:
+        pf2_compressed, errs_compressed = pf2, errs
+pf2_decompressed = preprocessing.svd_decompress_parafac2_tensor(
+    pf2_compressed, loadings
+)
+t3 = monotonic()
+print(
+    f"It took {t3 - t1:.1f}s to fit a PARAFAC2 model a tensor of shape {shape} "
+    + "with lossless SVD compression"
+)
+print(f"The compression took {t2 - t1:.1f}s and the fitting took {t3 - t2:.1f}s")
+
+##############################################################################
+# We see that we saved a lot of time by compressing the data before fitting the model.
+
+##############################################################################
+# Fitting with lossy compression
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# We can try to speed the process up even further by accepting a slight discrepancy
+# between the model obtained from compressed data and a model obtained from uncompressed
+# data. Specifically, we can truncate the singular values at some threshold, essentially
+# removing the parts of the data matrices that have a very low "signal strength".
+
+print("Fitting PARAFAC2 model with lossy SVD compression...")
+t1 = monotonic()
+lowest_error = float("inf")
+scores, loadings = preprocessing.svd_compress_tensor_slices(uncompressed_data, 1e-5)
+t2 = monotonic()
+for i in range(n_inits):
+    pf2, errs = parafac2(
+        scores,
+        rank,
+        n_iter_max=1000,
+        nn_modes=[0],
+        random_state=rng,
+        return_errors=True,
+    )
+    if errs[-1] < lowest_error:
+        pf2_compressed_lossy, errs_compressed_lossy = pf2, errs
+pf2_decompressed_lossy = preprocessing.svd_decompress_parafac2_tensor(
+    pf2_compressed_lossy, loadings
+)
+t3 = monotonic()
+print(
+    f"It took {t3 - t1:.1f}s to fit a PARAFAC2 model a tensor of shape {shape} "
+    + "with lossy SVD compression"
+)
+print(
+    f"Of which the compression took {t2 - t1:.1f}s and the fitting took {t3 - t2:.1f}s"
+)
+
+##############################################################################
+# We see that we didn't save much, if any, time in this case (compared to using
+# lossless compression). This is because the main bottleneck now is the CP-part of
+# the PARAFAC2 procedure, so reducing the tensor size from 10 x 15 x 15 to 10 x 4 x 15
+# (which is typically what we would get here) will have a negligible effect.
+
+
+##############################################################################
+# Compressing data that is approximately low-rank
+# -----------------------------------------------
+#
+# Here, we simulate data with many rows and columns but an approximately low rank.
+
+rank = 3
+shape = (10, 2_000, 2_000)
+noise_level = 0.33
+
+uncompressed_data = create_random_data(shape, rank=rank, noise_level=noise_level)
+
+##############################################################################
+# Fitting without compression
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Again, we start by fitting without compression as a baseline.
+
+print("Fitting PARAFAC2 model without compression...")
+t1 = monotonic()
+lowest_error = float("inf")
+for i in range(n_inits):
+    pf2, errs = parafac2(
+        uncompressed_data,
+        rank,
+        n_iter_max=1000,
+        nn_modes=[0],
+        random_state=rng,
+        return_errors=True,
+    )
+    if errs[-1] < lowest_error:
+        pf2_full, errs_full = pf2, errs
+t2 = monotonic()
+print(
+    f"It took {t2 - t1:.1f}s to fit a PARAFAC2 model a tensor of shape {shape} "
+    + "without compression"
+)
+
+##############################################################################
+# Fitting with lossless compression
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Next, we fit with lossless compression.
+
+print("Fitting PARAFAC2 model with SVD compression...")
+t1 = monotonic()
+lowest_error = float("inf")
+scores, loadings = preprocessing.svd_compress_tensor_slices(uncompressed_data)
+t2 = monotonic()
+for i in range(n_inits):
+    pf2, errs = parafac2(
+        scores,
+        rank,
+        n_iter_max=1000,
+        nn_modes=[0],
+        random_state=rng,
+        return_errors=True,
+    )
+    if errs[-1] < lowest_error:
+        pf2_compressed, errs_compressed = pf2, errs
+pf2_decompressed = preprocessing.svd_decompress_parafac2_tensor(
+    pf2_compressed, loadings
+)
+t3 = monotonic()
+print(
+    f"It took {t3 - t1:.1f}s to fit a PARAFAC2 model a tensor of shape {shape} "
+    + "with lossless SVD compression"
+)
+print(
+    f"Of which the compression took {t2 - t1:.1f}s and the fitting took {t3 - t2:.1f}s"
+)
+
+##############################################################################
+# We see that the lossless compression no effect for this data. This is because the
+# number ofrows is equal to the number of columns, so we cannot compress the data
+# losslessly with the SVD.
+
+##############################################################################
+# Fitting with lossy compression
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Finally, we fit with lossy SVD compression.
+
+print("Fitting PARAFAC2 model with lossy SVD compression...")
+t1 = monotonic()
+lowest_error = float("inf")
+scores, loadings = preprocessing.svd_compress_tensor_slices(uncompressed_data, 1e-5)
+t2 = monotonic()
+for i in range(n_inits):
+    pf2, errs = parafac2(
+        scores,
+        rank,
+        n_iter_max=1000,
+        nn_modes=[0],
+        random_state=rng,
+        return_errors=True,
+    )
+    if errs[-1] < lowest_error:
+        pf2_compressed_lossy, errs_compressed_lossy = pf2, errs
+pf2_decompressed_lossy = preprocessing.svd_decompress_parafac2_tensor(
+    pf2_compressed_lossy, loadings
+)
+t3 = monotonic()
+print(
+    f"It took {t3 - t1:.1f}s to fit a PARAFAC2 model a tensor of shape {shape} "
+    + "with lossy SVD compression"
+)
+print(
+    f"Of which the compression took {t2 - t1:.1f}s and the fitting took {t3 - t2:.1f}s"
+)
+
+
+##############################################################################
+# Here we see a large speedup. This is because the data is approximately low rank so
+# the compressed tensor slices will have shape R x 2_000, where R is typically below 10
+# in this example. If your tensor slices are large in both modes, you might want to plot
+# the singular values of your dataset to see if lossy compression could speed up
+# PARAFAC2.

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -16,9 +16,8 @@ from ...parafac2_tensor import Parafac2Tensor, parafac2_to_tensor, parafac2_to_s
 from ...metrics.factors import congruence_coefficient
 
 
-@pytest.mark.parametrize(
-    ("normalize_factors", "init"), itertools.product([True, False], ["random", "svd"])
-)
+@pytest.mark.parametrize("normalize_factors", [True, False])
+@pytest.mark.parametrize("init", ["random", "svd"])
 def test_parafac2(monkeypatch, normalize_factors, init):
     rng = tl.check_random_state(1234)
     tol_norm_2 = 10e-2

--- a/tensorly/preprocessing.py
+++ b/tensorly/preprocessing.py
@@ -1,0 +1,132 @@
+from tensorly import backend as T
+
+from .parafac2_tensor import Parafac2Tensor
+from .tenalg.svd import svd_interface
+
+
+def svd_compress_tensor_slices(
+    tensor_slices, compression_threshold=0.0, svd="truncated_svd"
+):
+    r"""Compress data with the SVD for running PARAFAC2.
+
+    PARAFAC2 can be sped up massively for data where the number of rows in the tensor slices
+    is much greater than their rank. In that case, we can compress the data by computing the
+    SVD and fitting the PARAFAC2 model to the right singular vectors multiplied by the singular
+    values. Then, we can "decompress" the decomposition by left-multiplying the :math:`B_i`-matrices
+    by the left singular values to get a decomposition as if it was fitted to the uncompressed
+    data. We can essentially think of this as running a PCA without centering the data for each
+    tensor slice and fitting the PARAFAC2 model to the scores. Then, to get back the components,
+    we left-multiply the :math:`B_i`-matrices with the loading matrices.
+
+    [1]_ states that we can constrain our :math:`B_i`-matrices to lie in a given vector space,
+    :math:`\mathscr{V}_i` by multiplying the data matrices with an orthogonal basis matrix that
+    spans :math:`\mathscr{V}_i`. However, since we know that :math:`B_i` lie in the column space
+    of :math:`X_i`, we can multiply the :math:`X_i`-matrices by an orthogonal matrix that spans
+    :math:`\text{col}(X_i)` without affecting the fit of the model. Thus we can compress our data
+    prior to fitting the PARAFAC2 model whenever the number of rows in our data matrices exceeds
+    the number of columns (as the rank of :math:`\text{col}(X_i)` cannot exceed the number of rows).
+
+    To implement this, we use the SVD to get an orthogonal basis for the column space of :math:`X_i`.
+    Moreover, since :math:`S_i V_i^T = U_i^T X_i`, we can skip an additional matrix multiplication
+    by fitting the model to :math:`S_i V_i^T`.
+
+    Finally, we note that this approach can also be implemented by truncating the SVD. If an appropriate
+    threshold is set, this will not affect the fitted model in any major form.
+
+    .. note::
+        This can be thought of as a simplified version of the DPAR approach for compressing PARAFAC2 models [2]_,
+        which compresses all modes of :math:`\mathcal{X}` to fit an approximate PARAFAC2 model.
+
+    Parameters
+    ----------
+    tensor_slices : list of matrices
+        The data matrices to compress
+    compression_threshold : float (0 <= compression_threshold <= 1)
+        Threshold at which the singular values should be truncated. Any singular value less than
+        compression_threshold * s[0] is set to zero. Note that if this is nonzero, then the found
+        components will likely be affected.
+    svd : str, default is 'truncated_svd'
+        function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
+
+    Returns
+    -------
+    list of matrices
+        The score matrices, used to fit the PARAFAC2 model to.
+    list of matrices
+        The loading matrices, used to decompress the PARAFAC2 components after fitting
+        to the scores.
+
+    References
+    ----------
+    .. [1] Helwig, N. E. (2017). Estimating latent trends in multivariate longitudinal
+           data via Parafac2 with functional and structural constraints. Biometrical
+           Journal, 59(4), 783-803. doi: 10.1002/bimj.201600045
+
+    .. [2] Jang JG, Kang U. Dpar2: Fast and scalable parafac2 decomposition for
+           irregular dense tensors. 38th International Conference on Data Engineering
+           (ICDE) 2022 May 9 (pp. 2454-2467). IEEE.
+
+    """
+    loading_matrices = [None for _ in tensor_slices]
+    score_matrices = [None for _ in tensor_slices]
+
+    for i, tensor_slice in enumerate(tensor_slices):
+        n_rows, n_cols = T.shape(tensor_slice)
+        if n_rows <= n_cols and not compression_threshold:
+            score_matrices[i] = tensor_slice
+            continue
+
+        U, s, Vh = svd_interface(tensor_slice, n_eigenvecs=n_cols, method=svd)
+
+        # Threshold SVD, keeping only singular values that satisfy s_i >= s_0 * epsilon
+        # where epsilon is the compression threshold
+        num_svds = len([s_i for s_i in s if s_i >= (s[0] * compression_threshold)])
+        U, s, Vh = U[:, :num_svds], s[:num_svds], Vh[:num_svds, :]
+
+        # Array broadcasting happens at the last dimension, since Vh is num_svds x n_cols
+        # we need to transpose it, multiply in the singular values and then transpose
+        # it again. This is equivalen to writing diag(s) @ Vh. If we skip the
+        # transposes, we would get Vh @ diag(s), which is wrong.
+        score_matrices[i] = T.transpose(s * T.transpose(Vh))
+        loading_matrices[i] = U
+
+    return score_matrices, loading_matrices
+
+
+def svd_decompress_parafac2_tensor(parafac2_tensor, loading_matrices):
+    """Decompress the factors obtained by fitting PARAFAC2 on SVD-compressed data
+
+    Decompress a PARAFAC2 decomposition that describes the compressed data so that it
+    models the original uncompressed data. Fitting to compressed data, and then
+    decompressing is mathematically equivalent to fitting to the uncompressed data.
+
+    See :py:meth:`svd_compress_tensor_slices` for information about SVD-compression and
+    decompression.
+
+    .. note::
+        To decompress the data, we left-multiply the loading-matrices into the
+        :math:`B_i`-matrices. However, :math:`B_i = P_i B`, so the decompression is
+        implemented by left-multiplying the loading matrices by the :math:`P_i`-matrices.
+
+    Parameters
+    ----------
+    parafac2_tensor: tl.Parafac2Tensor
+        A decomposition obtained from fitting a PARAFAC2 model to compressed data
+    loading_matrices: list of matrices
+        Loading matrices obtained when compressing the data. See
+        :py:meth:`svd_compress_tensor_slices` for more information.
+
+    Returns
+    -------
+    tl.Parafac2Tensor:
+        Decompressed PARAFAC2 decomposition - equivalent to the decomposition we would
+        get from fitting parafac2 to uncompressed data.
+    """
+    weights, factors, projections = parafac2_tensor
+    projections = projections.copy()
+
+    for i, projection in enumerate(projections):
+        if loading_matrices[i] is not None:
+            projections[i] = T.matmul(loading_matrices[i], projection)
+
+    return Parafac2Tensor((weights, factors, projections))

--- a/tensorly/tests/test_preprocessing.py
+++ b/tensorly/tests/test_preprocessing.py
@@ -1,0 +1,142 @@
+import pytest
+from pytest import approx
+
+import numpy as np
+import tensorly as tl
+
+from ..parafac2_tensor import parafac2_to_slices
+from ..random import random_parafac2
+from ..testing import assert_allclose
+from ..decomposition._parafac2 import parafac2, _parafac2_reconstruction_error
+from ..preprocessing import svd_compress_tensor_slices, svd_decompress_parafac2_tensor
+
+
+@pytest.mark.parametrize("normalize_factors", [True, False])
+@pytest.mark.parametrize("compression_threshold", [0, 1e-5])
+def test_svd_compression_gets_correct_components(
+    compression_threshold, normalize_factors
+):
+    """The compressed data can be used to find the components"""
+    rng = tl.check_random_state(1234)
+    rank = 3
+    tol_norm_2 = 1e-2
+
+    random_parafac2_tensor = random_parafac2(
+        shapes=[(20 + rng.randint(5), 19) for _ in range(10)],
+        rank=rank,
+        random_state=rng,
+        dtype=tl.float64,
+    )
+
+    slices = parafac2_to_slices(random_parafac2_tensor)
+    compressed_slices, loadings = svd_compress_tensor_slices(
+        slices, compression_threshold=compression_threshold
+    )
+    rec_pf2 = parafac2(
+        compressed_slices,
+        rank,
+        random_state=rng,
+        normalize_factors=normalize_factors,
+        n_iter_max=100,
+    )
+
+    decompressed_pf2 = svd_decompress_parafac2_tensor(rec_pf2, loadings)
+    rec_slices = parafac2_to_slices(decompressed_pf2)
+    for slice, rec_slice in zip(slices, rec_slices):
+        slice_error = tl.norm(slice - rec_slice) / tl.norm(slice)
+        assert slice_error < tol_norm_2, slice_error
+
+
+@pytest.mark.parametrize("normalize_factors", [True, False])
+def test_svd_compression_doesnt_disturb_error(normalize_factors):
+    """The SSE for the compressed data is equal to the SSE of the uncompressed data"""
+    rng = tl.check_random_state(1234)
+    rank = 3
+
+    random_parafac2_tensor = random_parafac2(
+        shapes=[(20 + rng.randint(5), 19) for _ in range(10)],
+        rank=rank,
+        random_state=rng,
+        dtype=tl.float64,
+    )
+
+    slices = parafac2_to_slices(random_parafac2_tensor)
+    compressed_slices, loadings = svd_compress_tensor_slices(
+        slices, compression_threshold=0
+    )
+    rec_pf2 = parafac2(
+        compressed_slices,
+        rank,
+        random_state=rng,
+        normalize_factors=normalize_factors,
+        n_iter_max=100,
+    )
+
+    decompressed_pf2 = svd_decompress_parafac2_tensor(rec_pf2, loadings)
+    compressed_error = _parafac2_reconstruction_error(compressed_slices, rec_pf2)
+    decompressed_error = _parafac2_reconstruction_error(slices, decompressed_pf2)
+    assert tl.to_numpy(compressed_error) == approx(tl.to_numpy(decompressed_error))
+
+
+def test_svd_compression_compresses_only_when_necessary():
+    """Compression is only done when the number of rows is less than the number of columns and compression_threshold != 0"""
+    rng = tl.check_random_state(1234)
+    tensor_slices = [
+        tl.tensor(rng.standard_normal((25, 10)), dtype=tl.float64),
+        tl.tensor(rng.standard_normal((10, 10)), dtype=tl.float64),
+    ]
+    compressed_slices, loadings = svd_compress_tensor_slices(tensor_slices)
+
+    # First slice is compressed
+    assert compressed_slices[0] is not tensor_slices[0]
+    assert compressed_slices[0].shape == (10, 10)
+    assert loadings[0].shape == (25, 10)
+
+    # Second slice is not compressed
+    assert compressed_slices[1] is tensor_slices[1]
+    assert loadings[1] is None
+
+
+def test_svd_compression_compresses_uses_compression_threshold():
+    """If compression threshold is set, small singular values are truncated"""
+    rng = tl.check_random_state(1234)
+    slice = tl.tensor(rng.standard_normal((10, 5)), dtype=tl.float64)
+    slice = tl.concatenate([slice, slice[:, -1:] + 1e-10], axis=1)
+
+    compressed_slices, loadings = svd_compress_tensor_slices(
+        [slice], compression_threshold=1e-5
+    )
+
+    assert tl.shape(compressed_slices[0]) == (5, 6)
+    assert tl.shape(loadings[0]) == (10, 5)
+
+
+def test_svd_compression_gives_orthogonal_scores():
+    """Compressed tensor slices should have orthogonal rows"""
+    rng = tl.check_random_state(1234)
+    tensor_slices = [
+        tl.tensor(rng.standard_normal((25, 10)), dtype=tl.float64),
+        tl.tensor(rng.standard_normal((25, 10)), dtype=tl.float64),
+    ]
+    compressed_slices, _loadings = svd_compress_tensor_slices(tensor_slices)
+    for compressed_slice in compressed_slices:
+        gramian = tl.to_numpy(
+            tl.matmul(compressed_slice, tl.transpose(compressed_slice))
+        )
+        diagonal_entries = np.diag(gramian)
+
+        np.testing.assert_allclose(np.diag(diagonal_entries), gramian, atol=1e-10)
+
+
+def test_svd_compression_gives_orthonormal_loadings():
+    """Loading matrices should have orthonormal columns"""
+    rng = tl.check_random_state(1234)
+    tensor_slices = [
+        tl.tensor(rng.standard_normal((25, 10)), dtype=tl.float64),
+        tl.tensor(rng.standard_normal((25, 10)), dtype=tl.float64),
+    ]
+    _compressed_slices, loadings = svd_compress_tensor_slices(tensor_slices)
+
+    for loading_matrix in loadings:
+        gramian = tl.matmul(tl.transpose(loading_matrix), loading_matrix)
+        assert_allclose(gramian, tl.eye(tl.shape(gramian)[0]), atol=1e-10)


### PR DESCRIPTION
A big downside with PARAFAC2 is that it is slow. This is exacerbated by the local minima issue, which means that we need to fit models with several different initialisations to avoid ending up in a local minima.

However, we can speed up the fitting procedure drastically in two cases: when J ≪ K (for an I × J × K tensor) or when the I horisontal slices have approximately low rank. In these cases, we can preprocess the data by computing the singular value decomposition, which we can think of as a data compression step. Then, we fit the PARAFAC2 model to the right singular vectors multiplied by the singular values, which will have a dimensionality of K × K (or L × K, with L < K if the data is approximately low rank). Finally, to decompress the decomposition to model the original, uncompressed data, we left-multiply the B_i-matrices with the left singular vectors of the data matrices.

However, we can speed up the fitting procedure drastically in two cases: when J ≪ K (for an I × J × K tensor) or when the I lateral slices have approximately low rank. In these cases, we can preprocess the data by computing the singular value decomposition. Then, we fit the PARAFAC2 model to the right singular vectors multiplied by the singular values. This is a data compression step since these matrices will have a size K × K (or L × K, with L < K if the data is approximately low rank and we truncate the SVD). Finally, to decompress the decomposition to model the original, uncompressed data, we left-multiply the B_i-matrices with the left singular vectors of the data matrices.

For more information about how this works, see the documentation of `tensorly.decomposition.preprocessing.svd_compress_tensor_slices` from this PR. This code also includes an example for the documentation demonstrating how to use this compression scheme with PARAFAC2.

**Note:**
Since we would typically like to do this once and share the compressed data for each initialisation (and each model in a grid search), we thought it made more sense to keep this in a separate preprocessing module instead of adding more flags to the PARAFAC2 function. This workflow makes it more apparent to the user that this step should be done once and cached, which is important since the SVD of the tensor slices can be time-consuming. 