### PR TITLE
Small fixes in NN PARAFAC/PARAFAC2

### DIFF
--- a/tensorly/decomposition/_nn_cp.py
+++ b/tensorly/decomposition/_nn_cp.py
@@ -308,7 +308,7 @@ def non_negative_parafac_hals(
         # One pass of least squares on each updated mode
         for mode in modes:
             # Computing Hadamard of cross-products
-            pseudo_inverse = tl.tensor(tl.ones((rank, rank)), **tl.context(tensor))
+            pseudo_inverse = tl.ones((rank, rank), **tl.context(tensor))
             for i, factor in enumerate(factors):
                 if i != mode:
                     pseudo_inverse = pseudo_inverse * tl.dot(

--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -436,6 +436,7 @@ def parafac2(
     weights, factors, projections = initialize_decomposition(
         tensor_slices, rank, init=init, svd=svd, random_state=random_state
     )
+    factors = list(factors)
 
     rec_errors = []
     norm_tensor = tl.sqrt(


### PR DESCRIPTION
This fixes two bugs I encountered when using PARAFAC2 alongside PyTorch, providing an initial set of factors:

- When providing an initial solution to PARAFAC2, it converts the factors to a tuple, which prevents index updating. This prevents ALS from working.
- `tl.tensor()` uses the `with torch.device(device):` context when copying the provided data, but this does not move the tensor to a different device. I changed this to provide the context directly to `tl.ones()`.

I can write a simple test for the PARAFAC2 bug. For the HALS CP one, there is already an issue about testing context more heavily. A more general testing solution would be preferable.