### PR TITLE
PARAFAC2: hybridize SVD init for high rank and add warning/tests

### DIFF
--- a/tensorly/decomposition/_parafac2.py
+++ b/tensorly/decomposition/_parafac2.py
@@ -96,6 +96,9 @@ def initialize_decomposition(
     tensor_slices : Iterable of ndarray
     rank : int
     init : {'random', 'svd', CPTensor, Parafac2Tensor}, optional
+        If ``init='svd'`` and ``rank`` exceeds the number of columns in each
+        slice, then as many components as possible are initialized from SVD and
+        the remaining components are initialized randomly.
     random_state : `np.random.RandomState`
     mask : ndarray, optional
         An array with the same shape as the tensor. It should be 0 where there are
@@ -117,10 +120,12 @@ def initialize_decomposition(
             shapes, rank, full=False, random_state=random_state, **context
         )
     elif init == "svd":
+        n_svd = min(rank, shapes[0][1])
 
-        if shapes[0][1] < rank:
-            raise ValueError(
-                f"Cannot perform SVD init if rank ({rank}) is greater than the number of columns in each tensor slice ({shapes[0][1]})"
+        if rank >= shapes[0][1]:
+            warn(
+                f"PARAFAC2 SVD initialization rank {rank} >= columns {shapes[0][1]} initializing remainder randomly",
+                UserWarning,
             )
 
         A = tl.ones((len(tensor_slices), rank), **context)
@@ -134,7 +139,17 @@ def initialize_decomposition(
         else:
             unfolded_mode_2 = tl.transpose(tl.concatenate(list(tensor_slices), axis=0))
 
-        C = svd_interface(unfolded_mode_2, n_eigenvecs=rank, method=svd)[0]
+        C = svd_interface(unfolded_mode_2, n_eigenvecs=n_svd, method=svd)[0]
+
+        if n_svd < rank:
+            random_part = random_parafac2(
+                shapes,
+                rank - n_svd,
+                full=False,
+                random_state=random_state,
+                **context,
+            ).factors[2]
+            C = tl.concatenate([C, random_part], axis=1)
 
         B = tl.eye(rank, **context)
         projections = _compute_projections(tensor_slices, (A, B, C), svd)
@@ -461,7 +476,9 @@ def parafac2(
 
             Previously, the default maximum number of iterations was 100.
     init : {'svd', 'random', CPTensor, Parafac2Tensor}
-        Type of factor matrix initialization. See `initialize_factors`.
+        Type of factor matrix initialization. See `initialize_decomposition`.
+        When ``init='svd'`` and ``rank`` exceeds the number of columns in each
+        slice, remaining components are initialized randomly.
     svd : str, default is 'truncated_svd'
         function to use to compute the SVD, acceptable values in tensorly.SVD_FUNS
     normalize_factors : bool (optional)
@@ -544,7 +561,7 @@ def parafac2(
             tensor_slices[0].shape[1] == tensor_slices[ii].shape[1]
         ), "All tensor slices must have the same number of columns."
 
-    (weights, factors, projections) = initialize_decomposition(
+    weights, factors, projections = initialize_decomposition(
         tensor_slices, rank, init=init, svd=svd, random_state=random_state
     )
     factors = list(factors)

--- a/tensorly/decomposition/tests/test_parafac2.py
+++ b/tensorly/decomposition/tests/test_parafac2.py
@@ -425,14 +425,33 @@ def test_parafac2_init_error():
             tensor, rank, init=("another", "bogus", "init", "type")
         )
 
+
+def test_parafac2_init_svd_warns_and_is_reproducible_for_high_rank():
+    rng = tl.check_random_state(1234)
     rank = 4
+
     random_parafac2_tensor = random_parafac2(
         shapes=[(15, 3)] * 25, rank=rank, random_state=rng
     )
     tensor = parafac2_to_tensor(random_parafac2_tensor)
 
-    with pytest.raises(Exception):
-        _ = initialize_decomposition(tensor, rank, init="svd")
+    with pytest.warns(UserWarning):
+        init_1 = initialize_decomposition(tensor, rank, init="svd", random_state=123)
+    with pytest.warns(UserWarning):
+        init_2 = initialize_decomposition(tensor, rank, init="svd", random_state=123)
+
+    assert init_1.shape == random_parafac2_tensor.shape
+    assert_array_almost_equal(init_1.factors[0], init_2.factors[0])
+    assert_array_almost_equal(init_1.factors[1], init_2.factors[1])
+    assert_array_almost_equal(init_1.factors[2], init_2.factors[2])
+
+    rank_equal = 3
+    random_parafac2_tensor_equal = random_parafac2(
+        shapes=[(15, 3)] * 25, rank=rank_equal, random_state=rng
+    )
+    tensor_equal = parafac2_to_tensor(random_parafac2_tensor_equal)
+    with pytest.warns(UserWarning):
+        initialize_decomposition(tensor_equal, rank_equal, init="svd", random_state=123)
 
 
 def test_parafac2_to_tensor():


### PR DESCRIPTION
I've run into a use-case of PARAFAC2 where I would like to initialize the decomposition with svd features (for a sensible initialization) but would like to allow for the decomposition to fit a higher rank than the dimension of the data. I've added some logic to concatenate svd initialized rankd with randomly initialized ranks for this use case. 

I've added a UserWarning as this use case is rare and the user should be intentional when specifying a high rank. I've also added a unittest of rebroducibility for this init mode.