### PR TITLE
Add missing targets to .PHONY directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Automate testing etc
 BACKEND?='numpy'
 
-.PHONY: all test install clean debug
+.PHONY: all install debug test test-all test-coverage
 
 all: install test
 


### PR DESCRIPTION
Add missing targets `test-all` and `test-coverage` to the .PHONY list. Remove unused `clean` target.