### PR TITLE
Simplify proximal operator code

### DIFF
--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -1158,6 +1158,11 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
           least squares algorithm. Journal of Chemometrics: A Journal of
           the Chemometrics Society, 11(5), 393-401.
     """
+    if tl.get_backend() == "tensorflow":
+        raise ValueError(
+            "Active set is not supported with the tensorflow backend. Consider using fista method with tensorflow."
+        )
+
     if x is None:
         x_vec = tl.zeros(tl.shape(UtU)[1], **tl.context(UtU))
     else:
@@ -1193,7 +1198,7 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
 
         # update support vector if it is necessary
         if tl.min(support_vec[~active_set]) <= 0:
-            for i in range(len(~active_set)):
+            for i in range(len(active_set)):
                 alpha = tl.min(
                     x_vec[~active_set][support_vec[~active_set] <= 0]
                     / (

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -1158,97 +1158,62 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
           least squares algorithm. Journal of Chemometrics: A Journal of
           the Chemometrics Society, 11(5), 393-401.
     """
-    if tl.get_backend() == "tensorflow":
-        raise ValueError(
-            "Active set is not supported with the tensorflow backend. Consider using fista method with tensorflow."
-        )
-
     if x is None:
         x_vec = tl.zeros(tl.shape(UtU)[1], **tl.context(UtU))
     else:
         x_vec = tl.base.tensor_to_vec(x)
 
     x_gradient = Utm - tl.dot(UtU, x_vec)
-    passive_set = x_vec > 0
     active_set = x_vec <= 0
     support_vec = tl.zeros(tl.shape(x_vec), **tl.context(x_vec))
 
     for iteration in range(n_iter_max):
         if iteration > 0 or tl.all(x_vec == 0):
             indice = tl.argmax(x_gradient)
-            passive_set = tl.index_update(passive_set, tl.index[indice], True)
             active_set = tl.index_update(active_set, tl.index[indice], False)
         # To avoid singularity error when initial x exists
         try:
             passive_solution = tl.solve(
-                UtU[passive_set, :][:, passive_set], Utm[passive_set]
+                UtU[~active_set, :][:, ~active_set], Utm[~active_set]
             )
-            indice_list = []
-            for i in range(tl.shape(support_vec)[0]):
-                if passive_set[i]:
-                    indice_list.append(i)
-                    support_vec = tl.index_update(
-                        support_vec,
-                        tl.index[int(i)],
-                        passive_solution[len(indice_list) - 1],
-                    )
-                else:
-                    support_vec = tl.index_update(support_vec, tl.index[int(i)], 0)
         # Start from zeros if solve is not achieved
         except:
             x_vec = tl.zeros(tl.shape(UtU)[1])
             support_vec = tl.zeros(tl.shape(x_vec), **tl.context(x_vec))
-            passive_set = x_vec > 0
             active_set = x_vec <= 0
             if tl.any(active_set):
                 indice = tl.argmax(x_gradient)
-                passive_set = tl.index_update(passive_set, tl.index[indice], True)
                 active_set = tl.index_update(active_set, tl.index[indice], False)
             passive_solution = tl.solve(
-                UtU[passive_set, :][:, passive_set], Utm[passive_set]
+                UtU[~active_set, :][:, ~active_set], Utm[~active_set]
             )
-            indice_list = []
-            for i in range(tl.shape(support_vec)[0]):
-                if passive_set[i]:
-                    indice_list.append(i)
-                    support_vec = tl.index_update(
-                        support_vec,
-                        tl.index[int(i)],
-                        passive_solution[len(indice_list) - 1],
-                    )
-                else:
-                    support_vec = tl.index_update(support_vec, tl.index[int(i)], 0)
+
+        support_vec = tl.zeros(tl.shape(support_vec), **tl.context(support_vec))
+        support_vec = tl.index_update(support_vec, ~active_set, passive_solution)
 
         # update support vector if it is necessary
-        if tl.min(support_vec[passive_set]) <= 0:
-            for i in range(len(passive_set)):
+        if tl.min(support_vec[~active_set]) <= 0:
+            for i in range(len(~active_set)):
                 alpha = tl.min(
-                    x_vec[passive_set][support_vec[passive_set] <= 0]
+                    x_vec[~active_set][support_vec[~active_set] <= 0]
                     / (
-                        x_vec[passive_set][support_vec[passive_set] <= 0]
-                        - support_vec[passive_set][support_vec[passive_set] <= 0]
+                        x_vec[~active_set][support_vec[~active_set] <= 0]
+                        - support_vec[~active_set][support_vec[~active_set] <= 0]
                     )
                 )
                 update = alpha * (support_vec - x_vec)
                 x_vec = x_vec + update
-                passive_set = x_vec > 0
                 active_set = x_vec <= 0
                 passive_solution = tl.solve(
-                    UtU[passive_set, :][:, passive_set], Utm[passive_set]
+                    UtU[~active_set, :][:, ~active_set], Utm[~active_set]
                 )
-                indice_list = []
-                for i in range(tl.shape(support_vec)[0]):
-                    if passive_set[i]:
-                        indice_list.append(i)
-                        support_vec = tl.index_update(
-                            support_vec,
-                            tl.index[int(i)],
-                            passive_solution[len(indice_list) - 1],
-                        )
-                    else:
-                        support_vec = tl.index_update(support_vec, tl.index[int(i)], 0)
 
-                if tl.any(passive_set) != True or tl.min(support_vec[passive_set]) > 0:
+                support_vec = tl.zeros(tl.shape(support_vec), **tl.context(support_vec))
+                support_vec = tl.index_update(
+                    support_vec, ~active_set, passive_solution
+                )
+
+                if tl.all(active_set) != True or tl.min(support_vec[~active_set]) > 0:
                     break
         # set x to s
         x_vec = tl.clip(support_vec, 0, tl.max(support_vec))

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -1193,12 +1193,13 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
                 UtU[~active_set, :][:, ~active_set], Utm[~active_set]
             )
 
+        # Update support vector with passive solution
         support_vec = tl.zeros(tl.shape(support_vec), **tl.context(support_vec))
         support_vec = tl.index_update(support_vec, ~active_set, passive_solution)
 
         # update support vector if it is necessary
         if tl.min(support_vec[~active_set]) <= 0:
-            for i in range(len(active_set)):
+            for _ in range(len(active_set)):
                 alpha = tl.min(
                     x_vec[~active_set][support_vec[~active_set] <= 0]
                     / (
@@ -1213,11 +1214,13 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
                     UtU[~active_set, :][:, ~active_set], Utm[~active_set]
                 )
 
+                # Update support vector with passive solution
                 support_vec = tl.zeros(tl.shape(support_vec), **tl.context(support_vec))
                 support_vec = tl.index_update(
                     support_vec, ~active_set, passive_solution
                 )
 
+                # Break if finished updating
                 if tl.all(active_set) != True or tl.min(support_vec[~active_set]) > 0:
                     break
         # set x to s

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -21,8 +21,13 @@ from ..proximal import (
 )
 from ...testing import assert_, assert_array_equal, assert_array_almost_equal
 from tensorly import tensor_to_vec, truncated_svd
+import pytest
 
 # Author: Jean Kossaifi
+skip_tensorflow = pytest.mark.skipif(
+    (T.get_backend() == "tensorflow"),
+    reason=f"Indexing with list not supported in TensorFlow",
+)
 
 
 def test_smoothness():
@@ -230,6 +235,7 @@ def test_admm():
     assert_array_almost_equal(true_res, T.transpose(x_admm), decimal=2)
 
 
+@skip_tensorflow
 def test_active_set_nnls():
     """Test for active_set_nnls operator"""
     a = T.tensor(np.random.rand(20, 10))

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -21,13 +21,8 @@ from ..proximal import (
 )
 from ...testing import assert_, assert_array_equal, assert_array_almost_equal
 from tensorly import tensor_to_vec, truncated_svd
-import pytest
 
 # Author: Jean Kossaifi
-skip_tensorflow = pytest.mark.skipif(
-    (T.get_backend() == "tensorflow"),
-    reason=f"Indexing with list not supported in TensorFlow",
-)
 
 
 def test_smoothness():
@@ -235,7 +230,6 @@ def test_admm():
     assert_array_almost_equal(true_res, T.transpose(x_admm), decimal=2)
 
 
-@skip_tensorflow
 def test_active_set_nnls():
     """Test for active_set_nnls operator"""
     a = T.tensor(np.random.rand(20, 10))


### PR DESCRIPTION
Indexing operations are slow on the Jax and Tensorflow backends. This aims to reduce the places where indexing occurs. It should also make it possible to use the Tensorflow backend.