### PR TITLE
[WIP] Approximate joint diagonalization

### DIFF
--- a/tensorly/__init__.py
+++ b/tensorly/__init__.py
@@ -84,6 +84,7 @@ from .backend import (
     prod,
     sign,
     abs,
+    diagonal,
     sqrt,
     norm,
     dot,

--- a/tensorly/backend/__init__.py
+++ b/tensorly/backend/__init__.py
@@ -63,6 +63,7 @@ class BackendManager(types.ModuleType):
         "clip",
         "kr",
         "kron",
+        "diagonal",
         "lstsq",
         "eps",
         "finfo",

--- a/tensorly/backend/cupy_backend.py
+++ b/tensorly/backend/cupy_backend.py
@@ -73,6 +73,7 @@ for name in (
         "concatenate",
         "max",
         "flip",
+        "diagonal",
         "mean",
         "argmax",
         "sum",

--- a/tensorly/backend/jax_backend.py
+++ b/tensorly/backend/jax_backend.py
@@ -85,6 +85,7 @@ for name in (
         "mean",
         "sum",
         "argmin",
+        "diagonal",
         "argmax",
         "stack",
         "sign",

--- a/tensorly/backend/numpy_backend.py
+++ b/tensorly/backend/numpy_backend.py
@@ -56,6 +56,7 @@ for name in (
         "mean",
         "sum",
         "argmin",
+        "diagonal",
         "argmax",
         "sign",
         "stack",

--- a/tensorly/backend/pytorch_backend.py
+++ b/tensorly/backend/pytorch_backend.py
@@ -230,6 +230,10 @@ class PyTorchBackend(Backend, backend_name="pytorch"):
     def logsumexp(tensor, axis=0):
         return torch.logsumexp(tensor, dim=axis)
 
+    @staticmethod
+    def diagonal(tensor, offset=0, axis1=0, axis2=1):
+        return torch.diagonal(tensor, offset=offset, dim1=axis1, dim2=axis2)
+
 
 # Register the other functions
 for name in (

--- a/tensorly/backend/tensorflow_backend.py
+++ b/tensorly/backend/tensorflow_backend.py
@@ -165,6 +165,7 @@ for name in (
         "stack",
         "copy",
         "max",
+        "diagonal",
         "sign",
         "mean",
         "sum",

--- a/tensorly/utils/jointdiag.py
+++ b/tensorly/utils/jointdiag.py
@@ -1,0 +1,164 @@
+from typing import Any
+from itertools import combinations
+import tensorly as tl
+
+
+def jointdiag(
+    X,
+    max_iter: int = 50,
+    threshold: float = 1e-10,
+    verbose: bool = False,
+) -> tuple[Any, Any]:
+    """
+    Jointly diagonalizes n matrices, organized in tensor of dimension (k,k,n).
+    Returns the diagonalized matrices, along with the transformation matrix.
+
+    If verbose = True, returns estimate of error in third index.
+    """
+
+    X = tl.tensor(X, **tl.context(X))
+    D = tl.shape(X)[0]  # Dimension of square matrix slices
+    assert tl.ndim(X) == 3, "Input must be a 3D tensor"
+    assert D == X.shape[1], "All slices must be square"
+
+    # Initial error calculation
+    # Transpose is because np.tril operates on the last two dimensions
+    e = tl.norm(X) ** 2.0 - tl.norm(tl.diagonal(X, axis1=1, axis2=2)) ** 2.0
+
+    if verbose:
+        print(f"Sweep # 0: e = {e:.3e}")
+
+    # Additional output parameters
+    Q_total = tl.eye(D)
+
+    for k in range(max_iter):
+        # loop over all pairs of slices
+        for p, q in combinations(range(D), 2):
+            # Finds matrix slice with greatest variability among diagonal elements
+            d_ = X[p, p, :] - X[q, q, :]
+            h = tl.argmax(tl.abs(d_))
+
+            # List of indices
+            all_but_pq = list(set(range(D)) - set([p, q]))
+
+            # Compute certain quantities
+            dh = d_[h]
+            Xh = X[:, :, h]
+            Kh = tl.dot(Xh[p, all_but_pq], Xh[q, all_but_pq]) - tl.dot(
+                Xh[all_but_pq, p], Xh[all_but_pq, q]
+            )
+            Gh = (
+                tl.norm(Xh[p, all_but_pq]) ** 2
+                + tl.norm(Xh[q, all_but_pq]) ** 2
+                + tl.norm(Xh[all_but_pq, p]) ** 2
+                + tl.norm(Xh[all_but_pq, q]) ** 2
+            )
+            xih = Xh[p, q] - Xh[q, p]
+
+            # Build shearing matrix out of these quantities
+            yk = tl.arctanh((Kh - xih * dh) / (2 * (dh**2 + xih**2) + Gh))
+
+            # Inverse of Sk on left side
+            pvec = tl.copy(X[p, :, :])
+            X = tl.index_update(
+                X,
+                tl.index[p, :, :],
+                X[p, :, :] * tl.cosh(yk) - X[q, :, :] * tl.sinh(yk),
+            )
+            X = tl.index_update(
+                X, tl.index[q, :, :], -pvec * tl.sinh(yk) + X[q, :, :] * tl.cosh(yk)
+            )
+
+            # Sk on right side
+            pvec = tl.copy(X[:, p, :])
+            X = tl.index_update(
+                X,
+                tl.index[:, p, :],
+                X[:, p, :] * tl.cosh(yk) + X[:, q, :] * tl.sinh(yk),
+            )
+            X = tl.index_update(
+                X, tl.index[:, q, :], pvec * tl.sinh(yk) + X[:, q, :] * tl.cosh(yk)
+            )
+
+            # Update Q_total
+            pvec = tl.copy(Q_total[:, p])
+            Q_total = tl.index_update(
+                Q_total,
+                tl.index[:, p],
+                Q_total[:, p] * tl.cosh(yk) + Q_total[:, q] * tl.sinh(yk),
+            )
+            Q_total = tl.index_update(
+                Q_total,
+                tl.index[:, q],
+                pvec * tl.sinh(yk) + Q_total[:, q] * tl.cosh(yk),
+            )
+
+            # Defines array of off-diagonal element differences
+            xi_ = -X[q, p, :] - X[p, q, :]
+
+            # More quantities computed
+            Esum = 2 * tl.dot(xi_, d_)
+            Dsum = tl.dot(d_, d_) - tl.dot(xi_, xi_)
+            qt = Esum / Dsum
+
+            th1 = tl.arctan(qt)
+            angle_selection = tl.cos(th1) * Dsum + tl.sin(th1) * Esum
+
+            # Defines 1 of 2 possible angles
+            if angle_selection > 0.0:
+                theta_k = th1 / 4
+            elif angle_selection < 0.0:
+                theta_k = (th1 + tl.pi) / 4
+            else:
+                raise RuntimeError("Jointdiag: No solution found.")
+
+            # Given's rotation, this will minimize norm of off-diagonal elements only
+            pvec = tl.copy(X[p, :, :])
+            X = tl.index_update(
+                X,
+                tl.index[p, :, :],
+                X[p, :, :] * tl.cos(theta_k) - X[q, :, :] * tl.sin(theta_k),
+            )
+            X = tl.index_update(
+                X,
+                tl.index[q, :, :],
+                pvec * tl.sin(theta_k) + X[q, :, :] * tl.cos(theta_k),
+            )
+
+            pvec = tl.copy(X[:, p, :])
+            X = tl.index_update(
+                X,
+                tl.index[:, p, :],
+                X[:, p, :] * tl.cos(theta_k) - X[:, q, :] * tl.sin(theta_k),
+            )
+            X = tl.index_update(
+                X,
+                tl.index[:, q, :],
+                pvec * tl.sin(theta_k) + X[:, q, :] * tl.cos(theta_k),
+            )
+
+            # Update Q_total
+            pvec = tl.copy(Q_total[:, p])
+            Q_total = tl.index_update(
+                Q_total,
+                tl.index[:, p],
+                Q_total[:, p] * tl.cos(theta_k) - Q_total[:, q] * tl.sin(theta_k),
+            )
+            Q_total = tl.index_update(
+                Q_total,
+                tl.index[:, q],
+                pvec * tl.sin(theta_k) + Q_total[:, q] * tl.cos(theta_k),
+            )
+
+        # Error computation, check if loop needed...
+        old_e = e
+        e = tl.norm(X) ** 2.0 - tl.norm(tl.diagonal(X, axis1=1, axis2=2)) ** 2.0
+
+        if verbose:
+            print(f"Sweep # {k + 1}: e = {e:.3e}")
+
+        # TODO: Strangely the error increases on the first iteration
+        if old_e - e < threshold and k > 2:
+            break
+
+    return X, Q_total

--- a/tensorly/utils/jointdiag.py
+++ b/tensorly/utils/jointdiag.py
@@ -14,6 +14,10 @@ def jointdiag(
     Returns the diagonalized matrices, along with the transformation matrix.
 
     If verbose = True, returns estimate of error in third index.
+
+    T. Fu and X. Gao, “Simultaneous diagonalization with similarity transformation for
+    non-defective matrices”, in Proc. IEEE International Conference on Acoustics, Speech
+    and Signal Processing (ICASSP 2006), vol. IV, pp. 1137-1140, Toulouse, France, May 2006.
     """
 
     X = tl.tensor(X, **tl.context(X))

--- a/tensorly/utils/tests/test_jointdiag.py
+++ b/tensorly/utils/tests/test_jointdiag.py
@@ -1,0 +1,39 @@
+import numpy as np
+import tensorly as tl
+from ..jointdiag import jointdiag
+
+
+def test_jointdiag():
+    """
+    Generates random diagonal tensor, and random mixing matrix
+    Multiplies every slice of diagonal tensor with matrix 'synthetic' S * D * S^-1
+    Sends altered tensor into jointdiag function
+    Returns the diagonal tensor estimate and mixing matrix estimate
+    """
+    k = 14
+    d = 10
+
+    rng = np.random.RandomState()
+    mixing = rng.randn(d, d)
+    diags = np.zeros((d, d, k))
+    synthetic = np.zeros((d, d, k))
+
+    # Generates k random diagonal matrices and scrambles according to the mixing matrix
+    for i in range(k):
+        temp_diag = np.diag(rng.randn(d))
+        diags[:, :, i] = temp_diag
+        synthetic[:, :, i] = np.linalg.inv(mixing) @ temp_diag @ mixing
+
+    synthetic = tl.tensor(synthetic, dtype=tl.float64)
+
+    diag_est, _ = jointdiag(synthetic, verbose=False)
+    diag_est = tl.to_numpy(diag_est)
+
+    ## Sorts outputted diagonal data
+    idx_est = np.argsort(np.diag(diag_est[:, :, 0]))
+    idx = np.argsort(np.diag(diags[:, :, 0]))
+    diag_est = diag_est[idx_est, idx_est, :]
+    diags = diags[idx, idx, :]
+
+    # Test that the diagonalized matrices are close to the starting diagonal matrices
+    np.testing.assert_allclose(diags, diag_est, atol=1e-10)


### PR DESCRIPTION
This adds a function for deriving an approximate joint diagonalization for a set of matrices. This function is the basis of [solvers that derive PARAFAC factorization by diagonalizing](http://ieeexplore.ieee.org/document/4518122/) the Tucker decomposition. By using only a few iterations, this can also be used to improve the starting estimate for initializing PARAFAC.