### PR TITLE
add normalization method to tucker_tensor class (similar to cp_tensor)

### DIFF
--- a/tensorly/tucker_tensor.py
+++ b/tensorly/tucker_tensor.py
@@ -306,6 +306,13 @@ class TuckerTensor(FactorizedTensor):
             self, matrix_or_vector, mode, keep_dim=keep_dim, copy=copy
         )
 
+    def normalize(self):
+        """
+        Transforms the tucker_tensor with `self.factors` normalised to unit length.
+        The normalizing constants absorbed into `self.core`.
+        """
+        self.core, self.factors = tucker_normalize(self)
+
 
 def _tucker_n_param(tensor_shape, rank):
     """Number of parameters of a Tucker decomposition for a given `rank` and full `tensor_shape`.


### PR DESCRIPTION
A small PR to add normalization as a class method for `tucker_tensor`, which is something we already have for cp_tensor and is quite convenient in my humble opinion.

I can write a test but we already test tucker_normalize and this is just a wrapper.

This was also part of #542.