### PR TITLE
Fix torch tensor creation dtype/device

### DIFF
--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -35,21 +35,19 @@ class PyTorchBackend(Backend, backend_name="pytorch"):
 
     @staticmethod
     def _from_torch(data, dtype, device, requires_grad):
-        if dtype is None:
-            # Infer dtype from data
-            dtype = data.dtype
+        # Clone tensor as recommended by PyTorch
+        tensor = data.clone()
 
-        if requires_grad is None:
-            # Infer requires_grad from data
-            requires_grad = data.requires_grad
+        if dtype is not None:
+            tensor = tensor.type(dtype)
 
-        if device is None:
-            # Infer device from data
-            device = data.device
+        if requires_grad is not None:
+            tensor.requires_grad_(requires_grad)
 
-        return torch.tensor(
-            data.clone(), dtype=dtype, device=device, requires_grad=requires_grad
-        )
+        if device is not None:
+            tensor = tensor.to(device=device)
+
+        return tensor
 
     @staticmethod
     def _from_numpy(data, dtype, device, requires_grad):

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -46,11 +46,14 @@ class TensorflowBackend(Backend, backend_name="tensorflow"):
 
         # If device or device_id is specified, place the tensor on the correct device
         if device is not None or device_id is not None:
-            with tf.device(f'{device}:{device_id}' if device_id is not None else device):
-                out = tf.Variable(out.numpy(), dtype=dtype)  # Re-wrap the tensor on the specified device
+            with tf.device(
+                f"{device}:{device_id}" if device_id is not None else device
+            ):
+                out = tf.Variable(
+                    out.numpy(), dtype=dtype
+                )  # Re-wrap the tensor on the specified device
 
         return out
-
 
     @staticmethod
     def is_tensor(tensor):

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -289,9 +289,9 @@ def test_parafac2_nn(linesearch):
     # The default random parafac2 tensor has non-negative A and C
     # we therefore multiply them randomly with -1, 0 or 1 to get both positive and negative components
     factors = [
-        factors[0] * T.tensor(rng.randint(-1, 2, factors[0].shape)),
+        factors[0] * T.tensor(rng.randint(-1, 2, factors[0].shape), dtype=tl.float64),
         factors[1],
-        factors[2] * T.tensor(rng.randint(-1, 2, factors[2].shape)),
+        factors[2] * T.tensor(rng.randint(-1, 2, factors[2].shape), dtype=tl.float64),
     ]
     slices = parafac2_to_slices((weights, factors, projections))
     rec, _ = parafac2(

--- a/tensorly/decomposition/tests/test_robust_decomposition.py
+++ b/tensorly/decomposition/tests/test_robust_decomposition.py
@@ -53,7 +53,7 @@ def test_RPCA():
     tensor = tl.tensor(corrupted_clean + corrupted_noise)
     corrupted_noise = tl.tensor(corrupted_noise)
     corrupted_clean = tl.tensor(corrupted_clean)
-    mask = tl.tensor(mask)
+    mask = tl.tensor(mask, dtype=tl.float64)
     # Decompose the tensor
     clean_pred, noise_pred = robust_pca(
         tensor,

--- a/tensorly/metrics/tests/test_regression.py
+++ b/tensorly/metrics/tests/test_regression.py
@@ -7,16 +7,16 @@ from ...testing import assert_array_almost_equal
 
 def test_MSE():
     """Test for MSE"""
-    y_true = tl.tensor([1, 0, 2, -2])
-    y_pred = tl.tensor([1, -1, 1, -1])
+    y_true = tl.tensor([1, 0, 2, -2], dtype=tl.float32)
+    y_pred = tl.tensor([1, -1, 1, -1], dtype=tl.float32)
     true_mse = 0.75
     assert_array_almost_equal(MSE(y_true, y_pred), true_mse)
 
 
 def test_RMSE():
     """Test for RMSE"""
-    y_true = tl.tensor([1, 0, 2, -2])
-    y_pred = tl.tensor([0, -1, 1, -1])
+    y_true = tl.tensor([1, 0, 2, -2], dtype=tl.float32)
+    y_pred = tl.tensor([0, -1, 1, -1], dtype=tl.float32)
     true_mse = 1
     assert_array_almost_equal(RMSE(y_true, y_pred), true_mse)
 
@@ -36,11 +36,11 @@ def test_correlation():
     assert_array_almost_equal(correlation(a, a * 2 + 1), 1)
     assert_array_almost_equal(correlation(a, -a * 2 + 1), -1)
 
-    a = tl.tensor([1, 2, 3, 2, 1])
-    b = tl.tensor([1, 2, 3, 4, 5])
+    a = tl.tensor([1, 2, 3, 2, 1], dtype=tl.float32)
+    b = tl.tensor([1, 2, 3, 4, 5], dtype=tl.float32)
     assert_array_almost_equal(correlation(a, b), 0)
 
-    a = tl.tensor([[1, 2, 3, 2, 1]] * 3)
-    b = tl.tensor([[1, 2, 3, 4, 5]] * 3)
-    res = tl.tensor([0, 0, 0])
+    a = tl.tensor([[1, 2, 3, 2, 1]] * 3, dtype=tl.float32)
+    b = tl.tensor([[1, 2, 3, 4, 5]] * 3, dtype=tl.float32)
+    res = tl.tensor([0, 0, 0], dtype=tl.float32)
     assert_array_almost_equal(correlation(a, b, axis=1), res)

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -435,9 +435,15 @@ def smoothness_prox(tensor, regularizer):
 
     """
     diag_matrix = (
-        tl.diag(2 * regularizer * tl.ones(tl.shape(tensor)[0]) + 1)
-        + tl.diag(-regularizer * tl.ones(tl.shape(tensor)[0] - 1), k=-1)
-        + tl.diag(-regularizer * tl.ones(tl.shape(tensor)[0] - 1), k=1)
+        tl.diag(
+            2 * regularizer * tl.ones(tl.shape(tensor)[0], **tl.context(tensor)) + 1
+        )
+        + tl.diag(
+            -regularizer * tl.ones(tl.shape(tensor)[0] - 1, **tl.context(tensor)), k=-1
+        )
+        + tl.diag(
+            -regularizer * tl.ones(tl.shape(tensor)[0] - 1, **tl.context(tensor)), k=1
+        )
     )
     return tl.solve(diag_matrix, tensor)
 
@@ -480,7 +486,7 @@ def monotonicity_prox(tensor, decreasing=False):
     row, column = tl.shape(tensor_mon)
     cum_sum = tl.cumsum(tensor_mon, axis=0)
     for j in range(column):
-        assisted_tensor = tl.zeros([row, row])
+        assisted_tensor = tl.zeros([row, row], **tl.context(tensor))
         for i in range(row):
             if i == 0:
                 assisted_tensor = tl.index_update(
@@ -738,11 +744,11 @@ def simplex_prox(tensor, parameter):
     tensor_sort = tl.flip(tl.sort(tensor, axis=0), axis=0)
     # Broadcasting is used to divide rows by 1,2,3...
     cumsum_min_param_by_k = (tl.cumsum(tensor_sort, axis=0) - parameter) / tl.cumsum(
-        tl.ones([row, 1]), axis=0
+        tl.ones([row, 1], **tl.context(tensor)), axis=0
     )
     # Added -1 to correspond to a Python index
     to_change = tl.sum(tl.where(tensor_sort > cumsum_min_param_by_k, 1, 0), axis=0) - 1
-    difference = tl.zeros(col)
+    difference = tl.zeros(col, **tl.context(tensor))
     for i in range(col):
         difference = tl.index_update(
             difference, tl.index[i], cumsum_min_param_by_k[to_change[i], i]
@@ -1196,7 +1202,7 @@ def active_set_nnls(Utm, UtU, x=None, n_iter_max=100, tol=10e-8):
                     support_vec = tl.index_update(support_vec, tl.index[int(i)], 0)
         # Start from zeros if solve is not achieved
         except:
-            x_vec = tl.zeros(tl.shape(UtU)[1])
+            x_vec = tl.zeros(tl.shape(UtU)[1], **tl.context(UtU))
             support_vec = tl.zeros(tl.shape(x_vec), **tl.context(x_vec))
             passive_set = x_vec > 0
             active_set = x_vec <= 0

--- a/tensorly/tenalg/tests/test_kronecker.py
+++ b/tensorly/tenalg/tests/test_kronecker.py
@@ -4,6 +4,7 @@ from ... import backend as T
 from .. import kronecker
 from .. import khatri_rao
 from ...testing import assert_array_equal, assert_array_almost_equal
+import tensorly as tl
 
 # Author: Jean Kossaifi
 
@@ -11,24 +12,31 @@ from ...testing import assert_array_equal, assert_array_almost_equal
 def test_kronecker():
     """Test for kronecker product"""
     # Mathematical test
-    a = T.tensor([[1, 2, 3], [3, 2, 1]])
-    b = T.tensor([[2, 1], [2, 3]])
+    a = T.tensor([[1, 2, 3], [3, 2, 1]], dtype=tl.float32)
+    b = T.tensor([[2, 1], [2, 3]], dtype=tl.float32)
     true_res = T.tensor(
-        [[2, 1, 4, 2, 6, 3], [2, 3, 4, 6, 6, 9], [6, 3, 4, 2, 2, 1], [6, 9, 4, 6, 2, 3]]
+        [
+            [2, 1, 4, 2, 6, 3],
+            [2, 3, 4, 6, 6, 9],
+            [6, 3, 4, 2, 2, 1],
+            [6, 9, 4, 6, 2, 3],
+        ],
+        dtype=tl.float32,
     )
     res = kronecker([a, b])
     assert_array_equal(true_res, res)
 
     # Another test
-    a = T.tensor([[1, 2], [3, 4]])
-    b = T.tensor([[0, 5], [6, 7]])
+    a = T.tensor([[1, 2], [3, 4]], dtype=tl.float32)
+    b = T.tensor([[0, 5], [6, 7]], dtype=tl.float32)
     true_res = T.tensor(
-        [[0, 5, 0, 10], [6, 7, 12, 14], [0, 15, 0, 20], [18, 21, 24, 28]]
+        [[0, 5, 0, 10], [6, 7, 12, 14], [0, 15, 0, 20], [18, 21, 24, 28]],
+        dtype=tl.float32,
     )
     res = kronecker([a, b])
     assert_array_equal(true_res, res)
     # Adding a third matrices
-    c = T.tensor([[0, 1], [2, 0]])
+    c = T.tensor([[0, 1], [2, 0]], dtype=tl.float32)
     res = kronecker([c, a, b])
     assert res.shape == (
         a.shape[0] * b.shape[0] * c.shape[0],
@@ -67,15 +75,16 @@ def test_kronecker():
     for i, shape in enumerate(shapes):
         assert_array_almost_equal(res, kr)
 
-    a = T.tensor([[1, 2], [0, 3]])
-    b = T.tensor([[0.5, 1], [1, 2]])
+    a = T.tensor([[1, 2], [0, 3]], dtype=tl.float32)
+    b = T.tensor([[0.5, 1], [1, 2]], dtype=tl.float32)
     true_res = T.tensor(
         [
             [0.5, 1.0, 1.0, 2.0],
             [1.0, 2.0, 2.0, 4.0],
             [0.0, 0.0, 1.5, 3.0],
             [0.0, 0.0, 3.0, 6.0],
-        ]
+        ],
+        dtype=tl.float32,
     )
     assert_array_equal(kronecker([a, b]), true_res)
     reversed_res = T.tensor(
@@ -84,7 +93,8 @@ def test_kronecker():
             [0.0, 1.5, 0.0, 3.0],
             [1.0, 2.0, 2.0, 4.0],
             [0.0, 3.0, 0.0, 6.0],
-        ]
+        ],
+        dtype=tl.float32,
     )
     assert_array_equal(kronecker([a, b], reverse=True), reversed_res)
 

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -22,6 +22,7 @@ from ..proximal import (
 from ...testing import assert_, assert_array_equal, assert_array_almost_equal
 from tensorly import tensor_to_vec, truncated_svd
 import pytest
+import tensorly as tl
 
 # Author: Jean Kossaifi
 skip_tensorflow = pytest.mark.skipif(
@@ -82,9 +83,9 @@ def test_simplex():
 
 def test_normalized_sparsity():
     """Test for normalized_sparsity operator"""
-    tensor = T.tensor([2, 3, 4])
+    tensor = T.tensor([2, 3, 4], dtype=tl.float32)
     res = normalized_sparsity_prox(tensor, 2)
-    true_res = T.tensor([0, 0.6, 0.8])
+    true_res = T.tensor([0, 0.6, 0.8], dtype=tl.float32)
     assert_array_almost_equal(true_res, res)
 
 
@@ -120,15 +121,15 @@ def test_unimodality():
 
 def test_l2_prox():
     """Test for l2 prox operator"""
-    tensor = T.tensor([2, 4, 4])
+    tensor = T.tensor([2, 4, 4], dtype=tl.float32)
     res = l2_prox(tensor, 3)
-    true_res = T.tensor([1, 2, 2])
+    true_res = T.tensor([1, 2, 2], dtype=tl.float32)
     assert_array_almost_equal(true_res, res)
 
 
 def test_squared_l2_prox():
     """Test for squared l2 prox operator"""
-    tensor = T.tensor([3, 6, 9])
+    tensor = T.tensor([3, 6, 9], dtype=tl.float32)
     res = l2_square_prox(tensor, 0.5)
     true_res = T.tensor([1.5, 3, 4.5])
     assert_array_almost_equal(true_res, res)
@@ -182,10 +183,10 @@ def test_soft_thresholding():
 
 def test_svd_thresholding():
     """Test for singular_value_thresholding operator"""
-    U = T.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    U = T.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=tl.float32)
     singular_values = T.tensor([0.4, 2.1, -2])
     tensor = T.dot(U, T.reshape(singular_values, (-1, 1)) * T.transpose(U))
-    shrinked_singular_values = T.tensor([0, 1.6, -1.5])
+    shrinked_singular_values = T.tensor([0, 1.6, -1.5], dtype=tl.float32)
     true_res = T.dot(U, T.reshape(shrinked_singular_values, (-1, 1)) * T.transpose(U))
     res = svd_thresholding(tensor, 0.5)
     assert_array_almost_equal(true_res, res)

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -184,7 +184,7 @@ def test_soft_thresholding():
 def test_svd_thresholding():
     """Test for singular_value_thresholding operator"""
     U = T.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=tl.float32)
-    singular_values = T.tensor([0.4, 2.1, -2])
+    singular_values = T.tensor([0.4, 2.1, -2], dtype=tl.float32)
     tensor = T.dot(U, T.reshape(singular_values, (-1, 1)) * T.transpose(U))
     shrinked_singular_values = T.tensor([0, 1.6, -1.5], dtype=tl.float32)
     true_res = T.dot(U, T.reshape(shrinked_singular_values, (-1, 1)) * T.transpose(U))

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -25,6 +25,7 @@ import pytest
 import tensorly as tl
 
 # Author: Jean Kossaifi
+
 skip_tensorflow = pytest.mark.skipif(
     (T.get_backend() == "tensorflow"),
     reason=f"Indexing with list not supported in TensorFlow",

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -91,7 +91,7 @@ def test_normalized_sparsity():
 
 def test_monotonicity():
     """Test for monotonicity operator"""
-    tensor = T.tensor(np.random.rand(20, 10))
+    tensor = T.tensor(np.random.rand(20, 10), dtype=tl.float32)
     # Monotone increasing
     tensor_monoton = monotonicity_prox(tensor)
     assert_(np.all(np.diff(tensor_monoton, axis=0) >= 0))
@@ -153,7 +153,7 @@ def test_soft_thresholding():
             [[0, 0.9, 1.9], [3.2, -0.1, 1.9]],
             [[0, -3.9, -0.2], [0.1, 2.6, -7.9]],
             [[-0.9, 0, 0], [0, -0, 0]],
-        ]
+        ],
     )
     # account for floating point errors: np array have a precision of around 2e-15
     # check np.finfo(np.float64).eps
@@ -173,7 +173,7 @@ def test_soft_thresholding():
     # Test with missing values
     tensor = T.tensor([[1, 2, 1.5], [4, -6, -0.5], [0.2, 1.02, -3.4]])
     copy_tensor = T.copy(tensor)
-    mask = T.tensor([[0, 1, 1], [1, 0, 1], [1, 1, 0]])
+    mask = T.tensor([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=tl.float64)
     threshold = 1.1 * mask
     true_res = T.tensor([[1, 0.9, 0.4], [2.9, -6, 0], [0, 0, -3.4]])
     res = soft_thresholding(tensor, threshold)

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -551,3 +551,41 @@ def test_logsumexp():
         tensorly_result = tl.logsumexp(tensor, axis=axis)
         scipy_result = special.logsumexp(x, axis=axis)
         assert_allclose(tensorly_result, scipy_result)
+
+
+only_torch = pytest.mark.skipif(
+    tl.get_backend() in ("tensorflow", "jax", "cupy", "numpy", "mxnet"),
+    reason=f"This test is specific to the PyTorch backend",
+)
+
+
+@only_torch
+def test_dtype_tensor_init():
+    import torch
+
+    dtypes_np = [np.float16, np.float32, np.float64, np.int32, np.int64]
+    dtypes_torch = [
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.int32,
+        torch.int64,
+    ]
+    for dtype_np, dtype_torch in zip(dtypes_np, dtypes_torch):
+        # Numpy array
+        array = np.zeros((1,), dtype=dtype_np)
+
+        # No dtype given -> dtype should be inferred from input array
+        tensor = T.tensor(array)
+        assert tensor.dtype == dtype_torch
+
+        # dtype given -> dtype should be overwritten
+        for dtype in dtypes_torch:
+            # Check init from numpy array
+            tensor = T.tensor(array, dtype=dtype)
+            assert tensor.dtype == dtype
+
+            # Check init from python list
+            array_py = array.tolist()
+            tensor = T.tensor(array_py, dtype=dtype)
+            assert tensor.dtype == dtype

--- a/tensorly/tests/test_backend.py
+++ b/tensorly/tests/test_backend.py
@@ -553,23 +553,13 @@ def test_logsumexp():
         assert_allclose(tensorly_result, scipy_result)
 
 
-only_torch = pytest.mark.skipif(
-    tl.get_backend() in ("tensorflow", "jax", "cupy", "numpy", "mxnet"),
-    reason=f"This test is specific to the PyTorch backend",
-)
-
-
-@only_torch
 def test_dtype_tensor_init():
-    import torch
-
-    dtypes_np = [np.float16, np.float32, np.float64, np.int32, np.int64]
+    dtypes_np = [np.float32, np.float64, np.int32, np.int64]
     dtypes_torch = [
-        torch.float16,
-        torch.float32,
-        torch.float64,
-        torch.int32,
-        torch.int64,
+        tl.float32,
+        tl.float64,
+        tl.int32,
+        tl.int64,
     ]
     for dtype_np, dtype_torch in zip(dtypes_np, dtypes_torch):
         # Numpy array

--- a/tensorly/tests/test_parafac2_tensor.py
+++ b/tensorly/tests/test_parafac2_tensor.py
@@ -88,19 +88,20 @@ def test_parafac2_normalise():
 
 
 def test_parafac2_to_tensor():
-    weights = tl.tensor([2, 3])
+    weights = tl.tensor([2, 3], dtype=tl.float32)
     factors = [
-        tl.tensor([[1, 1], [1, 0]]),
-        tl.tensor([[2, 1], [1, 2]]),
-        tl.tensor([[1, 1], [1, 0], [1, 0]]),
+        tl.tensor([[1, 1], [1, 0]], dtype=tl.float32),
+        tl.tensor([[2, 1], [1, 2]], dtype=tl.float32),
+        tl.tensor([[1, 1], [1, 0], [1, 0]], dtype=tl.float32),
     ]
     projections = [
-        tl.tensor([[0, 0], [1, 0], [0, 1]]),
-        tl.tensor([[1, 0], [0, 0], [0, -1]]),
+        tl.tensor([[0, 0], [1, 0], [0, 1]], dtype=tl.float32),
+        tl.tensor([[1, 0], [0, 0], [0, -1]], dtype=tl.float32),
     ]
 
     true_res = tl.tensor(
-        [[[0, 0, 0], [7, 4, 4], [8, 2, 2]], [[4, 4, 4], [0, 0, 0], [-2, -2, -2]]]
+        [[[0, 0, 0], [7, 4, 4], [8, 2, 2]], [[4, 4, 4], [0, 0, 0], [-2, -2, -2]]],
+        dtype=tl.float32,
     )
 
     res = parafac2_to_tensor((weights, factors, projections))
@@ -108,16 +109,19 @@ def test_parafac2_to_tensor():
 
 
 def test_parafac2_to_slices():
-    weights = tl.tensor([2, 3])
+    weights = tl.tensor([2, 3], dtype=tl.float32)
     factors = [
-        tl.tensor([[1, 1], [1, 0]]),
-        tl.tensor([[2, 1], [1, 2]]),
-        tl.tensor([[1, 1], [1, 0], [1, 0]]),
+        tl.tensor([[1, 1], [1, 0]], dtype=tl.float32),
+        tl.tensor([[2, 1], [1, 2]], dtype=tl.float32),
+        tl.tensor([[1, 1], [1, 0], [1, 0]], dtype=tl.float32),
     ]
-    projections = [tl.tensor([[1, 0], [0, 1]]), tl.tensor([[1, 0], [0, 0], [0, -1]])]
+    projections = [
+        tl.tensor([[1, 0], [0, 1]], dtype=tl.float32),
+        tl.tensor([[1, 0], [0, 0], [0, -1]], dtype=tl.float32),
+    ]
     true_res = [
-        tl.tensor([[7, 4, 4], [8, 2, 2]]),
-        tl.tensor([[4, 4, 4], [0, 0, 0], [-2, -2, -2]]),
+        tl.tensor([[7, 4, 4], [8, 2, 2]], dtype=tl.float32),
+        tl.tensor([[4, 4, 4], [0, 0, 0], [-2, -2, -2]], dtype=tl.float32),
     ]
     for i, true_slice in enumerate(true_res):
         assert_array_equal(
@@ -166,14 +170,17 @@ def test_parafac2_to_vec():
 def test_apply_parafac2_projections():
     weights = tl.tensor([2, 3])
     factors = [
-        tl.tensor([[1, 1], [1, 0]]),
-        tl.tensor([[2, 1], [1, 2]]),
-        tl.tensor([[1, 1], [1, 0], [1, 0]]),
+        tl.tensor([[1, 1], [1, 0]], dtype=tl.float32),
+        tl.tensor([[2, 1], [1, 2]], dtype=tl.float32),
+        tl.tensor([[1, 1], [1, 0], [1, 0]], dtype=tl.float32),
     ]
-    projections = [tl.tensor([[1, 0], [0, 1]]), tl.tensor([[1, 0], [0, 0], [0, -1]])]
+    projections = [
+        tl.tensor([[1, 0], [0, 1]], dtype=tl.float32),
+        tl.tensor([[1, 0], [0, 0], [0, -1]], dtype=tl.float32),
+    ]
     true_res = [
-        tl.tensor([[7, 4, 4], [8, 2, 2]]),
-        tl.tensor([[4, 4, 4], [0, 0, 0], [-2, -2, -2]]),
+        tl.tensor([[7, 4, 4], [8, 2, 2]], dtype=tl.float32),
+        tl.tensor([[4, 4, 4], [0, 0, 0], [-2, -2, -2]], dtype=tl.float32),
     ]
 
     new_weights, projected_factors = apply_parafac2_projections(

--- a/tensorly/tests/test_testing.py
+++ b/tensorly/tests/test_testing.py
@@ -10,7 +10,7 @@ from ..testing import (
 
 
 def test_assert_allclose():
-    tensor = tl.tensor([5, 5, 5])
+    tensor = tl.tensor([5, 5, 5], dtype=tl.float32)
 
     assert_allclose(tensor, tensor)
     assert_allclose(tensor, tensor + 1e-10)
@@ -40,7 +40,7 @@ def test_assert_equal():
 
 
 def test_assert_array_almost_equal():
-    tensor = tl.tensor([5, 5, 5])
+    tensor = tl.tensor([5, 5, 5], dtype=tl.float32)
 
     assert_array_almost_equal(tensor, tensor)
     assert_array_almost_equal(tensor, tensor + 1e-10)
@@ -59,7 +59,7 @@ def test_assert_array_almost_equal():
 
 
 def test_assert_array_equal():
-    tensor = tl.tensor([5, 5, 5])
+    tensor = tl.tensor([5, 5, 5], dtype=tl.float32)
 
     assert_equal(tensor, tensor)
     assert_equal(tl.tensor([1, 2]), tl.tensor([1.0, 2.0]))


### PR DESCRIPTION
The previous implementation simply took the input data and forced it to be on the given device (`cpu` default) of the given dtype (`torch.float32` default).

This lead to `tl.tensor(torch.zeros(1, device="cuda:0"))` creating a `torch.float32` tensor on `cpu` while the expected behavior should be an `torch.int32` tensor on `cuda:0`.

Using the snippet provided in #537:

```python
import tensorly as tl
import torch

tl.set_backend("pytorch")

def print_info(x: torch.Tensor):
    o = tl.tensor(x)
    print(f"In: dtype={str(x.dtype):14} device={str(x.device):10} -- Out: dtype={str(o.dtype):14} device={str(o.device):10}")

dtypes = [torch.int, torch.long, torch.float16, torch.float32, torch.float64]
devices = ["cpu", "cuda"]

for dtype in dtypes:
    for device in devices:
        x = torch.zeros(1, dtype=dtype, device=device)
        print_info(x)
```

**Before**:
```
In: dtype=torch.int32    device=cpu        -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.int32    device=cuda:0     -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.int64    device=cpu        -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.int64    device=cuda:0     -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.float16  device=cpu        -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.float16  device=cuda:0     -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.float32  device=cpu        -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.float32  device=cuda:0     -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.float64  device=cpu        -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.float64  device=cuda:0     -- Out: dtype=torch.float32  device=cpu
```

**After**:
```
In: dtype=torch.int32    device=cpu        -- Out: dtype=torch.int32    device=cpu
In: dtype=torch.int32    device=cuda:0     -- Out: dtype=torch.int32    device=cuda:0
In: dtype=torch.int64    device=cpu        -- Out: dtype=torch.int64    device=cpu
In: dtype=torch.int64    device=cuda:0     -- Out: dtype=torch.int64    device=cuda:0
In: dtype=torch.float16  device=cpu        -- Out: dtype=torch.float16  device=cpu
In: dtype=torch.float16  device=cuda:0     -- Out: dtype=torch.float16  device=cuda:0
In: dtype=torch.float32  device=cpu        -- Out: dtype=torch.float32  device=cpu
In: dtype=torch.float32  device=cuda:0     -- Out: dtype=torch.float32  device=cuda:0
In: dtype=torch.float64  device=cpu        -- Out: dtype=torch.float64  device=cpu
In: dtype=torch.float64  device=cuda:0     -- Out: dtype=torch.float64  device=cuda:0
```

Resolves: #537