### PR TITLE
Escape characters compatible with python >= 3.12

### DIFF
--- a/tensorly/solvers/admm.py
+++ b/tensorly/solvers/admm.py
@@ -96,7 +96,7 @@ def admm(
 
     .. math:: x_{split} = argmin_{x_{split}}~ f(x_{split}) + (\\rho/2)\\|Ax_{split} + Bx - c\\|_2^2
     .. math:: x = argmin_x~ g(x) + (\\rho/2)\\|Ax_{split} + Bx - c\\|_2^2
-    .. math:: dual\_var = dual\_var + (Ax + Bx_{split} - c)
+    .. math:: dual\\_var = dual\\_var + (Ax + Bx_{split} - c)
 
     where rho is a constant defined by the user.
 
@@ -104,12 +104,12 @@ def admm(
 
     ADMM can be adapted to this least square problem as following
 
-    .. math:: x_{split} = (UtU + \\rho\\times I)\\times(UtM + \\rho\\times(x + dual\_var)^T)
-    .. math:: x = argmin_{x}~ r(x) + (\\rho/2)\\|x - x_{split}^T + dual\_var\\|_2^2
-    .. math:: dual\_var = dual\_var + x - x_{split}^T
+    .. math:: x_{split} = (UtU + \\rho\\times I)\\times(UtM + \\rho\\times(x + dual\\_var)^T)
+    .. math:: x = argmin_{x}~ r(x) + (\\rho/2)\\|x - x_{split}^T + dual\\_var\\|_2^2
+    .. math:: dual\\_var = dual\\_var + x - x_{split}^T
 
     where r is the regularization operator. Here, x can be updated by using proximity operator
-    of :math:`x_{split}^T - dual\_var`.
+    of :math:`x_{split}^T - dual\\_var`.
 
     References
     ----------

--- a/tensorly/solvers/nnls.py
+++ b/tensorly/solvers/nnls.py
@@ -100,14 +100,14 @@ def hals_nnls(
 
     This problem can also be defined by adding respectively a sparsity coefficient and a ridge coefficients
 
-    .. math:: \lambda_s, \lambda_r
+    .. math:: \\lambda_s, \\lambda_r
 
     enhancing sparsity or smoothness in the solution [2]. In this sparse/ridge version, the update rule becomes
 
     .. math::
 
             \\begin{equation}
-                V[k,:]_{(j+1)} = V[k,:]_{(j)} + (UtM[k,:] - UtU[k,:]\\times V_{(j)} - \lambda_s)/(UtU[k,k]+2\lambda_r)
+                V[k,:]_{(j+1)} = V[k,:]_{(j)} + (UtM[k,:] - UtU[k,:]\\times V_{(j)} - \\lambda_s)/(UtU[k,k]+2\\lambda_r)
             \\end{equation}
 
     Note that the data fitting is halved but not the ridge penalization.


### PR DESCRIPTION
Minor correction in docstrings: changed escape characters to prevent 'SyntaxError' in python versions >= 3.12