### PR TITLE
Added support for factors-only initialization in tucker decomposition

### DIFF
--- a/tensorly/decomposition/_tucker.py
+++ b/tensorly/decomposition/_tucker.py
@@ -22,6 +22,13 @@ from ..tenalg.svd import svd_interface
 # License: BSD 3 clause
 
 
+def _is_tucker_factors_init(init):
+    return (
+        isinstance(init, Iterable)
+        and not isinstance(init, (str, bytes, tuple, TuckerTensor))
+    )
+
+
 def initialize_tucker(
     tensor,
     rank,
@@ -92,8 +99,34 @@ def initialize_tucker(
             for index, mode in enumerate(modes)
         ]
 
-    else:
+    elif isinstance(init, tuple):
+        if len(init) != 2 or not isinstance(init[1], Iterable):
+            raise ValueError(
+                "If `init` is a tuple, it must be of the form (core, factors) "
+                "with `factors` an iterable of factor matrices."
+            )
         (core, factors) = init
+    elif isinstance(init, TuckerTensor):
+        core, factors = init
+    elif _is_tucker_factors_init(init):
+        factors = list(init)
+        if len(factors) != len(modes):
+            raise ValueError(f"Expected {len(modes)} factors, got {len(factors)}")
+
+        for i, (factor, mode) in enumerate(zip(factors, modes)):
+            expected_shape = (tensor.shape[mode], rank[i])
+            if tl.shape(factor) != expected_shape:
+                raise ValueError(
+                    f"Factor {i} has shape {tl.shape(factor)} but expected "
+                    f"{expected_shape}"
+                )
+
+        core = multi_mode_dot(tensor, factors, modes=modes, transpose=True)
+    else:
+        raise ValueError(
+            "Got invalid `init`. Expected 'svd', 'random', a Tucker tensor, "
+            "a (core, factors) tuple, or an iterable of factors."
+        )
 
     if non_negative is True:
         factors = [tl.abs(f) for f in factors]
@@ -285,8 +318,18 @@ def tucker(
     """
     if fixed_factors:
         try:
-            (core, factors) = init
-        except:
+            if _is_tucker_factors_init(init):
+                core, factors = initialize_tucker(
+                    tensor,
+                    rank,
+                    modes=list(range(tl.ndim(tensor))),
+                    init=init,
+                    svd=svd,
+                    random_state=random_state,
+                )
+            else:
+                (core, factors) = init
+        except Exception:
             raise ValueError(
                 f'Got fixed_factor={fixed_factors} but no appropriate Tucker tensor was passed for "init".'
             )

--- a/tensorly/decomposition/tests/test_tucker.py
+++ b/tensorly/decomposition/tests/test_tucker.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import tensorly as tl
 from .._tucker import (
+    initialize_tucker,
     tucker,
     partial_tucker,
     non_negative_tucker,
@@ -143,6 +144,47 @@ def test_tucker(monkeypatch):
     assert_class_wrapper_correctly_passes_arguments(
         monkeypatch, tucker, Tucker, ignore_args={}, rank=3
     )
+
+
+def test_tucker_factors_only_init_recomputes_core():
+    rng = tl.check_random_state(1234)
+    rank = (2, 3, 2)
+    core, factors = random_tucker((4, 5, 6), rank=rank, random_state=rng)
+    tensor = tucker_to_tensor((core, factors))
+
+    initialized_core, initialized_factors = initialize_tucker(
+        tensor,
+        rank=rank,
+        modes=list(range(tl.ndim(tensor))),
+        random_state=rng,
+        init=[tl.copy(factor) for factor in factors],
+    )
+
+    expected_core = multi_mode_dot(
+        tensor, initialized_factors, modes=list(range(tl.ndim(tensor))), transpose=True
+    )
+
+    assert_array_equal(initialized_core, expected_core)
+    for factor, expected_factor in zip(initialized_factors, factors):
+        assert_array_equal(factor, expected_factor)
+
+
+def test_tucker_runs_with_factors_only_init():
+    rng = tl.check_random_state(1234)
+    rank = (2, 2, 2)
+    core, factors = random_tucker((3, 4, 5), rank=rank, random_state=rng)
+    tensor = tucker_to_tensor((core, factors))
+
+    decomposition = tucker(
+        tensor,
+        rank=rank,
+        init=[tl.copy(factor) for factor in factors],
+        n_iter_max=5,
+    )
+    reconstruction_error = tl.norm(tucker_to_tensor(decomposition) - tensor, 2)
+    reconstruction_error /= tl.norm(tensor, 2)
+
+    assert_(reconstruction_error < 1e-6)
 
 
 def test_masked_tucker():


### PR DESCRIPTION
## Motivation
The `initialize_tucker` function currently requires `init` to be `"svd"`, `"random"`, or a `(core, factors)` tuple. For warm-starting Tucker decomposition, users may only have factors without a core. This PR lets `init` accept a list of factors and recomputes the core internally.

## Changes
- In `initialize_tucker`:
  - Added support for `init` as a list of factors under `elif isinstance(init, (tuple, list)):`
  - Validates factor count and shapes, then recomputes core with `multi_mode_dot`
  - Updated error message to include the new option
  
- In `mode_dot`:
  - Added handling of Complex32 floats to support low-precision complex tensors.