### PR TITLE
Add Group Lasso regularization in CP decomposition

### DIFF
--- a/tensorly/decomposition/_constrained_cp.py
+++ b/tensorly/decomposition/_constrained_cp.py
@@ -27,6 +27,7 @@ def initialize_constrained_parafac(
     random_state=None,
     non_negative=None,
     l1_reg=None,
+    group_lasso=None,
     l2_reg=None,
     l2_square_reg=None,
     unimodality=None,
@@ -64,6 +65,8 @@ def initialize_constrained_parafac(
         If it is True, non-negative constraint is applied to all modes.
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the l1 norm using the input value as regularization parameter.
+    group_lasso : float or list or dictionary, optional
+        Penalizes each row of the factor with the given group lasso regularization parameter.
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the l2 norm using the input value as regularization parameter.
     l2_square_reg : float or list or dictionary, optional
@@ -146,6 +149,7 @@ def initialize_constrained_parafac(
             factors[i],
             non_negative=non_negative,
             l1_reg=l1_reg,
+            group_lasso=group_lasso,
             l2_reg=l2_reg,
             l2_square_reg=l2_square_reg,
             unimodality=unimodality,
@@ -179,6 +183,7 @@ def constrained_parafac(
     fixed_modes=None,
     non_negative=None,
     l1_reg=None,
+    group_lasso=None,
     l2_reg=None,
     l2_square_reg=None,
     unimodality=None,
@@ -231,6 +236,8 @@ def constrained_parafac(
         If it is True, non-negative constraint is applied to all modes.
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the l1 norm using the input value as regularization parameter.
+    group_lasso : float or list or dictionary, optional
+        Penalizes each row of the factor with the given group lasso regularization parameter.
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the l2 norm using the input value as regularization parameter.
     l2_square_reg : float or list or dictionary, optional
@@ -284,6 +291,7 @@ def constrained_parafac(
     _, _ = validate_constraints(
         non_negative=non_negative,
         l1_reg=l1_reg,
+        group_lasso=group_lasso,
         l2_reg=l2_reg,
         l2_square_reg=l2_square_reg,
         unimodality=unimodality,
@@ -305,6 +313,7 @@ def constrained_parafac(
         random_state=random_state,
         non_negative=non_negative,
         l1_reg=l1_reg,
+        group_lasso=group_lasso,
         l2_reg=l2_reg,
         l2_square_reg=l2_square_reg,
         unimodality=unimodality,
@@ -364,6 +373,7 @@ def constrained_parafac(
                 order=mode,
                 non_negative=non_negative,
                 l1_reg=l1_reg,
+                group_lasso=group_lasso,
                 l2_reg=l2_reg,
                 l2_square_reg=l2_square_reg,
                 unimodality=unimodality,
@@ -531,6 +541,7 @@ class ConstrainedCP(DecompositionMixin):
         fixed_modes=None,
         non_negative=None,
         l1_reg=None,
+        group_lasso=None,
         l2_reg=None,
         l2_square_reg=None,
         unimodality=None,
@@ -556,6 +567,7 @@ class ConstrainedCP(DecompositionMixin):
         self.fixed_modes = fixed_modes
         self.non_negative = non_negative
         self.l1_reg = l1_reg
+        self.group_lasso = group_lasso
         self.l2_reg = l2_reg
         self.l2_square_reg = l2_square_reg
         self.unimodality = unimodality
@@ -595,6 +607,7 @@ class ConstrainedCP(DecompositionMixin):
             fixed_modes=self.fixed_modes,
             non_negative=self.non_negative,
             l1_reg=self.l1_reg,
+            group_lasso=self.group_lasso,
             l2_reg=self.l2_reg,
             l2_square_reg=self.l2_square_reg,
             unimodality=self.unimodality,

--- a/tensorly/decomposition/_constrained_cp.py
+++ b/tensorly/decomposition/_constrained_cp.py
@@ -237,7 +237,8 @@ def constrained_parafac(
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the l1 norm using the input value as regularization parameter.
     group_lasso : float or list or dictionary, optional
-        Penalizes each row of the factor with the given group lasso regularization parameter.
+        Penalizes each row of the factor with the given group lasso regularization parameter,
+        following Yuan and Lin [3]_.
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the l2 norm using the input value as regularization parameter.
     l2_square_reg : float or list or dictionary, optional
@@ -286,6 +287,9 @@ def constrained_parafac(
     .. [2] Huang, Kejun, Nicholas D. Sidiropoulos, and Athanasios P. Liavas.
            "A flexible and efficient algorithmic framework for constrained matrix and tensor factorization." IEEE
            Transactions on Signal Processing 64.19 (2016): 5052-5065.
+    .. [3] Yuan, M. and Lin, Y. (2006). Model selection and estimation in
+           regression with grouped variables. Journal of the Royal Statistical
+           Society: Series B, 68(1), 49-67.
     """
     rank = validate_cp_rank(tl.shape(tensor), rank=rank)
     _, _ = validate_constraints(
@@ -475,6 +479,9 @@ class ConstrainedCP(DecompositionMixin):
         If it is True, non-negative constraint is applied to all modes.
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the l1 norm using the input value as regularization parameter.
+    group_lasso : float or list or dictionary, optional
+        Penalizes each row of the factor with the given group lasso regularization parameter,
+        following Yuan and Lin [3]_.
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the l2 norm using the input value as regularization parameter.
     l2_square_reg : float or list or dictionary, optional
@@ -523,6 +530,9 @@ class ConstrainedCP(DecompositionMixin):
     .. [2] Huang, Kejun, Nicholas D. Sidiropoulos, and Athanasios P. Liavas.
            "A flexible and efficient algorithmic framework for constrained matrix and tensor factorization." IEEE
            Transactions on Signal Processing 64.19 (2016): 5052-5065.
+    .. [3] Yuan, M. and Lin, Y. (2006). Model selection and estimation in
+           regression with grouped variables. Journal of the Royal Statistical
+           Society: Series B, 68(1), 49-67.
     """
 
     def __init__(

--- a/tensorly/decomposition/tests/test_constrained_parafac.py
+++ b/tensorly/decomposition/tests/test_constrained_parafac.py
@@ -146,6 +146,47 @@ def test_constrained_parafac_l2():
     )
 
 
+def test_constrained_parafac_group_lasso():
+    """Test for the CANDECOMP-PARAFAC decomposition with row-wise group lasso regularization"""
+    rng = T.check_random_state(1234)
+    tol_norm_2 = 0.5
+    tol_max_abs = 0.5
+    rank = 3
+    init = "random"
+    weights_init, factors_init = initialize_constrained_parafac(
+        T.zeros([6, 8, 4]), rank, group_lasso=[1e-3, 1e-3, 1e-3], init=init
+    )
+    tensor = cp_to_tensor((weights_init, factors_init))
+    for i in range(len(factors_init)):
+        factors_init[i] += T.tensor(
+            0.1 * rng.random_sample(T.shape(factors_init[i])),
+            **T.context(factors_init[i]),
+        )
+    tensor_init = CPTensor((weights_init, factors_init))
+    res, errors = constrained_parafac(
+        tensor,
+        group_lasso=[1e-3, 1e-3, 1e-3],
+        rank=rank,
+        init=tensor_init,
+        random_state=rng,
+        return_errors=True,
+        tol_outer=1e-16,
+        n_iter_max=1000,
+    )
+    res = cp_to_tensor(res)
+    error = T.norm(res - tensor, 2)
+    error /= T.norm(tensor, 2)
+    assert_(
+        error < tol_norm_2,
+        f"norm 2 of reconstruction higher = {error} than tolerance={tol_norm_2}",
+    )
+    # Test the max abs difference between the reconstruction and the tensor
+    assert_(
+        T.max(T.abs(res - tensor)) < tol_max_abs,
+        f"abs norm of reconstruction error = {T.max(T.abs(res - tensor))} higher than tolerance={tol_max_abs}",
+    )
+
+
 def test_constrained_parafac_squared_l2():
     """Test for the CANDECOMP-PARAFAC decomposition with ADMM and squared l2 norm regularization"""
     rng = T.check_random_state(1234)

--- a/tensorly/solvers/admm.py
+++ b/tensorly/solvers/admm.py
@@ -12,6 +12,7 @@ def admm(
     order=None,
     non_negative=None,
     l1_reg=None,
+    group_lasso=None,
     l2_reg=None,
     l2_square_reg=None,
     unimodality=None,
@@ -53,6 +54,8 @@ def admm(
         If it is True, non-negative constraint is applied to all modes.
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the l1 norm using the input value as regularization parameter.
+    group_lasso : float or list or dictionary, optional
+        Penalizes each row of the factor with the given group lasso regularization parameter.
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the l2 norm using the input value as regularization parameter.
     l2_square_reg : float or list or dictionary, optional
@@ -128,6 +131,7 @@ def admm(
             tl.transpose(x_split) - dual_var,
             non_negative=non_negative,
             l1_reg=l1_reg,
+            group_lasso=group_lasso,
             l2_reg=l2_reg,
             l2_square_reg=l2_square_reg,
             unimodality=unimodality,

--- a/tensorly/solvers/admm.py
+++ b/tensorly/solvers/admm.py
@@ -55,7 +55,8 @@ def admm(
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the l1 norm using the input value as regularization parameter.
     group_lasso : float or list or dictionary, optional
-        Penalizes each row of the factor with the given group lasso regularization parameter.
+        Penalizes each row of the factor with the given group lasso regularization parameter,
+        following Yuan and Lin [2]_.
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the l2 norm using the input value as regularization parameter.
     l2_square_reg : float or list or dictionary, optional
@@ -119,6 +120,9 @@ def admm(
     .. [1] Huang, Kejun, Nicholas D. Sidiropoulos, and Athanasios P. Liavas.
        "A flexible and efficient algorithmic framework for constrained matrix and tensor factorization."
        IEEE Transactions on Signal Processing 64.19 (2016): 5052-5065.
+    .. [2] Yuan, M. and Lin, Y. (2006). Model selection and estimation in
+       regression with grouped variables. Journal of the Royal Statistical
+       Society: Series B, 68(1), 49-67.
     """
     rho = tl.trace(UtU) / tl.shape(x)[1]
     for iteration in range(n_iter_max):

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -4,6 +4,7 @@ import tensorly as tl
 def validate_constraints(
     non_negative=None,
     l1_reg=None,
+    group_lasso=None,
     l2_reg=None,
     l2_square_reg=None,
     unimodality=None,
@@ -28,6 +29,8 @@ def validate_constraints(
         If it is True, non-negative constraint is applied to all modes.
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the l1 norm using the input value as regularization parameter.
+    group_lasso : float or list or dictionary, optional
+        Penalizes each row of the factor with the given group lasso regularization parameter.
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the l2 norm using the input value as regularization parameter.
     l2_square_reg : float or list or dictionary, optional
@@ -70,6 +73,7 @@ def validate_constraints(
     constraints_list = [
         non_negative,
         l1_reg,
+        group_lasso,
         l2_reg,
         l2_square_reg,
         unimodality,
@@ -85,6 +89,7 @@ def validate_constraints(
     constraints_names = [
         "non_negative",
         "l1_reg",
+        "group_lasso",
         "l2_reg",
         "l2_square_reg",
         "unimodality",
@@ -149,6 +154,7 @@ def proximal_operator(
     tensor,
     non_negative=None,
     l1_reg=None,
+    group_lasso=None,
     l2_reg=None,
     l2_square_reg=None,
     unimodality=None,
@@ -176,6 +182,8 @@ def proximal_operator(
         If it is True, non-negative constraint is applied to all modes.
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the given regularizer
+    group_lasso : float or list or dictionary, optional
+        Penalizes each row of the factor with the given group lasso regularizer
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the given regularizer
     l2_square_reg : float or list or dictionary, optional
@@ -224,6 +232,7 @@ def proximal_operator(
     constraint, parameter = validate_constraints(
         non_negative=non_negative,
         l1_reg=l1_reg,
+        group_lasso=group_lasso,
         l2_reg=l2_reg,
         l2_square_reg=l2_square_reg,
         unimodality=unimodality,
@@ -243,6 +252,8 @@ def proximal_operator(
         return tl.clip(tensor, 0, tl.max(tensor))
     elif constraint == "l1_reg":
         return soft_thresholding(tensor, parameter)
+    elif constraint == "group_lasso":
+        return group_lasso_prox(tensor, parameter)
     elif constraint == "l2_reg":
         return l2_prox(tensor, parameter)
     elif constraint == "l2_square_reg":
@@ -491,6 +502,33 @@ def l2_prox(tensor, regularizer):
     else:
         bigger_value = regularizer
     return tensor - (tensor * regularizer / bigger_value)
+
+
+def group_lasso_prox(tensor, regularizer):
+    """
+    Proximal operator of a row-wise group lasso penalty.
+
+    Each row is treated as one group. For CP factors this couples the
+    coefficients of a single feature across all components.
+
+    Parameters
+    ----------
+    tensor : ndarray
+    regularizer : float
+
+    Returns
+    -------
+    ndarray
+    """
+
+    row_norms = tl.sqrt(tl.sum(tensor * tensor, axis=1))
+    safe_row_norms = tl.where(
+        row_norms > 0,
+        row_norms,
+        tl.ones(tl.shape(row_norms), **tl.context(tensor)),
+    )
+    shrinkage = tl.clip(1 - regularizer / safe_row_norms, 0, 1)
+    return tensor * tl.reshape(shrinkage, (-1, 1))
 
 
 def normalized_sparsity_prox(tensor, threshold):

--- a/tensorly/tenalg/proximal.py
+++ b/tensorly/tenalg/proximal.py
@@ -183,7 +183,8 @@ def proximal_operator(
     l1_reg : float or list or dictionary, optional
         Penalizes the factor with the given regularizer
     group_lasso : float or list or dictionary, optional
-        Penalizes each row of the factor with the given group lasso regularizer
+        Penalizes each row of the factor with the given group lasso regularizer,
+        following Yuan and Lin [3]_.
     l2_reg : float or list or dictionary, optional
         Penalizes the factor with the given regularizer
     l2_square_reg : float or list or dictionary, optional
@@ -226,6 +227,9 @@ def proximal_operator(
             Comptes rendus hebdomadaires des séances de l'Académie des sciences, 255, 2897-2899.
     .. [2]: Parikh, N., & Boyd, S. (2014). Proximal algorithms.
             Foundations and Trends in optimization, 1(3), 127-239.
+    .. [3] Yuan, M. and Lin, Y. (2006). Model selection and estimation in
+           regression with grouped variables. Journal of the Royal Statistical
+           Society: Series B, 68(1), 49-67.
     """
     if n_const is None:
         return tensor

--- a/tensorly/tenalg/tests/test_proximal.py
+++ b/tensorly/tenalg/tests/test_proximal.py
@@ -7,6 +7,7 @@ from tensorly.tenalg.proximal import (
     soft_thresholding,
     procrustes,
     hard_thresholding,
+    group_lasso_prox,
     soft_sparsity_prox,
     simplex_prox,
     normalized_sparsity_prox,
@@ -119,6 +120,14 @@ def test_l2_prox():
     tensor = tl.tensor([2.0, 4.0, 4.0])
     res = l2_prox(tensor, 3)
     true_res = tl.tensor([1.0, 2.0, 2.0])
+    assert_array_almost_equal(true_res, res)
+
+
+def test_group_lasso_prox():
+    """Test for row-wise group lasso prox operator"""
+    tensor = tl.tensor([[3.0, 4.0], [0.3, 0.4], [0.0, 2.0]])
+    res = group_lasso_prox(tensor, 1.0)
+    true_res = tl.tensor([[2.4, 3.2], [0.0, 0.0], [0.0, 1.0]])
     assert_array_almost_equal(true_res, res)
 
 


### PR DESCRIPTION
Implements Group Lasso regularization for grouped variable selection in constrained CP decomposition, as described by Yuan and Lin (2006) . 

Group Lasso promotes sparsity in groups, allowing entire groups of variables to be selected or removed together. For CP decomposition, it means shrinking the entire factor groups to zero across components. I have personally found this useful for feature selection.

I have also added two new tests for Group Lasso.

## Reference

M. Yuan and Y. Lin (2006),
*Model selection and estimation in regression with grouped variables*,
Journal of the Royal Statistical Society: Series B, 68(1), 49–67. 