### PR TITLE
Avoid large concatenation within PARAFAC2 upon SVD initialization

### DIFF
--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -10,6 +10,7 @@ from ...testing import (
     assert_,
     assert_class_wrapper_correctly_passes_arguments,
     assert_array_almost_equal,
+    assert_allclose,
 )
 from .._parafac2 import (
     Parafac2,
@@ -422,8 +423,8 @@ def test_parafac2_init_cross_product():
     init_double = initialize_decomposition(slices + slices, rank, init="svd")
 
     # These factor matrices should be essentially the same
-    assert_array_almost_equal(init.factors[1], init_double.factors[1])
-    assert_array_almost_equal(init.factors[2], init_double.factors[2])
+    assert_allclose(init.factors[1], init_double.factors[1], rtol=1e-3, atol=1e-5)
+    assert_allclose(init.factors[2], init_double.factors[2], rtol=1e-3, atol=1e-5)
 
 
 def test_parafac2_init_error():

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -405,6 +405,27 @@ def test_parafac2_init_valid():
         assert init.shape == random_parafac2_tensor.shape
 
 
+def test_parafac2_init_cross_product():
+    """Test that SVD initialization using the cross-product or concatenated
+    tensor yields the same result."""
+    rng = tl.check_random_state(1234)
+    rank = 3
+
+    random_parafac2_tensor = random_parafac2(
+        shapes=[(25, 100)] * 3, rank=rank, random_state=rng
+    )
+    slices = parafac2_to_slices(random_parafac2_tensor)
+
+    init = initialize_decomposition(slices, rank, init="svd")
+
+    # Double the number of matrices so that we switch to the cross-product
+    init_double = initialize_decomposition(slices + slices, rank, init="svd")
+
+    # These factor matrices should be essentially the same
+    assert_array_almost_equal(init.factors[1], init_double.factors[1])
+    assert_array_almost_equal(init.factors[2], init_double.factors[2])
+
+
 def test_parafac2_init_error():
     rng = tl.check_random_state(1234)
     rank = 3


### PR DESCRIPTION
Currently with SVD initialization, we concatenate all the matrices into one large tensor. This requires essentially copying the entire dataset. This PR adds a check for whether assembling the cross-product would be smaller, and then follows that route if so.