### PR TITLE
[Paddle] Fix default device setting and allow lstsq fallback

### DIFF
--- a/tensorly/solvers/nnls.py
+++ b/tensorly/solvers/nnls.py
@@ -15,7 +15,7 @@ def hals_nnls(
     epsilon=0.0,
     callback=None,
 ):
-    """
+    r"""
     Non Negative Least Squares (NNLS)
 
     Computes an approximate solution of a nonnegative least

--- a/tensorly/solvers/nnls.py
+++ b/tensorly/solvers/nnls.py
@@ -15,7 +15,7 @@ def hals_nnls(
     epsilon=0.0,
     callback=None,
 ):
-    r"""
+    """
     Non Negative Least Squares (NNLS)
 
     Computes an approximate solution of a nonnegative least


### PR DESCRIPTION
1. Switch the default device from CPU to current global device automatically detected by paddle
2. Allow lstsq fallback to CPU implementation when default device is not CPU, with propriate warning given, or the `test_tensor_ring_als` will fail when GPU is available.
3. Relax Paddle version check to allow nightly build version which a lot of paddle users has been installed


test result:

``` sh
TENSORLY_BACKEND='paddle' pytest -s -v -x tensorly
``` 

![B70AAC32F9C348F366604742BF5525F9](https://github.com/user-attachments/assets/80a69afb-01a6-4109-9152-184c46a21bab)
