### PR TITLE
Disambiguating the choices of modes in tensor contraction (Issue #585).

### DIFF
--- a/tensorly/tenalg/core_tenalg/_batched_tensordot.py
+++ b/tensorly/tenalg/core_tenalg/_batched_tensordot.py
@@ -11,7 +11,12 @@ def tensordot(tensor1, tensor2, modes, batched_modes=()):
     tensor1 : tl.tensor
     tensor2 : tl.tensor
     modes : int list or int
-        modes on which to contract tensor1 and tensor2
+        modes on which to contract tensor1 and tensor2.
+        NB: If two modes are provided:
+        * The default behavior is to contract tensor1 on the first mode, and tensor2 on the second mode.
+        _e.g. ``tensordot(t1, t2, [m1, m2])`` contracts mode m1 of t1 with mode m2 of tensor t2_
+        * Users that want to contract both tensors on both modes should provide a tuple of two identical modes.
+        _e.g. ``tensordot(t1, t2, ([m1, m2], [m1, m2]))`` contracts both t1 and t2 on both modes m1 and m2_
     batched_modes : int or tuple[int]
 
     Returns


### PR DESCRIPTION
Hi, just adding a comment to try to disambiguate the choice of the modes in tensor contraction, when the number of modes is equal to 2 (see Issue #585 for discussion).