### PR TITLE
Fully deprecate mxnet

### DIFF
--- a/tensorly/backend/mxnet_backend.py
+++ b/tensorly/backend/mxnet_backend.py
@@ -18,8 +18,8 @@ mx.npx.set_np()
 class MxnetBackend(Backend, backend_name="mxnet"):
     def __init__(name):
         message = (
-            "The MXNet backend may be deprecated in future versions.\n"
-            "Please consider transitioning to an alternative."
+            "The MXNet backend is deprecated and will be removed in future versions.\n"
+            "Please transition to another backend."
         )
         DeprecationWarning(message)
         super().__init__()


### PR DESCRIPTION
The mxnet project has been [formally archived](https://whimsy.apache.org/board/minutes/MXNet.html). Therefore, I think it is reasonable to fully deprecate mxnet, before it stops working on various new Python and numpy versions.

I will also open a draft PR for removing mxnet that we can keep open until a new TensorLy version is issued.

Searching on Github, I only found mxnet being used in copies of the tutorials and one project that tests against all backends, so I think that the impact will be minimal.